### PR TITLE
feat: refresh available_scheduler and available_scheduler_cluster_id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,10 @@ pub enum Error {
     #[error{"piece {0} state is failed"}]
     PieceStateIsFailed(String),
 
+    // AvailableSchedulersNotFound is the error when the available schedulers is not found.
+    #[error{"available schedulers not found"}]
+    AvailableSchedulersNotFound(),
+
     // ColumnFamilyNotFound is the error when the column family is not found.
     #[error{"column family {0} not found"}]
     ColumnFamilyNotFound(String),


### PR DESCRIPTION
Dynconfig will be periodically refreshed avaliable-schedulers and available_scheduler_cluster_id from manager.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
