### PR TITLE
refactor: remove unnessery mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ hex = "0.4"
 uuid = { version = "1.4", features = ["v4"] }
 url = "2.4.0"
 async-stream = "0.3.5"
+anyhow = "1.0.75"

--- a/src/dynconfig/mod.rs
+++ b/src/dynconfig/mod.rs
@@ -28,6 +28,7 @@ use tonic_health::pb::{health_check_response::ServingStatus, HealthCheckRequest}
 use tracing::{error, info};
 
 // Data is the dynamic configuration of the dfdaemon.
+#[derive(Default)]
 pub struct Data {
     // schedulers is the schedulers of the dfdaemon.
     schedulers: ListSchedulersResponse,
@@ -72,12 +73,7 @@ impl Dynconfig {
         // Create a new Dynconfig.
         let mut dc = Dynconfig {
             config,
-            data: Data {
-                schedulers: ListSchedulersResponse::default(),
-                available_schedulers: Vec::new(),
-                available_scheduler_cluster_id: None,
-                object_storage: None,
-            },
+            data: Data::default(),
             manager_client,
             shutdown,
             _shutdown_complete: shutdown_complete_tx,

--- a/src/grpc/manager.rs
+++ b/src/grpc/manager.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::{Result, Error};
+use crate::{Error, Result};
 use dragonfly_api::manager::v2::{
     manager_client::ManagerClient as ManagerGRPCClient, DeleteSeedPeerRequest,
     GetObjectStorageRequest, ListSchedulersRequest, ListSchedulersResponse, ObjectStorage,
@@ -95,5 +95,4 @@ mod tests {
             _ => panic!("unexpected error"),
         }
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@ pub enum Error {
     // InvalidState is the error when the state is invalid.
     #[error{"invalid state {0}"}]
     InvalidState(String),
+
+    #[error("invalid uri {0}")]
+    InvalidURI(String),
 }
 
 // Result is the result for Client.


### PR DESCRIPTION
1. mut is like a virus in rust, the grpc channel is cloneable, and it's trival to clone the object, so we could clone the client to avoid mut ref
2. use anyhow context instead of unwrap the result
3. use anyhow::Error instead of Box<dyn Error>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
