### PR TITLE
fix: add path to registry mirror and rename config name of containerd

### DIFF
--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -127,7 +127,7 @@ impl Containerd {
             let registry_config_dir = PathBuf::from(config_path).join(registry.host_namespace);
             fs::create_dir_all(registry_config_dir.as_os_str()).await?;
             fs::write(
-                registry_config_dir.join("config.toml").as_os_str(),
+                registry_config_dir.join("hosts.toml").as_os_str(),
                 registry_table.to_string().as_bytes(),
             )
             .await?;

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -724,7 +724,7 @@ fn make_registry_mirror_request(
     // Convert the Reqwest header to the Hyper header.
     let reqwest_request_header = hyper_headermap_to_reqwest_headermap(request.headers());
     let registry_mirror_uri = match header::get_registry(&reqwest_request_header) {
-        Some(registry) => registry.parse::<http::Uri>()?,
+        Some(registry) => format!("{}{}", registry, request.uri().path()).parse::<http::Uri>()?,
         None => format!(
             "{}{}",
             config.proxy.registry_mirror.addr,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
