### PR TITLE
feat: extract storage engine into traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempdir",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1260,6 +1261,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -2498,7 +2505,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2899,13 +2906,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2915,8 +2935,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2958,6 +2993,15 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3023,6 +3067,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -3599,6 +3652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,7 +4015,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4090,7 +4153,7 @@ dependencies = [
  "http 0.2.11",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror",
  "url",

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -26,3 +26,6 @@ tokio-util.workspace = true
 sha2.workspace = true
 num_cpus = "1.0"
 base16ct = { version = "0.2", features = ["alloc"] }
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -22,7 +22,6 @@ use reqwest::header::HeaderMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
-use storage_engine::rocksdb::RocksdbStorageEngine;
 use tokio::io::AsyncRead;
 
 pub mod content;
@@ -39,7 +38,7 @@ pub struct Storage {
     config: Arc<Config>,
 
     // metadata implements the metadata storage.
-    metadata: metadata::Metadata<RocksdbStorageEngine>,
+    metadata: metadata::Metadata,
 
     // content implements the content storage.
     content: content::Content,

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -22,10 +22,13 @@ use reqwest::header::HeaderMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+use storage_engine::rocksdb::RocksdbStorageEngine;
 use tokio::io::AsyncRead;
 
 pub mod content;
 pub mod metadata;
+
+pub mod storage_engine;
 
 // DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL is the default interval for waiting for the piece to be finished.
 pub const DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL: Duration = Duration::from_millis(500);
@@ -36,7 +39,7 @@ pub struct Storage {
     config: Arc<Config>,
 
     // metadata implements the metadata storage.
-    metadata: metadata::Metadata,
+    metadata: metadata::Metadata<RocksdbStorageEngine>,
 
     // content implements the content storage.
     content: content::Content,

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -15,48 +15,19 @@
  */
 
 use chrono::{NaiveDateTime, Utc};
-use dragonfly_client_core::{
-    error::{ErrorType, OrErr},
-    Error, Result,
-};
+use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::http::reqwest_headermap_to_hashmap;
 use reqwest::header::{self, HeaderMap};
-use rocksdb::{
-    BlockBasedOptions, Cache, ColumnFamily, IteratorMode, Options, Transaction, TransactionDB,
-    TransactionDBOptions,
-};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::error;
 
-// DEFAULT_DIR_NAME is the default directory name to store metadata.
-const DEFAULT_DIR_NAME: &str = "metadata";
-
-// DEFAULT_MEMTABLE_MEMORY_BUDGET is the default memory budget for memtable, default is 64MB.
-const DEFAULT_MEMTABLE_MEMORY_BUDGET: usize = 64 * 1024 * 1024;
-
-// DEFAULT_MAX_OPEN_FILES is the default max open files for rocksdb.
-const DEFAULT_MAX_OPEN_FILES: i32 = 10_000;
-
-// DEFAULT_BLOCK_SIZE is the default block size for rocksdb.
-const DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
-
-// DEFAULT_CACHE_SIZE is the default cache size for rocksdb.
-const DEFAULT_CACHE_SIZE: usize = 16 * 1024 * 1024;
-
-/// TASK_CF_NAME is the column family name of [Task].
-const TASK_CF_NAME: &str = "task";
-
-/// PIECE_CF_NAME is the column family name of [Piece].
-const PIECE_CF_NAME: &str = "piece";
-
-/// ColumnFamilyDescriptor marks a type can be stored in rocksdb, which has a cf name.
-trait ColumnFamilyDescriptor: Default + Serialize + DeserializeOwned {
-    /// CF_NAME returns the column family name.
-    const CF_NAME: &'static str;
-}
+use crate::storage_engine::{
+    rocksdb::RocksdbStorageEngine, DatabaseObject, Operations, StorageEngine, StorageEngineOwned,
+    Transaction,
+};
 
 // Task is the metadata of the task.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -87,8 +58,9 @@ pub struct Task {
     pub finished_at: Option<NaiveDateTime>,
 }
 
-impl ColumnFamilyDescriptor for Task {
-    const CF_NAME: &'static str = TASK_CF_NAME;
+impl DatabaseObject for Task {
+    /// NAMESPACE is the namespace of [Task] objects.
+    const NAMESPACE: &'static str = "task";
 }
 
 // Task implements the task metadata.
@@ -174,8 +146,9 @@ pub struct Piece {
     pub finished_at: Option<NaiveDateTime>,
 }
 
-impl ColumnFamilyDescriptor for Piece {
-    const CF_NAME: &'static str = PIECE_CF_NAME;
+impl DatabaseObject for Piece {
+    /// NAMESPACE is the namespace of [Piece] objects.
+    const NAMESPACE: &'static str = "piece";
 }
 
 // Piece implements the piece metadata.
@@ -223,49 +196,29 @@ impl Piece {
 }
 
 /// Metadata manages the metadata of [Task] and [Piece].
-pub struct Metadata {
+pub struct Metadata<E>
+where
+    E: StorageEngineOwned,
+{
     /// db is the underlying rocksdb instance.
-    db: TransactionDB,
+    db: E,
 }
 
-impl Metadata {
+impl Metadata<RocksdbStorageEngine> {
     /// new creates a new metadata instance.
-    pub fn new(dir: &Path) -> Result<Metadata> {
-        // Initialize rocksdb options.
-        let mut options = Options::default();
-        options.create_if_missing(true);
-        options.create_missing_column_families(true);
-        options.optimize_level_style_compaction(DEFAULT_MEMTABLE_MEMORY_BUDGET);
-        options.increase_parallelism(num_cpus::get() as i32);
-        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
-        // Set prefix extractor to reduce the memory usage of bloom filter and length of task id is 64.
-        options.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(64));
-        options.set_memtable_prefix_bloom_ratio(0.2);
-
-        // Initialize rocksdb block based table options.
-        let mut block_options = BlockBasedOptions::default();
-        block_options.set_block_cache(&Cache::new_lru_cache(DEFAULT_CACHE_SIZE));
-        block_options.set_block_size(DEFAULT_BLOCK_SIZE);
-        block_options.set_cache_index_and_filter_blocks(true);
-        block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
-        block_options.set_bloom_filter(10.0, false);
-        options.set_block_based_table_factory(&block_options);
-
-        // Open rocksdb.
-        let dir = dir.join(DEFAULT_DIR_NAME);
-        let cf_names = [Task::CF_NAME, Piece::CF_NAME];
-        let db = TransactionDB::open_cf(&options, &TransactionDBOptions::default(), &dir, cf_names)
-            .or_err(ErrorType::StorageError)?;
-        info!("metadata initialized directory: {:?}", dir);
+    pub fn new(dir: &Path) -> Result<Metadata<RocksdbStorageEngine>> {
+        let db = RocksdbStorageEngine::open(dir, &[Task::NAMESPACE, Piece::NAMESPACE])?;
 
         Ok(Metadata { db })
     }
+}
 
+impl<E: StorageEngineOwned> Metadata<E> {
     /// with_txn executes the enclosed closure within a transaction.
-    fn with_txn<T>(&self, f: impl FnOnce(&Transaction<TransactionDB>) -> Result<T>) -> Result<T> {
-        let txn = self.db.transaction();
+    fn with_txn<T>(&self, f: impl FnOnce(&<E as StorageEngine>::Txn) -> Result<T>) -> Result<T> {
+        let txn = self.db.start_transaction();
         let result = f(&txn)?;
-        txn.commit().or_err(ErrorType::StorageError)?;
+        txn.commit()?;
         Ok(result)
     }
 
@@ -281,21 +234,15 @@ impl Metadata {
         or_else: impl FnOnce() -> Result<T>,
     ) -> Result<T>
     where
-        T: ColumnFamilyDescriptor,
+        T: DatabaseObject,
     {
         self.with_txn(|txn| {
-            let handle = self.cf_handle::<T>()?;
-            let object = match txn
-                .get_for_update_cf(handle, key, true)
-                .or_err(ErrorType::StorageError)?
-            {
-                Some(bytes) => serde_json::from_slice(&bytes).or_err(ErrorType::SerializeError)?,
+            let object: T = match txn.get_for_update(key.as_bytes())? {
+                Some(object) => object,
                 None => or_else()?,
             };
             let object = update(object)?;
-            let json = serde_json::to_string(&object).or_err(ErrorType::SerializeError)?;
-            txn.put_cf(handle, key.as_bytes(), json.as_bytes())
-                .or_err(ErrorType::StorageError)?;
+            txn.put(key.as_bytes(), &object)?;
             Ok(object)
         })
     }
@@ -396,54 +343,24 @@ impl Metadata {
 
     /// get_task gets the task metadata.
     pub fn get_task(&self, id: &str) -> Result<Option<Task>> {
-        // Get the column family handle of task.
-        let handle = self.cf_handle::<Task>()?;
-        match self.db.get_cf(handle, id).or_err(ErrorType::StorageError)? {
-            Some(bytes) => Ok(Some(
-                serde_json::from_slice(&bytes).or_err(ErrorType::SerializeError)?,
-            )),
-            None => Ok(None),
-        }
+        self.db.get(id.as_bytes())
     }
 
     /// get_tasks gets the task metadatas.
     pub fn get_tasks(&self) -> Result<Vec<Task>> {
-        // Get the column family handle of task.
-        let handle = self.cf_handle::<Task>()?;
-
-        self.with_txn(|txn| {
-            let iter = txn.iterator_cf(handle, IteratorMode::Start);
-
-            // Iterate the task metadatas.
-            let mut tasks = Vec::new();
-            for ele in iter {
-                let (_, value) = ele.or_err(ErrorType::StorageError)?;
-                let task: Task =
-                    serde_json::from_slice(&value).or_err(ErrorType::SerializeError)?;
-                tasks.push(task);
-            }
-
-            Ok(tasks)
-        })
+        self.with_txn(|txn| txn.iter()?.map(|ele| ele.map(|(_, task)| task)).collect())
     }
 
     /// delete_task deletes the task metadata.
     pub fn delete_task(&self, task_id: &str) -> Result<()> {
-        // Get the column family handle of task.
-        let handle = self.cf_handle::<Task>()?;
-
         self.with_txn(|txn| {
-            txn.delete_cf(handle, task_id)
-                .or_err(ErrorType::SerializeError)?;
+            txn.delete::<Task>(task_id.as_bytes())?;
             Ok(())
         })
     }
 
     /// download_piece_started updates the metadata of the piece when the piece downloads started.
     pub fn download_piece_started(&self, task_id: &str, number: u32) -> Result<Piece> {
-        // Get the column family handle of piece.
-        let handle = self.cf_handle::<Piece>()?;
-
         // Get the piece id.
         let id = self.piece_id(task_id, number);
 
@@ -457,9 +374,7 @@ impl Metadata {
 
         self.with_txn(|txn| {
             // Put the piece metadata.
-            let json = serde_json::to_string(&piece).or_err(ErrorType::SerializeError)?;
-            txn.put_cf(handle, id.as_bytes(), json.as_bytes())
-                .or_err(ErrorType::StorageError)?;
+            txn.put(id.as_bytes(), &piece)?;
             Ok(piece)
         })
     }
@@ -494,23 +409,14 @@ impl Metadata {
 
     /// download_piece_failed updates the metadata of the piece when the piece downloads failed.
     pub fn download_piece_failed(&self, task_id: &str, number: u32) -> Result<Piece> {
-        // Get the column family handle of piece.
-        let handle = self.cf_handle::<Piece>()?;
-
         // Get the piece id.
         let id = self.piece_id(task_id, number);
 
         self.with_txn(|txn| {
-            let piece = match txn
-                .get_for_update_cf(handle, id.as_bytes(), true)
-                .or_err(ErrorType::StorageError)?
-            {
+            let piece = match txn.get_for_update(id.as_bytes())? {
                 // If the piece exists, delete the piece metadata.
-                Some(bytes) => {
-                    txn.delete_cf(handle, id.as_bytes())
-                        .or_err(ErrorType::StorageError)?;
-                    let piece: Piece =
-                        serde_json::from_slice(&bytes).or_err(ErrorType::SerializeError)?;
+                Some(piece) => {
+                    txn.delete::<Piece>(id.as_bytes())?;
                     piece
                 }
                 // If the piece does not exist, return error.
@@ -573,52 +479,28 @@ impl Metadata {
     /// get_piece gets the piece metadata.
     pub fn get_piece(&self, task_id: &str, number: u32) -> Result<Option<Piece>> {
         let id = self.piece_id(task_id, number);
-        let handle = self.cf_handle::<Piece>()?;
-        match self
-            .db
-            .get_cf(handle, id.as_bytes())
-            .or_err(ErrorType::StorageError)?
-        {
-            Some(bytes) => Ok(Some(
-                serde_json::from_slice(&bytes).or_err(ErrorType::SerializeError)?,
-            )),
-            None => Ok(None),
-        }
+        self.db.get(id.as_bytes())
     }
 
     /// get_pieces gets the piece metadatas.
     pub fn get_pieces(&self, task_id: &str) -> Result<Vec<Piece>> {
-        // Get the column family handle of piece.
-        let handle = self.cf_handle::<Piece>()?;
-
         self.with_txn(|txn| {
-            let iter = txn.prefix_iterator_cf(handle, task_id.as_bytes());
-
             // Iterate the piece metadatas.
-            let mut pieces = Vec::new();
-            for ele in iter {
-                let (_, value) = ele.or_err(ErrorType::StorageError)?;
-                let piece: Piece =
-                    serde_json::from_slice(&value).or_err(ErrorType::SerializeError)?;
-                pieces.push(piece);
-            }
-
-            Ok(pieces)
+            txn.prefix_iter(task_id.as_bytes())?
+                .map(|ele| ele.map(|(_, piece)| piece))
+                .collect()
         })
     }
 
     /// delete_pieces deletes the piece metadatas.
     pub fn delete_pieces(&self, task_id: &str) -> Result<()> {
-        // Get the column family handle of piece.
-        let handle = self.cf_handle::<Piece>()?;
-
         self.with_txn(|txn| {
-            let iter = txn.prefix_iterator_cf(handle, task_id.as_bytes());
+            let iter = txn.prefix_iter::<Piece>(task_id.as_bytes())?;
 
             // Iterate the piece metadatas.
             for ele in iter {
-                let (key, _) = ele.or_err(ErrorType::StorageError)?;
-                txn.delete_cf(handle, key).or_err(ErrorType::StorageError)?;
+                let (key, _) = ele?;
+                txn.delete::<Piece>(&key)?;
             }
             Ok(())
         })
@@ -627,16 +509,5 @@ impl Metadata {
     /// piece_id returns the piece id.
     pub fn piece_id(&self, task_id: &str, number: u32) -> String {
         format!("{}-{}", task_id, number)
-    }
-
-    // cf_handle returns the column family handle.
-    fn cf_handle<T>(&self) -> Result<&ColumnFamily>
-    where
-        T: ColumnFamilyDescriptor,
-    {
-        let cf_name = T::CF_NAME;
-        self.db
-            .cf_handle(cf_name)
-            .ok_or_else(|| Error::ColumnFamilyNotFound(cf_name.to_string()))
     }
 }

--- a/dragonfly-client-storage/src/storage_engine/mod.rs
+++ b/dragonfly-client-storage/src/storage_engine/mod.rs
@@ -1,0 +1,65 @@
+use dragonfly_client_core::{
+    error::{ErrorType, OrErr},
+    Result,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+pub mod rocksdb;
+
+/// DatabaseObject marks a type can be stored in database, which has a namespace.
+/// The namespace is used to separate different types of objects, for example
+/// column families in rocksdb.
+pub trait DatabaseObject: Serialize + DeserializeOwned {
+    /// NAMESPACE is the namespace of the object.
+    const NAMESPACE: &'static str;
+
+    /// serialized serializes the object to bytes.
+    fn serialized(&self) -> Result<Vec<u8>> {
+        Ok(serde_json::to_vec(self).or_err(ErrorType::SerializeError)?)
+    }
+
+    /// deserialize_from deserializes the object from bytes.
+    fn deserialize_from(bytes: &[u8]) -> Result<Self> {
+        Ok(serde_json::from_slice(bytes).or_err(ErrorType::SerializeError)?)
+    }
+}
+
+/// StorageEngine defines basic storage engine operations.
+pub trait StorageEngine<'db>: Operations {
+    /// Txn is the transaction type.
+    type Txn: Transaction;
+
+    /// start_transaction starts a transaction.
+    fn start_transaction(&'db self) -> Self::Txn;
+}
+
+/// StorageEngineOwned is a marker trait to indicate the storage engine is owned.
+pub trait StorageEngineOwned: for<'db> StorageEngine<'db> {}
+impl<T: for<'db> StorageEngine<'db>> StorageEngineOwned for T {}
+
+/// Operations defines basic crud operations.
+pub trait Operations {
+    /// get gets the object by key.
+    fn get<O: DatabaseObject>(&self, key: &[u8]) -> Result<Option<O>>;
+    /// put puts the object by key.
+    fn put<O: DatabaseObject>(&self, key: &[u8], value: &O) -> Result<()>;
+    /// delete deletes the object by key.
+    fn delete<O: DatabaseObject>(&self, key: &[u8]) -> Result<()>;
+    /// iter iterates all objects.
+    fn iter<O: DatabaseObject>(&self) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>>;
+    /// prefix_iter iterates all objects with prefix.
+    fn prefix_iter<O: DatabaseObject>(
+        &self,
+        prefix: &[u8],
+    ) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>>;
+}
+
+/// Transaction defines transactional operations.
+pub trait Transaction: Operations {
+    /// get_for_update gets the object for update.
+    fn get_for_update<O: DatabaseObject>(&self, key: &[u8]) -> Result<Option<O>>;
+    /// commit commits the transaction.
+    fn commit(self) -> Result<()>;
+    /// rollback rolls back the transaction.
+    fn rollback(&self) -> Result<()>;
+}

--- a/dragonfly-client-storage/src/storage_engine/rocksdb.rs
+++ b/dragonfly-client-storage/src/storage_engine/rocksdb.rs
@@ -1,0 +1,220 @@
+use std::{ops::Deref, path::Path};
+
+use dragonfly_client_core::{
+    error::{ErrorType, OrErr},
+    Error, Result,
+};
+
+use tracing::info;
+
+use crate::storage_engine::{DatabaseObject, Operations, StorageEngine, Transaction};
+
+/// RocksdbStorageEngine is a storage engine based on rocksdb.
+pub struct RocksdbStorageEngine {
+    inner: rocksdb::TransactionDB,
+}
+
+impl Deref for RocksdbStorageEngine {
+    type Target = rocksdb::TransactionDB;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl RocksdbStorageEngine {
+    /// DEFAULT_DIR_NAME is the default directory name to store metadata.
+    const DEFAULT_DIR_NAME: &'static str = "metadata";
+
+    /// DEFAULT_MEMTABLE_MEMORY_BUDGET is the default memory budget for memtable, default is 64MB.
+    const DEFAULT_MEMTABLE_MEMORY_BUDGET: usize = 64 * 1024 * 1024;
+
+    /// DEFAULT_MAX_OPEN_FILES is the default max open files for rocksdb.
+    const DEFAULT_MAX_OPEN_FILES: i32 = 10_000;
+
+    /// DEFAULT_BLOCK_SIZE is the default block size for rocksdb.
+    const DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
+
+    /// DEFAULT_CACHE_SIZE is the default cache size for rocksdb.
+    const DEFAULT_CACHE_SIZE: usize = 16 * 1024 * 1024;
+
+    /// open opens a rocksdb storage engine with the given directory and column families.
+    pub fn open(dir: &Path, cf_names: &[&str]) -> Result<Self> {
+        // Initialize rocksdb options.
+        let mut options = rocksdb::Options::default();
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        options.optimize_level_style_compaction(Self::DEFAULT_MEMTABLE_MEMORY_BUDGET);
+        options.increase_parallelism(num_cpus::get() as i32);
+        options.set_max_open_files(Self::DEFAULT_MAX_OPEN_FILES);
+        // Set prefix extractor to reduce the memory usage of bloom filter and length of task id is 64.
+        options.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(64));
+        options.set_memtable_prefix_bloom_ratio(0.2);
+
+        // Initialize rocksdb block based table options.
+        let mut block_options = rocksdb::BlockBasedOptions::default();
+        block_options.set_block_cache(&rocksdb::Cache::new_lru_cache(Self::DEFAULT_CACHE_SIZE));
+        block_options.set_block_size(Self::DEFAULT_BLOCK_SIZE);
+        block_options.set_cache_index_and_filter_blocks(true);
+        block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        block_options.set_bloom_filter(10.0, false);
+        options.set_block_based_table_factory(&block_options);
+
+        // Open rocksdb.
+        let dir = dir.join(Self::DEFAULT_DIR_NAME);
+        let db = rocksdb::TransactionDB::open_cf(
+            &options,
+            &rocksdb::TransactionDBOptions::default(),
+            &dir,
+            cf_names,
+        )
+        .or_err(ErrorType::StorageError)?;
+        info!("metadata initialized directory: {:?}", dir);
+
+        Ok(Self { inner: db })
+    }
+}
+
+impl Operations for RocksdbStorageEngine {
+    fn get<O: DatabaseObject>(&self, key: &[u8]) -> Result<Option<O>> {
+        let cf = cf_handle::<O>(self)?;
+        let value = self.get_cf(cf, key).or_err(ErrorType::StorageError)?;
+        match value {
+            Some(value) => Ok(Some(O::deserialize_from(&value)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn put<O: DatabaseObject>(&self, key: &[u8], value: &O) -> Result<()> {
+        let cf = cf_handle::<O>(self)?;
+        let serialized = value.serialized()?;
+        self.put_cf(cf, key, serialized)
+            .or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+
+    fn delete<O: DatabaseObject>(&self, key: &[u8]) -> Result<()> {
+        let cf = cf_handle::<O>(self)?;
+        self.delete_cf(cf, key).or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+
+    fn iter<O: DatabaseObject>(&self) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>> {
+        let cf = cf_handle::<O>(self)?;
+        let iter = self.iterator_cf(cf, rocksdb::IteratorMode::Start);
+        Ok(iter.map(|ele| {
+            let (key, value) = ele.or_err(ErrorType::StorageError)?;
+            Ok((key, O::deserialize_from(&value)?))
+        }))
+    }
+
+    fn prefix_iter<O: DatabaseObject>(
+        &self,
+        prefix: &[u8],
+    ) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>> {
+        let cf = cf_handle::<O>(self)?;
+        let iter = self.prefix_iterator_cf(cf, prefix);
+        Ok(iter.map(|ele| {
+            let (key, value) = ele.or_err(ErrorType::StorageError)?;
+            Ok((key, O::deserialize_from(&value)?))
+        }))
+    }
+}
+
+impl<'db> StorageEngine<'db> for RocksdbStorageEngine {
+    type Txn = RocksdbTransaction<'db>;
+
+    fn start_transaction(&'db self) -> RocksdbTransaction<'db> {
+        let txn = self.transaction();
+        RocksdbTransaction { txn, db: self }
+    }
+}
+
+/// RocksdbTransaction wraps a rocksdb transaction.
+pub struct RocksdbTransaction<'db> {
+    txn: rocksdb::Transaction<'db, rocksdb::TransactionDB>,
+    db: &'db rocksdb::TransactionDB,
+}
+
+impl Operations for RocksdbTransaction<'_> {
+    fn get<O: DatabaseObject>(&self, key: &[u8]) -> Result<Option<O>> {
+        let cf = cf_handle::<O>(self.db)?;
+        let value = self.txn.get_cf(cf, key).or_err(ErrorType::StorageError)?;
+        match value {
+            Some(value) => Ok(Some(O::deserialize_from(&value)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn put<O: DatabaseObject>(&self, key: &[u8], value: &O) -> Result<()> {
+        let cf = cf_handle::<O>(self.db)?;
+        let serialized = value.serialized()?;
+        self.txn
+            .put_cf(cf, key, serialized)
+            .or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+
+    fn delete<O: DatabaseObject>(&self, key: &[u8]) -> Result<()> {
+        let cf = cf_handle::<O>(self.db)?;
+        self.txn
+            .delete_cf(cf, key)
+            .or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+
+    fn iter<O: DatabaseObject>(&self) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>> {
+        let cf = cf_handle::<O>(self.db)?;
+        let iter = self.txn.iterator_cf(cf, rocksdb::IteratorMode::Start);
+        Ok(iter.map(|ele| {
+            let (key, value) = ele.or_err(ErrorType::StorageError)?;
+            Ok((key, O::deserialize_from(&value)?))
+        }))
+    }
+
+    fn prefix_iter<O: DatabaseObject>(
+        &self,
+        prefix: &[u8],
+    ) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>> {
+        let cf = cf_handle::<O>(self.db)?;
+        let iter = self.txn.prefix_iterator_cf(cf, prefix);
+        Ok(iter.map(|ele| {
+            let (key, value) = ele.or_err(ErrorType::StorageError)?;
+            Ok((key, O::deserialize_from(&value)?))
+        }))
+    }
+}
+
+impl Transaction for RocksdbTransaction<'_> {
+    fn get_for_update<O: DatabaseObject>(&self, key: &[u8]) -> Result<Option<O>> {
+        let cf = cf_handle::<O>(self.db)?;
+        let value = self
+            .txn
+            .get_for_update_cf(cf, key, true)
+            .or_err(ErrorType::StorageError)?;
+        match value {
+            Some(value) => Ok(Some(O::deserialize_from(&value)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn commit(self) -> Result<()> {
+        self.txn.commit().or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<()> {
+        self.txn.rollback().or_err(ErrorType::StorageError)?;
+        Ok(())
+    }
+}
+
+/// cf_handle returns the column family handle for the given object.
+fn cf_handle<T>(db: &rocksdb::TransactionDB) -> Result<&rocksdb::ColumnFamily>
+where
+    T: DatabaseObject,
+{
+    let cf_name = T::NAMESPACE;
+    db.cf_handle(cf_name)
+        .ok_or_else(|| Error::ColumnFamilyNotFound(cf_name.to_string()))
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extract rocksdb logic into several traits like `StorageEngine`, `Transaction`, `Operation`, etc., so that `Metadata` is db-agnostic.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
