### PR TITLE
chore: pin rust version to 1.77.2 to prevent rocksdb bug

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.77.2"


### PR DESCRIPTION
Change-Id: I6cd315ed953169cd5ecfc5f579fe6c2d24220e0f

<!--- Provide a general summary of your changes in the Title above -->

## Description

ref: https://github.com/dragonflyoss/client/pull/401#issuecomment-2066990059

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
