### PR TITLE
feat: remove remote_address label from PROXY_REQUSET_COUNT and PROXY_REQUSET_FAILURE_COUNT

### DIFF
--- a/dragonfly-client/src/metrics/mod.rs
+++ b/dragonfly-client/src/metrics/mod.rs
@@ -106,14 +106,14 @@ lazy_static! {
     pub static ref PROXY_REQUSET_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new("proxy_request_total", "Counter of the number of the proxy request.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
-            &["remote_address"]
+            &[]
         ).expect("metric can be created");
 
     // PROXY_REQUSET_FAILURE_COUNT is used to count the failed number of proxy request.
     pub static ref PROXY_REQUSET_FAILURE_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new("proxy_request_failure_total", "Counter of the number of failed of the proxy request.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
-            &["remote_address"]
+            &[]
         ).expect("metric can be created");
 }
 
@@ -331,17 +331,13 @@ pub fn collect_upload_piece_failure_metrics() {
 }
 
 // collect_proxy_request_started_metrics collects the proxy request started metrics.
-pub fn collect_proxy_request_started_metrics(remote_address: &str) {
-    PROXY_REQUSET_COUNT
-        .with_label_values(&[remote_address])
-        .inc();
+pub fn collect_proxy_request_started_metrics() {
+    PROXY_REQUSET_COUNT.with_label_values(&[]).inc();
 }
 
 // collect_proxy_request_failure_metrics collects the proxy request failure metrics.
-pub fn collect_proxy_request_failure_metrics(remote_address: &str) {
-    PROXY_REQUSET_FAILURE_COUNT
-        .with_label_values(&[remote_address])
-        .inc();
+pub fn collect_proxy_request_failure_metrics() {
+    PROXY_REQUSET_FAILURE_COUNT.with_label_values(&[]).inc();
 }
 
 // Metrics is the metrics server.

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -169,7 +169,7 @@ impl Proxy {
 
                     // Spawn a task to handle the connection.
                     let io = TokioIo::new(tcp);
-                    collect_proxy_request_started_metrics(remote_address.to_string().as_str());
+                    collect_proxy_request_started_metrics();
                     info!("accepted connection from {}", remote_address);
 
                     let config = self.config.clone();
@@ -188,7 +188,7 @@ impl Proxy {
                             .with_upgrades()
                             .await
                         {
-                            collect_proxy_request_failure_metrics(remote_address.to_string().as_str());
+                            collect_proxy_request_failure_metrics();
                             error!("failed to serve connection from {}: {}", remote_address, err);
                         }
                     });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
