### PR TITLE
feat: delete task when task status is valid.

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -514,8 +514,26 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         &self,
         request: Request<DeleteTaskRequest>,
     ) -> Result<Response<()>, Status> {
-        println!("delete_task: {:?}", request);
-        Err(Status::unimplemented("not implemented"))
+        // Clone the request.
+        let request = request.into_inner();
+
+        // Generate the host id.
+        let host_id = self.task.id_generator.host_id();
+
+        // Get the task id from the request.
+        let task_id = request.task_id;
+
+        // Span record the host id and task id.
+        Span::current().record("host_id", host_id.as_str());
+        Span::current().record("task_id", task_id.as_str());
+
+        // Delete the task from the scheduler.
+        self.task.delete_task(task_id.as_str()).await.map_err(|e| {
+            error!("delete task: {}", e);
+            Status::internal(e.to_string())
+        })?;
+
+        Ok(Response::new(()))
     }
 
     // delete_host calls the scheduler to delete the host.


### PR DESCRIPTION
## Description

This pull request adds functionality to check task status and handle status data within the `dfdaemon_download` and `task` modules. The implementation includes new methods for deleting tasks and reclaiming local storage.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/dragonflyoss/Dragonfly2/issues/2818

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The changes are required to improve the task management capabilities of the system. By adding these methods, users can better manage and delete tasks, ensuring efficient resource usage and task tracking.

- Design: https://www.yuque.com/baimo/fv9qk8/ed40b9sg7l9crdt4
- Design: https://github.com/dragonflyoss/Dragonfly2/issues/2818#issuecomment-2190419157

## Screenshots (if appropriate)
