### PR TITLE
feat: add delete task rpc implement by checking task status and reclaiming local storage with metadata.

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -514,8 +514,29 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         &self,
         request: Request<DeleteTaskRequest>,
     ) -> Result<Response<()>, Status> {
-        println!("delete_task: {:?}", request);
-        Err(Status::unimplemented("not implemented"))
+        // Clone the request.
+        let request = request.into_inner();
+
+        // Generate the host id.
+        let host_id = self.task.id_generator.host_id();
+
+        // Get the task id from the request.
+        let task_id = request.task_id;
+
+        // Span record the host id and task id.
+        Span::current().record("host_id", host_id.as_str());
+        Span::current().record("task_id", task_id.as_str());
+
+        // Delete the task from the scheduler.
+        self.task
+            .delete_task(task_id.as_str())
+            .await
+            .map_err(|err| {
+                error!("delete task: {}", err);
+                Status::invalid_argument(err.to_string())
+            })?;
+
+        Ok(Response::new(()))
     }
 
     // delete_host calls the scheduler to delete the host.

--- a/dragonfly-client/src/task/mod.rs
+++ b/dragonfly-client/src/task/mod.rs
@@ -1548,4 +1548,41 @@ impl Task {
             "not all pieces are downloaded from source".to_string(),
         ))
     }
+
+    // Delete a task and reclaim local storage
+    pub async fn delete_task(&self, task_id: &str) -> ClientResult<()> {
+        let task_result = self.storage.get_task(task_id).map_err(|err| {
+            error!("get task {} from local storage error: {:?}", task_id, err);
+            Status::internal(err.to_string())
+        })?;
+
+        match task_result {
+            Some(task) => {
+                // Check current task is valid to be deleted
+                if !task.is_finished() && task.is_uploading() {
+                    return Err(Error::InvalidState(
+                        "current task is not finished or uploading".to_string(),
+                    ));
+                }
+
+                self.storage
+                    .delete_task(task.id.as_str())
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "delete task {} from local storage error: {:?}",
+                            task.id, err
+                        );
+                        Status::internal(err.to_string())
+                    })?;
+                info!("delete task {} from local storage", task.id);
+
+                Ok(())
+            }
+            None => {
+                error!("delete_task task {} not found", task_id);
+                Err(Error::TaskNotFound(task_id.to_owned()))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

This pull request adds functionality to check task status and handle status data within the `dfdaemon_download` and `task` modules. The implementation includes new methods for deleting tasks and reclaiming local storage.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/dragonflyoss/Dragonfly2/issues/2818

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The changes are required to improve the task management capabilities of the system. By adding these methods, users can better manage and delete tasks, ensuring efficient resource usage and task tracking.

- Design: https://www.yuque.com/baimo/fv9qk8/ed40b9sg7l9crdt4
- Design: https://github.com/dragonflyoss/Dragonfly2/issues/2818#issuecomment-2190419157

## Screenshots (if appropriate)
