### PR TITLE
feat: support OSS protocol to download single file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +945,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1052,6 +1072,7 @@ dependencies = [
  "futures",
  "httpmock",
  "libloading",
+ "opendal",
  "reqwest",
  "rustls",
  "rustls-pki-types",
@@ -1306,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,8 +1532,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1652,6 +1681,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1998,7 +2036,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -2326,6 +2364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2673,35 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opendal"
+version = "0.47.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac4826fe3d5482a49b92955b0f6b06ce45b46ec84484176588209bfbf996870"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "flagset",
+ "futures",
+ "getrandom",
+ "http 1.1.0",
+ "log",
+ "md-5",
+ "once_cell",
+ "percent-encoding",
+ "quick-xml 0.31.0",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "openssl"
@@ -3234,6 +3311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3506,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqsign"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "form_urlencoded",
+ "getrandom",
+ "hex",
+ "hmac",
+ "home",
+ "http 1.1.0",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -4682,6 +4796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/dragonfly-client-backend/Cargo.toml
+++ b/dragonfly-client-backend/Cargo.toml
@@ -23,6 +23,7 @@ url.workspace = true
 tracing.workspace = true
 futures = "0.3.28"
 libloading = "0.8.4"
+opendal = { version = "0.47.3", features = ["services-oss"]}
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -104,6 +104,7 @@ impl crate::Backend for HTTP {
             http_header: Some(header),
             http_status_code: Some(status_code),
             error_message: Some(status_code.to_string()),
+            entries: None,
         })
     }
 
@@ -182,6 +183,7 @@ mod tests {
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
                 object_storage: None,
+                recursive: false,
             })
             .await
             .unwrap();
@@ -208,6 +210,7 @@ mod tests {
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
                 object_storage: None,
+                recursive: false,
             })
             .await;
 

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -181,6 +181,7 @@ mod tests {
                 http_header: Some(HeaderMap::new()),
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
             })
             .await
             .unwrap();
@@ -206,6 +207,7 @@ mod tests {
                 http_header: None,
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
             })
             .await;
 
@@ -231,6 +233,7 @@ mod tests {
                 http_header: Some(HeaderMap::new()),
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
             })
             .await
             .unwrap();

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use dragonfly_api::common::v2::Range;
+use dragonfly_api::common::v2::{ObjectStorage, Range};
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -53,6 +53,9 @@ pub struct HeadRequest {
 
     // client_certs is the client certificates for the request.
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
+
+    // the object storage related information.
+    pub object_storage: Option<ObjectStorage>,
 }
 
 // HeadResponse is the head response for backend.
@@ -92,6 +95,9 @@ pub struct GetRequest {
 
     // client_certs is the client certificates for the request.
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
+
+    // the object storage related information.
+    pub object_storage: Option<ObjectStorage>,
 }
 
 // GetResponse is the get response for backend.

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -55,7 +55,7 @@ pub struct HeadRequest {
     // client_certs is the client certificates for the request.
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
-    // recursive is to define whether to traverse the directory recersively
+    // recursive is to define whether to traverse the directory recersively.
     pub recursive: bool,
 
     // object_storage is the object storage related information.
@@ -79,7 +79,7 @@ pub struct HeadResponse {
     // error_message is the error message of the response.
     pub error_message: Option<String>,
 
-    // entries the the entries of directory
+    // entries is the entries of directory.
     pub entries: Option<Vec<DirEntry>>,
 }
 
@@ -229,6 +229,10 @@ impl BackendFactory {
         self.backends
             .insert("https".to_string(), Box::new(http::HTTP::new()));
         info!("load [https] builtin backend ");
+
+        self.backends
+            .insert("oss".to_string(), Box::new(oss::OSS::new()));
+        info!("load [oss] builtin backend ");
     }
 
     // load_plugin_backends loads the plugin backends.

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -30,6 +30,7 @@ use tracing::{error, info, warn};
 use url::Url;
 
 pub mod http;
+pub mod oss;
 
 // NAME is the name of the package.
 pub const NAME: &str = "backend";
@@ -54,7 +55,10 @@ pub struct HeadRequest {
     // client_certs is the client certificates for the request.
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
-    // the object storage related information.
+    // recursive is to define whether to traverse the directory recersively
+    pub recursive: bool,
+
+    // object_storage is the object storage related information.
     pub object_storage: Option<ObjectStorage>,
 }
 
@@ -74,6 +78,9 @@ pub struct HeadResponse {
 
     // error_message is the error message of the response.
     pub error_message: Option<String>,
+
+    // entries the the entries of directory
+    pub entries: Option<Vec<DirEntry>>,
 }
 
 // GetRequest is the get request for backend.
@@ -133,6 +140,15 @@ where
             .await?;
         Ok(buffer)
     }
+}
+
+/// The File Entry of a directory, including some relevant file metadata.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DirEntry {
+    pub url: String,
+    pub content_length: usize,
+    pub is_dir: bool,
+    pub version: Option<String>,
 }
 
 // Backend is the interface of the backend.

--- a/dragonfly-client-backend/src/oss.rs
+++ b/dragonfly-client-backend/src/oss.rs
@@ -1,0 +1,263 @@
+use std::time::Duration;
+
+use dragonfly_client_core::*;
+use dragonfly_client_util::tls::NoVerifier;
+use error::BackendError;
+use opendal::{raw::HttpClient, Metakey, Operator};
+use reqwest::{header::HeaderMap, StatusCode};
+use rustls_pki_types::CertificateDer;
+use tokio_util::io::StreamReader;
+use tracing::info;
+use url::Url;
+
+use crate::*;
+
+/// the config that parsed from the url
+#[derive(Debug)]
+struct OSSConfig {
+    url: Url,
+    bucket: String,
+    endpoint: String,
+    version: Option<String>,
+}
+
+impl OSSConfig {
+    fn is_dir(&self) -> bool {
+        self.url.path().ends_with('/')
+    }
+
+    #[inline]
+    fn key(&self) -> &str {
+        self.url.path().trim_start_matches('/')
+    }
+
+    fn build_url_with_same_endpoint(&self, path: &str) -> String {
+        let mut url = self.url.clone();
+        url.set_path(path);
+        url.to_string()
+    }
+}
+
+impl TryFrom<Url> for OSSConfig {
+    type Error = Error;
+
+    fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
+        let host_str = url
+            .host_str()
+            .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
+
+        // Check the url is valid.
+        if url.scheme() != "oss"
+            || url.path().is_empty()
+            || !host_str.ends_with("aliyuncs.com")
+            || host_str.matches('.').count() < 3
+        {
+            return Err(Error::InvalidURI(url.to_string()));
+        }
+
+        // Parse the bucket and endpoint
+        let (bucket, endpoint) = host_str
+            .split_once('.')
+            .map(|(s1, s2)| (s1.to_string(), format!("https://{}", s2))) // Add scheme for endpoint.
+            .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
+
+        // Parse the possible version
+        let version = url
+            .query_pairs()
+            .find(|(key, _)| key == "versionId")
+            .map(|(_, version)| version.to_string());
+
+        Ok(Self {
+            url,
+            endpoint,
+            bucket,
+            version,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct OSS;
+
+impl OSS {
+    pub fn new() -> Self {
+        Self
+    }
+
+    // client_builder returns a new reqwest client builder.
+    fn client_builder(
+        &self,
+        client_certs: Option<Vec<CertificateDer<'static>>>,
+    ) -> reqwest::ClientBuilder {
+        let client_config_builder = match client_certs.as_ref() {
+            Some(client_certs) => {
+                let mut root_cert_store = rustls::RootCertStore::empty();
+                root_cert_store.add_parsable_certificates(client_certs.to_owned());
+
+                // TLS client config using the custom CA store for lookups.
+                rustls::ClientConfig::builder()
+                    .with_root_certificates(root_cert_store)
+                    .with_no_client_auth()
+            }
+            // Default TLS client config with native roots.
+            None => rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(NoVerifier::new())
+                .with_no_client_auth(),
+        };
+
+        reqwest::Client::builder().use_preconfigured_tls(client_config_builder)
+    }
+
+    // Set up the operator of OSS and OSSConfig.
+    fn setup_operator_with_config(
+        &self,
+        header: HeaderMap,
+        certs: Option<Vec<CertificateDer<'static>>>,
+        timeout: Duration,
+        url: String,
+        object_storage: Option<ObjectStorage>,
+    ) -> Result<(OSSConfig, Operator)> {
+        let client = self
+            .client_builder(certs)
+            .timeout(timeout)
+            .default_headers(header)
+            .build()?;
+
+        let url: Url = url.parse().map_err(|_| Error::InvalidURI(url))?;
+
+        let config = OSSConfig::try_from(url)?;
+
+        let mut oss_builder = opendal::services::Oss::default();
+
+        let ObjectStorage {
+            access_key_id,
+            access_key_secret,
+        } = object_storage.ok_or(Error::InvalidParameter)?;
+
+        oss_builder
+            .access_key_id(&access_key_id)
+            .access_key_secret(&access_key_secret)
+            .http_client(HttpClient::with(client))
+            .root("/")
+            .bucket(&config.bucket)
+            .endpoint(&config.endpoint);
+
+        Ok((
+            config,
+            Operator::new(oss_builder).map_err(map_sdk_error)?.finish(),
+        ))
+    }
+}
+
+#[tonic::async_trait]
+impl Backend for OSS {
+    async fn head(&self, request: HeadRequest) -> Result<HeadResponse> {
+        info!(
+            "head request {} {}: {:?}",
+            request.task_id, request.url, request.http_header
+        );
+
+        let (config, op) = self.setup_operator_with_config(
+            request.http_header.clone().unwrap_or_default(),
+            request.client_certs,
+            request.timeout,
+            request.url,
+            request.object_storage,
+        )?;
+
+        // Get the entries if url point to a directory.
+        let entries = if config.is_dir() {
+            Some(
+                op.list_with(config.key())
+                    .recursive(request.recursive)
+                    .metakey(Metakey::ContentLength | Metakey::Mode | Metakey::Version)
+                    .await // Do the list op here.
+                    .map_err(map_sdk_error)?
+                    .into_iter()
+                    .map(|entry| {
+                        let path = entry.path();
+                        let metadata = entry.metadata();
+
+                        let content_length = metadata.content_length() as usize;
+                        let is_dir = metadata.is_dir();
+                        let version = metadata.version().map(|v| v.into());
+
+                        DirEntry {
+                            url: config.build_url_with_same_endpoint(path),
+                            content_length,
+                            is_dir,
+                            version,
+                        }
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        let mut stat_op = op.stat_with(config.key());
+
+        if let Some(ref version) = config.version {
+            stat_op = stat_op.version(version);
+        }
+
+        let stat = stat_op.await.map_err(map_sdk_error)?;
+
+        Ok(HeadResponse {
+            success: true,
+            content_length: Some(stat.content_length()),
+            http_header: request.http_header,
+            http_status_code: Some(reqwest::StatusCode::OK),
+            error_message: None,
+            entries,
+        })
+    }
+
+    async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
+        info!(
+            "get request {} {}: {:?}",
+            request.piece_id, request.url, request.http_header
+        );
+
+        let (config, op) = self.setup_operator_with_config(
+            request.http_header.clone().unwrap_or_default(),
+            request.client_certs,
+            request.timeout,
+            request.url,
+            request.object_storage,
+        )?;
+
+        let mut reader_op = op.reader_with(config.key()).chunk(8 << 10);
+
+        if let Some(ref version) = config.version {
+            reader_op = reader_op.version(version);
+        }
+
+        let reader = reader_op.await.map_err(map_sdk_error)?;
+
+        let stream = match request.range {
+            Some(range) => reader
+                .into_bytes_stream(range.start..range.start + range.length)
+                .await
+                .map_err(map_sdk_error)?,
+            None => reader.into_bytes_stream(..).await.map_err(map_sdk_error)?,
+        };
+
+        Ok(GetResponse {
+            success: true,
+            http_header: None,
+            http_status_code: Some(reqwest::StatusCode::OK),
+            reader: Box::new(StreamReader::new(stream)),
+            error_message: None,
+        })
+    }
+}
+
+fn map_sdk_error(e: opendal::Error) -> Error {
+    Error::BackendError(BackendError {
+        message: e.to_string(),
+        status_code: StatusCode::INTERNAL_SERVER_ERROR,
+        header: HeaderMap::default(),
+    })
+}

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -205,13 +205,13 @@ struct Args {
 
     #[arg(
         long,
-        help = "Specify the access key ID of the Object Storage Services"
+        help = "Specify the access key ID of the Object Storage Services. It should be provided with `access_key_secret` at the same time."
     )]
     access_key_id: Option<String>,
 
     #[arg(
         long,
-        help = "Specify the access key secret of the Object Storage Services"
+        help = "Specify the access key secret of the Object Storage Services. It should be provided with `access_key_id` at the same time."
     )]
     access_key_secret: Option<String>,
 }
@@ -382,6 +382,8 @@ async fn run(args: Args) -> Result<()> {
 
     let mut object_storage = None;
 
+    // Only when the `access_key_id` and `access_key_secret` are provided at the same time,
+    // they will be pass to the `DownloadTaskRequest`.
     if let (Some(access_key_id), Some(access_key_secret)) =
         (args.access_key_id, args.access_key_secret)
     {

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -19,7 +19,7 @@ use crate::metrics::{
     collect_download_piece_traffic_metrics, collect_upload_piece_traffic_metrics,
 };
 use chrono::Utc;
-use dragonfly_api::common::v2::{Peer, Range, TrafficType};
+use dragonfly_api::common::v2::{ObjectStorage, Peer, Range, TrafficType};
 use dragonfly_api::dfdaemon::v2::DownloadPieceRequest;
 use dragonfly_client_backend::{BackendFactory, GetRequest};
 use dragonfly_client_config::dfdaemon::Config;
@@ -447,6 +447,7 @@ impl Piece {
         offset: u64,
         length: u64,
         request_header: HeaderMap,
+        object_storage: Option<ObjectStorage>,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", self.storage.piece_id(task_id, number));
@@ -487,6 +488,7 @@ impl Piece {
                 http_header: Some(request_header),
                 timeout: self.config.download.piece_timeout,
                 client_certs: None,
+                object_storage,
             })
             .await
             .map_err(|err| {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -144,6 +144,7 @@ impl Task {
                 timeout: self.config.download.piece_timeout,
                 client_certs: None,
                 object_storage: download.object_storage,
+                recursive: false,
             })
             .await?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR add support for Aliyun OSS protocol to download **ONE** file.

<!--- Describe your changes in detail -->

This PR is done by the following task:
- [x] Add object storage related information such `access_key_id` (mostly about the security) in the `HeadRequest`, `GetRequest` and other position that need this information
- [x] Add a `OSSConfig` struct that parse request url and store the object storage related information such as `endpoint`, `bucket` and so on.
- [x] Add a `OSS` struct that implements the `Backend` traits and using [OpenDAL](https://github.com/apache/opendal) to access the Aliyun OSS System

Also, the `HeadRequest` now support list directory (recursively)

## Related Issue

#496 

## Motivation and Context

Dragonfly rust client does not support back-to-source downloading of different object storage protocols. Priority is given to supporting OSS protocol back-to-source downloads. Need to support OSS protocol in dragonfly-client-backend crate, implemented based on trait Backend and it needs to support directory recursive downloading.