### PR TITLE
Add Scheduler automatic switching function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +945,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1052,6 +1072,7 @@ dependencies = [
  "futures",
  "httpmock",
  "libloading",
+ "opendal",
  "reqwest",
  "rustls",
  "rustls-pki-types",
@@ -1306,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,8 +1532,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1652,6 +1681,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1998,7 +2036,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -2326,6 +2364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2673,35 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opendal"
+version = "0.47.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac4826fe3d5482a49b92955b0f6b06ce45b46ec84484176588209bfbf996870"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "flagset",
+ "futures",
+ "getrandom",
+ "http 1.1.0",
+ "log",
+ "md-5",
+ "once_cell",
+ "percent-encoding",
+ "quick-xml 0.31.0",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "openssl"
@@ -3234,6 +3311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3506,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqsign"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "form_urlencoded",
+ "getrandom",
+ "hex",
+ "hmac",
+ "home",
+ "http 1.1.0",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -4682,6 +4796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/dragonfly-client-backend/Cargo.toml
+++ b/dragonfly-client-backend/Cargo.toml
@@ -23,6 +23,7 @@ url.workspace = true
 tracing.workspace = true
 futures = "0.3.28"
 libloading = "0.8.4"
+opendal = { version = "0.47.3", features = ["services-oss"]}
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -104,6 +104,7 @@ impl crate::Backend for HTTP {
             http_header: Some(header),
             http_status_code: Some(status_code),
             error_message: Some(status_code.to_string()),
+            entries: None,
         })
     }
 
@@ -181,6 +182,8 @@ mod tests {
                 http_header: Some(HeaderMap::new()),
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
+                recursive: false,
             })
             .await
             .unwrap();
@@ -206,6 +209,8 @@ mod tests {
                 http_header: None,
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
+                recursive: false,
             })
             .await;
 
@@ -231,6 +236,7 @@ mod tests {
                 http_header: Some(HeaderMap::new()),
                 timeout: std::time::Duration::from_secs(5),
                 client_certs: None,
+                object_storage: None,
             })
             .await
             .unwrap();

--- a/dragonfly-client-backend/src/oss.rs
+++ b/dragonfly-client-backend/src/oss.rs
@@ -1,0 +1,359 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::io::{self, ErrorKind};
+use std::time::Duration;
+
+use dragonfly_client_core::*;
+use dragonfly_client_util::tls::NoVerifier;
+use error::BackendError;
+use opendal::{raw::HttpClient, Metakey, Operator};
+use reqwest::{header::HeaderMap, StatusCode};
+use rustls_pki_types::CertificateDer;
+use tokio_util::io::StreamReader;
+use tracing::info;
+use url::Url;
+
+use crate::*;
+
+/// The OSS config that parsed from the url.
+#[derive(Debug)]
+struct Config {
+    url: Url,
+    bucket: String,
+    endpoint: String,
+    version: Option<String>,
+}
+
+impl Config {
+    fn is_dir(&self) -> bool {
+        self.url.path().ends_with('/')
+    }
+
+    #[inline]
+    /// Returns a key derived from the URL path.
+    fn key(&self) -> &str {
+        // Get the path part of the URL and trim any leading slashes.
+        self.url.path().trim_start_matches('/')
+    }
+
+    /// Get url that have the same endpoint with the config's with given path.
+    fn get_url(&self, path: &str) -> String {
+        let mut url = self.url.clone();
+        url.set_path(path);
+        url.to_string()
+    }
+}
+
+impl TryFrom<Url> for Config {
+    type Error = Error;
+
+    fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
+        let host_str = url
+            .host_str()
+            .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
+
+        // Check the url is valid.
+        //
+        // The scheme of url should be "oss".
+        // The path of url should not be empty to access the oss system.
+        // The domain name should end with "aliyuncs.com" to access the oss system.
+        // There should be at least three "." in the host string to parse the "bucket",
+        // "region" and "endpoint".
+        if url.scheme() != "oss"
+            || url.path().is_empty()
+            || !host_str.ends_with("aliyuncs.com")
+            || host_str.matches('.').count() < 3
+        {
+            return Err(Error::InvalidURI(url.to_string()));
+        }
+
+        // Parse the bucket and endpoint.
+        //
+        // OSS use the "Virtual Hosting of Buckets", so the bucket will be the lowest level of
+        // the host, the rest of the host string is the endpoint.
+        let (bucket, endpoint) = host_str
+            .split_once('.')
+            .map(|(s1, s2)| (s1.to_string(), format!("https://{}", s2))) // Add scheme for endpoint.
+            .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
+
+        // Parse the version if possible.
+        let version = url
+            .query_pairs()
+            .find(|(key, _)| key == "versionId")
+            .map(|(_, version)| version.to_string());
+
+        Ok(Self {
+            url,
+            endpoint,
+            bucket,
+            version,
+        })
+    }
+}
+
+/// Initialize operator that used to access the OSS service.
+fn init_operator(
+    header: HeaderMap,
+    certs: Option<Vec<CertificateDer<'static>>>,
+    timeout: Duration,
+    object_storage: Option<ObjectStorage>,
+    config: &Config,
+) -> Result<Operator> {
+    let client_config_builder = match certs.as_ref() {
+        Some(client_certs) => {
+            let mut root_cert_store = rustls::RootCertStore::empty();
+            root_cert_store.add_parsable_certificates(client_certs.to_owned());
+
+            // TLS client config using the custom CA store for lookups.
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_cert_store)
+                .with_no_client_auth()
+        }
+        // Default TLS client config with native roots.
+        None => rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(NoVerifier::new())
+            .with_no_client_auth(),
+    };
+
+    let client = reqwest::Client::builder()
+        .use_preconfigured_tls(client_config_builder)
+        .timeout(timeout)
+        .default_headers(header)
+        .build()?;
+
+    let ObjectStorage {
+        access_key_id,
+        access_key_secret,
+    } = object_storage.ok_or(Error::InvalidParameter)?;
+
+    let mut operator_builder = opendal::services::Oss::default();
+
+    // Set up operator builder.
+    operator_builder
+        .access_key_id(&access_key_id)
+        .access_key_secret(&access_key_secret)
+        .http_client(HttpClient::with(client))
+        .root("/")
+        .bucket(&config.bucket)
+        .endpoint(&config.endpoint);
+
+    Ok(Operator::new(operator_builder)
+        .map_err(|err| {
+            Error::BackendError(BackendError {
+                message: err.to_string(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                header: HeaderMap::default(),
+            })
+        })?
+        .finish())
+}
+
+#[derive(Default)]
+pub struct OSS;
+
+impl OSS {
+    /// Returns OSS that implement `Backend` trait.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[tonic::async_trait]
+impl Backend for OSS {
+    /// Returns the header(mainly is Content-Length) of requested file or directory.
+    ///
+    /// # Note
+    ///
+    /// This function will automatically list the entries if the requested url is a
+    /// directory.
+    ///
+    /// If `HeadRequest.recursive` is true, this fucntion will list all the entries.
+    ///
+    /// # Error
+    ///
+    /// This function will return error when:
+    /// - the `HeadRequest.url` is not valid.
+    /// - other network/IO error.
+    async fn head(&self, request: HeadRequest) -> Result<HeadResponse> {
+        info!(
+            "head request {} {}: {:?}",
+            request.task_id, request.url, request.http_header
+        );
+
+        let url: Url = request
+            .url
+            .parse()
+            .map_err(|_| Error::InvalidURI(request.url))?;
+
+        let config: Config = url.try_into()?;
+
+        let operator = init_operator(
+            request.http_header.clone().unwrap_or_default(),
+            request.client_certs,
+            request.timeout,
+            request.object_storage,
+            &config,
+        )?;
+
+        // Get the entries if url point to a directory.
+        let entries = if config.is_dir() {
+            Some(
+                operator
+                    .list_with(config.key())
+                    .recursive(request.recursive)
+                    .metakey(Metakey::ContentLength | Metakey::Mode | Metakey::Version)
+                    .await // Do the list op here.
+                    .map_err(|err| {
+                        error!(
+                            "get request fail {} {}: {}",
+                            request.task_id, config.url, err
+                        );
+
+                        Error::BackendError(BackendError {
+                            message: err.to_string(),
+                            status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                            header: HeaderMap::default(),
+                        })
+                    })?
+                    .into_iter()
+                    .map(|entry| {
+                        let path = entry.path();
+                        let metadata = entry.metadata();
+
+                        DirEntry {
+                            url: config.get_url(path),
+                            content_length: metadata.content_length() as usize,
+                            is_dir: metadata.is_dir(),
+                            version: metadata.version().map(|v| v.into()),
+                        }
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        // Initialize the stat_operator with the key from the config.
+        let mut stat_operator = operator.stat_with(config.key());
+
+        // If a version is specified in the config, set the stat_operator to use that version.
+        if let Some(ref version) = config.version {
+            stat_operator = stat_operator.version(version);
+        }
+
+        // Await the result of the stat_operator. If an error occurs, log the error and return a BackendError.
+        let stat = stat_operator.await.map_err(|err| {
+            error!(
+                "get request fail {} {}: {}",
+                request.task_id, config.url, err
+            );
+            // Return a BackendError with the error message, status code, and an empty header map.
+            Error::BackendError(BackendError {
+                message: err.to_string(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                header: HeaderMap::default(),
+            })
+        })?;
+
+        info!("head response {} {}", request.task_id, config.url,);
+
+        Ok(HeadResponse {
+            success: true,
+            content_length: Some(stat.content_length()),
+            http_header: request.http_header,
+            http_status_code: Some(reqwest::StatusCode::OK),
+            error_message: None,
+            entries,
+        })
+    }
+
+    /// Returns content of requested file or directory.
+    ///
+    /// # Error
+    ///
+    /// This function will return error when:
+    /// - the `GetRequest.url` is not valid.
+    /// - the `GetRequest.url` points to a directory.
+    /// - the `GetRequest.url` is not existed.
+    /// - other network/IO error.
+    async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
+        info!(
+            "get request {} {}: {:?}",
+            request.piece_id, request.url, request.http_header
+        );
+
+        let url: Url = request
+            .url
+            .parse()
+            .map_err(|_| Error::InvalidURI(request.url))?;
+
+        let config: Config = url.try_into()?;
+
+        let operator = init_operator(
+            request.http_header.clone().unwrap_or_default(),
+            request.client_certs,
+            request.timeout,
+            request.object_storage,
+            &config,
+        )?;
+
+        // Set up the reader_operator with the key from the config and a chunk size of 8 KB.
+        let mut reader_operator = operator.reader_with(config.key()).chunk(8 << 10);
+
+        // If a version is specified in the config, set the reader_operator to use that version.
+        if let Some(ref version) = config.version {
+            reader_operator = reader_operator.version(version);
+        }
+
+        // Await the result of the reader_operator. If an error occurs, log the error and return a BackendError.
+        let reader = reader_operator.await.map_err(|err| {
+            error!(
+                "get request fail {} {}: {}",
+                request.piece_id, config.url, err
+            );
+            // Return a BackendError with the error message, status code, and an empty header map.
+            Error::BackendError(BackendError {
+                message: err.to_string(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                header: HeaderMap::default(),
+            })
+        })?;
+
+        // Create a byte stream based on the range specified in the request.
+        let stream = match request.range {
+            // If a range is specified, create a byte stream for the specified range.
+            Some(range) => reader
+                .into_bytes_stream(range.start..range.start + range.length)
+                .await
+                .map_err(|err| io::Error::new(ErrorKind::Other, err))?,
+            // If no range is specified, create a byte stream for the entire content.
+            None => reader
+                .into_bytes_stream(..)
+                .await
+                .map_err(|err| io::Error::new(ErrorKind::Other, err))?,
+        };
+
+        Ok(GetResponse {
+            success: true,
+            http_header: None,
+            http_status_code: Some(reqwest::StatusCode::OK),
+            reader: Box::new(StreamReader::new(stream)),
+            error_message: None,
+        })
+    }
+}

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -98,6 +98,14 @@ pub enum DFError {
     #[error{"scheduler client not found"}]
     SchedulerClientNotFound,
 
+    // ExceededMaxAttempts is the error when the maximum number of attempts is exceeded.
+    #[error("exceeded maximum number of attempts")]
+    ExceededMaxAttempts,
+
+    // SchedulerNotServing is the error when the current scheduler is not serving.
+    #[error("current scheduler is not serving")]
+    SchedulerNotServing,
+
     // UnexpectedResponse is the error when the response is unexpected.
     #[error{"unexpected response"}]
     UnexpectedResponse,

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -15,7 +15,7 @@
  */
 
 use clap::Parser;
-use dragonfly_api::common::v2::{Download, TaskType};
+use dragonfly_api::common::v2::{Download, ObjectStorage, TaskType};
 use dragonfly_api::dfdaemon::v2::{download_task_response, DownloadTaskRequest};
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
@@ -202,6 +202,18 @@ struct Args {
         help = "Specify the dfdaemon's max number of log files"
     )]
     dfdaemon_log_max_files: usize,
+
+    #[arg(
+        long,
+        help = "Specify the access key ID of the Object Storage Services. It should be provided with `access_key_secret` at the same time."
+    )]
+    access_key_id: Option<String>,
+
+    #[arg(
+        long,
+        help = "Specify the access key secret of the Object Storage Services. It should be provided with `access_key_id` at the same time."
+    )]
+    access_key_secret: Option<String>,
 }
 
 #[tokio::main]
@@ -368,6 +380,19 @@ async fn run(args: Args) -> Result<()> {
         err
     })?;
 
+    let mut object_storage = None;
+
+    // Only when the `access_key_id` and `access_key_secret` are provided at the same time,
+    // they will be pass to the `DownloadTaskRequest`.
+    if let (Some(access_key_id), Some(access_key_secret)) =
+        (args.access_key_id, args.access_key_secret)
+    {
+        object_storage = Some(ObjectStorage {
+            access_key_id,
+            access_key_secret,
+        });
+    }
+
     // Create dfdaemon client.
     let response = dfdaemon_download_client
         .download_task(DownloadTaskRequest {
@@ -392,7 +417,7 @@ async fn run(args: Args) -> Result<()> {
                 disable_back_to_source: args.disable_back_to_source,
                 certificate_chain: Vec::new(),
                 prefetch: false,
-                object_storage: None,
+                object_storage,
             }),
         })
         .await

--- a/dragonfly-client/src/grpc/scheduler.rs
+++ b/dragonfly-client/src/grpc/scheduler.rs
@@ -39,8 +39,8 @@ use std::time::Instant;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tonic::transport::Channel;
-use tracing::{error, info, instrument, Instrument};
 use tonic_health::pb::health_check_response::ServingStatus;
+use tracing::{error, info, instrument, Instrument};
 
 // VNode is the virtual node of the hashring.
 #[derive(Debug, Copy, Clone, Hash, PartialEq)]
@@ -94,6 +94,7 @@ impl SchedulerClient {
             available_schedulers: Arc::new(RwLock::new(Vec::new())),
             available_scheduler_addrs: Arc::new(RwLock::new(Vec::new())),
             hashring: Arc::new(RwLock::new(HashRing::new())),
+            unavailable_schedulers: Arc::new(RwLock::new(HashMap::new())),
             cooldown_duration: 60,
             max_attempts: 5,
             refresh_threshold: 10,
@@ -537,7 +538,6 @@ impl SchedulerClient {
 
         return Err(Error::AvailableSchedulersNotFound);
     }
-
 
     // Check the health of the scheduler.
     async fn check_scheduler(&self, scheduler_addr: &SocketAddr) -> Result<Channel> {

--- a/dragonfly-client/src/grpc/scheduler.rs
+++ b/dragonfly-client/src/grpc/scheduler.rs
@@ -16,6 +16,7 @@
 
 // use crate::dynconfig::Dynconfig;
 use crate::dynconfig::Dynconfig;
+use crate::grpc::health::HealthClient;
 use dragonfly_api::common::v2::{CachePeer, CacheTask, Peer, Task};
 use dragonfly_api::manager::v2::Scheduler;
 use dragonfly_api::scheduler::v2::{
@@ -29,13 +30,17 @@ use dragonfly_api::scheduler::v2::{
 use dragonfly_client_core::error::{ErrorType, ExternalError, OrErr};
 use dragonfly_client_core::{Error, Result};
 use hashring::HashRing;
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tonic::transport::Channel;
 use tracing::{error, info, instrument, Instrument};
+use tonic_health::pb::health_check_response::ServingStatus;
 
 // VNode is the virtual node of the hashring.
 #[derive(Debug, Copy, Clone, Hash, PartialEq)]
@@ -66,6 +71,18 @@ pub struct SchedulerClient {
 
     // hashring is the hashring of the scheduler.
     hashring: Arc<RwLock<HashRing<VNode>>>,
+
+    // unavailable_schedulers is a map of unavailable schedulers and the time they were marked as unavailable.
+    unavailable_schedulers: Arc<RwLock<HashMap<SocketAddr, Instant>>>,
+
+    // cooldown_duration is the scheduler's cooldown time.
+    cooldown_duration: u64,
+
+    // max_attempts is the maximum number of attempts allowed.
+    max_attempts: u32,
+
+    // refresh_threshold is the threshold for refreshing the scheduler list.
+    refresh_threshold: u32,
 }
 
 // SchedulerClient implements the grpc client of the scheduler.
@@ -77,6 +94,9 @@ impl SchedulerClient {
             available_schedulers: Arc::new(RwLock::new(Vec::new())),
             available_scheduler_addrs: Arc::new(RwLock::new(Vec::new())),
             hashring: Arc::new(RwLock::new(HashRing::new())),
+            cooldown_duration: 60,
+            max_attempts: 5,
+            refresh_threshold: 10,
         };
 
         client.refresh_available_scheduler_addrs().await?;
@@ -434,7 +454,7 @@ impl SchedulerClient {
         // Update scheduler addresses of the client.
         self.update_available_scheduler_addrs().await?;
 
-        // Get the scheduler address from the hashring.
+        // First try to get the address from the task_id.
         let addrs = self.hashring.read().await;
         let addr = *addrs
             .get(&task_id[0..5].to_string())
@@ -442,28 +462,121 @@ impl SchedulerClient {
         drop(addrs);
         info!("picked {:?}", addr);
 
-        let channel = match Channel::from_shared(format!("http://{}", addr))
+        match Channel::from_shared(format!("http://{}", addr))
             .map_err(|_| Error::InvalidURI(addr.to_string()))?
             .connect_timeout(super::CONNECT_TIMEOUT)
             .connect()
             .await
         {
-            Ok(channel) => channel,
+            Ok(channel) => {
+                let mut unavailable_schedulers = self.unavailable_schedulers.write().await;
+                unavailable_schedulers.remove(&addr.addr);
+                return Ok(SchedulerGRPCClient::new(channel)
+                    .max_decoding_message_size(usize::MAX)
+                    .max_encoding_message_size(usize::MAX));
+            }
+
             Err(err) => {
                 error!("connect to {} failed: {}", addr.to_string(), err);
-                if let Err(err) = self.refresh_available_scheduler_addrs().await {
-                    error!("failed to refresh scheduler client: {}", err);
-                };
+                let mut unavailable_schedulers = self.unavailable_schedulers.write().await;
+                unavailable_schedulers
+                    .entry(addr.addr)
+                    .or_insert_with(std::time::Instant::now);
+            }
+        }
 
+        // Read the shooting configuration items.
+        let cooldown_duration = Duration::from_secs(self.cooldown_duration);
+        let max_attempts = self.max_attempts;
+        let refresh_threshold = self.refresh_threshold;
+
+        let mut attempts = 0;
+
+        // Traverse through available scheduler collections.
+        let hashring = self.hashring.read().await;
+        for vnode in hashring.clone().into_iter() {
+            let scheduler_addr = vnode.addr;
+
+            let unavailable_schedulers = self.unavailable_schedulers.write().await;
+            if let Some(&instant) = unavailable_schedulers.get(&scheduler_addr) {
+                if instant.elapsed() < cooldown_duration {
+                    continue;
+                }
+            }
+
+            match self.check_scheduler(&scheduler_addr).await {
+                Ok(channel) => {
+                    let mut unavailable_schedulers = self.unavailable_schedulers.write().await;
+                    unavailable_schedulers.remove(&scheduler_addr);
+                    return Ok(SchedulerGRPCClient::new(channel)
+                        .max_decoding_message_size(usize::MAX)
+                        .max_encoding_message_size(usize::MAX));
+                }
+                Err(err) => {
+                    error!("Scheduler {} is not available: {}", scheduler_addr, err);
+
+                    let mut unavailable_schedulers = self.unavailable_schedulers.write().await;
+                    unavailable_schedulers
+                        .entry(scheduler_addr)
+                        .or_insert_with(std::time::Instant::now);
+
+                    attempts += 1;
+
+                    if attempts >= refresh_threshold {
+                        if let Err(err) = self.refresh_available_scheduler_addrs().await {
+                            error!("failed to refresh scheduler client: {}", err);
+                        };
+                    }
+
+                    if attempts >= max_attempts {
+                        return Err(Error::ExceededMaxAttempts);
+                    }
+                }
+            }
+        }
+
+        return Err(Error::AvailableSchedulersNotFound);
+    }
+
+
+    // Check the health of the scheduler.
+    async fn check_scheduler(&self, scheduler_addr: &SocketAddr) -> Result<Channel> {
+        let addr = format!("http://{}", scheduler_addr);
+        let health_client = match HealthClient::new(&addr).await {
+            Ok(client) => client,
+            Err(err) => {
+                error!("create {} health client failed: {}", addr, err);
                 return Err(ExternalError::new(ErrorType::ConnectError)
                     .with_cause(Box::new(err))
                     .into());
             }
         };
 
-        Ok(SchedulerGRPCClient::new(channel)
-            .max_decoding_message_size(usize::MAX)
-            .max_encoding_message_size(usize::MAX))
+        match health_client.check().await {
+            Ok(resp) => {
+                if resp.status == ServingStatus::Serving as i32 {
+                    return Channel::from_shared(format!("http://{}", scheduler_addr))
+                        .map_err(|_| Error::InvalidURI(scheduler_addr.to_string()))?
+                        .connect_timeout(super::CONNECT_TIMEOUT)
+                        .connect()
+                        .await
+                        .map_err(|err| {
+                            error!("connect to {} failed: {}", scheduler_addr.to_string(), err);
+                            ExternalError::new(ErrorType::ConnectError)
+                                .with_cause(Box::new(err))
+                                .into()
+                        });
+                }
+
+                Err(Error::SchedulerNotServing)
+            }
+            Err(err) => {
+                error!("check scheduler health failed: {}", err);
+                Err(ExternalError::new(ErrorType::ConnectError)
+                    .with_cause(Box::new(err))
+                    .into())
+            }
+        }
     }
 
     // update_available_scheduler_addrs updates the addresses of available schedulers.

--- a/dragonfly-client/src/grpc/scheduler.rs
+++ b/dragonfly-client/src/grpc/scheduler.rs
@@ -497,14 +497,13 @@ impl SchedulerClient {
         let hashring = self.hashring.read().await;
         for vnode in hashring.clone().into_iter() {
             let scheduler_addr = vnode.addr;
-
             let unavailable_schedulers = self.unavailable_schedulers.write().await;
             if let Some(&instant) = unavailable_schedulers.get(&scheduler_addr) {
                 if instant.elapsed() < cooldown_duration {
                     continue;
                 }
             }
-
+            
             match self.check_scheduler(&scheduler_addr).await {
                 Ok(channel) => {
                     let mut unavailable_schedulers = self.unavailable_schedulers.write().await;

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -19,7 +19,7 @@ use crate::metrics::{
     collect_download_piece_traffic_metrics, collect_upload_piece_traffic_metrics,
 };
 use chrono::Utc;
-use dragonfly_api::common::v2::{Peer, Range, TrafficType};
+use dragonfly_api::common::v2::{ObjectStorage, Peer, Range, TrafficType};
 use dragonfly_api::dfdaemon::v2::DownloadPieceRequest;
 use dragonfly_client_backend::{BackendFactory, GetRequest};
 use dragonfly_client_config::dfdaemon::Config;
@@ -447,6 +447,7 @@ impl Piece {
         offset: u64,
         length: u64,
         request_header: HeaderMap,
+        object_storage: Option<ObjectStorage>,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", self.storage.piece_id(task_id, number));
@@ -487,6 +488,7 @@ impl Piece {
                 http_header: Some(request_header),
                 timeout: self.config.download.piece_timeout,
                 client_certs: None,
+                object_storage,
             })
             .await
             .map_err(|err| {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -15,7 +15,9 @@
  */
 
 use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
-use dragonfly_api::common::v2::{Download, Peer, Piece, Range, Task as CommonTask, TrafficType};
+use dragonfly_api::common::v2::{
+    Download, ObjectStorage, Peer, Piece, Range, Task as CommonTask, TrafficType,
+};
 use dragonfly_api::dfdaemon::{
     self,
     v2::{download_task_response, DownloadTaskResponse},
@@ -141,6 +143,8 @@ impl Task {
                 http_header: Some(request_header),
                 timeout: self.config.download.piece_timeout,
                 client_certs: None,
+                object_storage: download.object_storage,
+                recursive: false,
             })
             .await?;
 
@@ -1150,6 +1154,7 @@ impl Task {
                 _permit: OwnedSemaphorePermit,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
                 in_stream_tx: Sender<AnnouncePeerRequest>,
+                object_storage: Option<ObjectStorage>,
             ) -> ClientResult<metadata::Piece> {
                 info!(
                     "start to download piece {} from source",
@@ -1164,6 +1169,7 @@ impl Task {
                         offset,
                         length,
                         request_header,
+                        object_storage,
                     )
                     .await?;
 
@@ -1249,6 +1255,7 @@ impl Task {
                     permit,
                     download_progress_tx.clone(),
                     in_stream_tx.clone(),
+                    download.object_storage.clone(),
                 )
                 .in_current_span(),
             );
@@ -1441,6 +1448,7 @@ impl Task {
                 storage: Arc<Storage>,
                 _permit: OwnedSemaphorePermit,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
+                object_storage: Option<ObjectStorage>,
             ) -> ClientResult<metadata::Piece> {
                 info!(
                     "start to download piece {} from source",
@@ -1455,6 +1463,7 @@ impl Task {
                         offset,
                         length,
                         request_header,
+                        object_storage,
                     )
                     .await?;
 
@@ -1517,6 +1526,7 @@ impl Task {
                     self.storage.clone(),
                     permit,
                     download_progress_tx.clone(),
+                    download.object_storage.clone(),
                 )
                 .in_current_span(),
             );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
To address potential issues with Scheduler failures during P2P downloads, this project aims to implement an automatic switching feature at the Peer node. When a Scheduler encounters an issue and cannot properly handle downloads, the Peer node will switch to other Scheduler nodes using a hash ring to continue the download, thereby preventing download failures and improving success rates.

## Requirements

1. Scheduler Availability Check During Peer Registration: Ensure that the Scheduler is available during the Peer node registration process.

2. Automatic Scheduler Switching: If the current Scheduler is unavailable, automatically switch to another Scheduler node until a usable Scheduler is found.

3. Feature Development: Complete the development of the automatic switching logic and Scheduler availability detection.
Testing: Implement unit tests and end-to-end (E2E) tests to ensure the reliability and stability of the feature.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- [https://github.com/dragonflyoss/client/issues/551](url)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Please refer to the following document link for detailed instructions

- [https://www.yuque.com/baimo/fv9qk8/ghfsq8uldrer2p7r](url)
