### PR TITLE
feat: peer automatically injects existing task metadata to scheduler upon restart

### DIFF
--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -401,6 +401,7 @@ impl Storage {
     }
 
     // get_pieces returns the piece metadatas.
+    #[instrument(skip_all)]
     pub fn get_pieces(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
         self.metadata.get_pieces(task_id)
     }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -88,9 +88,10 @@ impl Storage {
         piece_length: Option<u64>,
         content_length: Option<u64>,
         response_header: Option<HeaderMap>,
+        url: &str,
     ) -> Result<metadata::Task> {
         self.metadata
-            .download_task_started(id, piece_length, content_length, response_header)
+            .download_task_started(id, piece_length, content_length, response_header, url)
     }
 
     // download_task_finished updates the metadata of the task when the task downloads finished.

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -51,6 +51,9 @@ pub struct Task {
     // uploaded_count is the count of the task has been uploaded by other peers.
     pub uploaded_count: u64,
 
+    // url is the download url.
+    pub url: String,
+
     // updated_at is the time when the task metadata is updated. If the task is downloaded
     // by other peers, it will also update updated_at.
     pub updated_at: NaiveDateTime,
@@ -335,6 +338,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
         piece_length: Option<u64>,
         content_length: Option<u64>,
         response_header: Option<HeaderMap>,
+        url: &str,
     ) -> Result<Task> {
         // Convert the response header to hashmap.
         let response_header = response_header
@@ -371,6 +375,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
                 piece_length,
                 content_length,
                 response_header,
+                url: url.to_string(),
                 updated_at: Utc::now().naive_utc(),
                 created_at: Utc::now().naive_utc(),
                 ..Default::default()
@@ -932,7 +937,7 @@ mod tests {
 
         // Test download_task_started.
         metadata
-            .download_task_started(task_id, Some(1024), Some(1024), None)
+            .download_task_started(task_id, Some(1024), Some(1024), None, "url")
             .unwrap();
         let task = metadata
             .get_task(task_id)
@@ -942,6 +947,7 @@ mod tests {
         assert_eq!(task.piece_length, Some(1024));
         assert_eq!(task.content_length, Some(1024));
         assert!(task.response_header.is_empty());
+        assert_eq!(task.url, "url");
         assert_eq!(task.uploading_count, 0);
         assert_eq!(task.uploaded_count, 0);
 
@@ -989,7 +995,7 @@ mod tests {
         // Test get_tasks.
         let task_id = "a535b115f18d96870f0422ac891f91dd162f2f391e4778fb84279701fcd02dd1";
         metadata
-            .download_task_started(task_id, Some(1024), None, None)
+            .download_task_started(task_id, Some(1024), None, None, "url")
             .unwrap();
         let tasks = metadata.get_tasks().unwrap();
         assert_eq!(tasks.len(), 2, "should get 2 tasks in total");

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -825,6 +825,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     // get_pieces gets the piece metadatas.
+    #[instrument(skip_all)]
     pub fn get_pieces(&self, task_id: &str) -> Result<Vec<Piece>> {
         let pieces = self
             .db

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -237,10 +237,11 @@ async fn main() -> Result<(), anyhow::Error> {
     // Initialize scheduler announcer.
     let scheduler_announcer = SchedulerAnnouncer::new(
         config.clone(),
-        id_generator.host_id(),
         scheduler_client.clone(),
         shutdown.clone(),
         shutdown_complete_tx.clone(),
+        id_generator.clone(),
+        storage.clone(),
     )
     .await
     .map_err(|err| {

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -116,6 +116,12 @@ impl Piece {
         self.storage.get_piece(task_id, number)
     }
 
+    // get_all gets all pieces from the local storage.
+    #[instrument(skip_all)]
+    pub fn get_all(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
+        self.storage.get_pieces(task_id)
+    }
+
     // calculate_interested calculates the interested pieces by content_length and range.
     #[instrument(skip_all)]
     pub fn calculate_interested(

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -120,7 +120,9 @@ impl Task {
         id: &str,
         request: Download,
     ) -> ClientResult<metadata::Task> {
-        let task = self.storage.download_task_started(id, None, None, None)?;
+        let task =
+            self.storage
+                .download_task_started(id, None, None, None, request.url.as_str())?;
         if task.content_length.is_some() && task.piece_length.is_some() {
             return Ok(task);
         }
@@ -151,7 +153,7 @@ impl Task {
         let response = backend
             .head(HeadRequest {
                 task_id: id.to_string(),
-                url: request.url,
+                url: request.url.clone(),
                 http_header: Some(request_header),
                 timeout: self.config.download.piece_timeout,
                 client_certs: None,
@@ -204,6 +206,7 @@ impl Task {
             Some(piece_length),
             Some(content_length),
             response.http_header,
+            request.url.as_str(),
         )
     }
 


### PR DESCRIPTION
## Description

Announce peers to the scheduler after host announcement during `SchedulerAnnouncer.new()`.

## Related Issue

https://github.com/dragonflyoss/Dragonfly2/issues/3387

## Motivation and Context

Rust's dfdaemon stores the task's metadata in RocksDB at the beginning of the download. Add a new rpc interface: AnnounceTask() to the v2 scheduler. dfdaemon of Rust will fetch the metadata of downloaded tasks (including the metadata of tasks and pieces) from RocksDB at each startup, filter out all the completed tasks, call AnnounceTask() to the schedulerscheduler to add the metadata of Task and Peer to the Manager for subsequent scheduling.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

## Test doc
https://www.yuque.com/baimo/fv9qk8/vw6mgd2aw0ksv0c8