### PR TITLE
fix: add missing fields to the announce host request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1154,7 @@ dependencies = [
  "lazy_static",
  "leaky-bucket",
  "libc",
+ "nix 0.29.0",
  "openssl",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -2676,6 +2683,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,7 +3321,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "parking_lot",
  "protobuf",
@@ -4479,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4489,7 +4508,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows",
 ]
 
 [[package]]

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -75,7 +75,7 @@ prometheus = { version = "0.13", features = ["process"] }
 tonic-health = "0.9.2"
 tonic-reflection = "0.9.2"
 bytes = "1.6"
-sysinfo = "0.29.6"
+sysinfo = "0.30.13"
 tower = "0.4.13"
 indicatif = "0.17.8"
 dashmap = "6.0.1"
@@ -90,6 +90,7 @@ futures-util = "0.3.30"
 termion = "4.0.2"
 tabled = "0.15.0"
 path-absolutize = "3.1.1"
+nix = { version = "0.29.0", features = ["fs"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5.4", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }


### PR DESCRIPTION
## Description

1. According to [official migration guide](https://github.com/GuillaumeGomez/sysinfo/blob/master/migration_guide.md), migrate crate `sysinfo` from v0.29.6 to v0.30.13, in order to get more information.
2. Add missing `process_used_percent` field in announce host request.
3. Add missing `total` `free` `used` and `used_percent` for `Disk`, following [disk_usage()](https://github.com/rust-psutil/rust-psutil/blob/670454357ee89f5a74bad57da3f7105c5a7c9154/src/disk/sys/unix/disk_usage.rs#L42-L64).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
