### PR TITLE
fix: fix url encode/decode bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "httpmock",
  "libloading",
  "opendal",
+ "percent-encoding",
  "reqwest",
  "rustls",
  "rustls-pki-types",

--- a/dragonfly-client-backend/Cargo.toml
+++ b/dragonfly-client-backend/Cargo.toml
@@ -22,6 +22,7 @@ tonic.workspace = true
 url.workspace = true
 tracing.workspace = true
 opendal.workspace = true
+percent-encoding.workspace = true
 futures = "0.3.28"
 libloading = "0.8.4"
 

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -18,6 +18,7 @@ use dragonfly_api::common;
 use dragonfly_client_core::error::BackendError;
 use dragonfly_client_core::{Error as ClientError, Result as ClientResult};
 use opendal::{raw::HttpClient, Metakey, Operator};
+use percent_encoding::percent_decode_str;
 use std::fmt;
 use std::result::Result;
 use std::str::FromStr;
@@ -136,14 +137,15 @@ impl TryFrom<Url> for ParsedURL {
         let key = url
             .path()
             .strip_prefix('/')
-            .ok_or_else(|| ClientError::InvalidURI(url.to_string()))?
-            .to_string();
+            .ok_or_else(|| ClientError::InvalidURI(url.to_string()))?;
+        // Decode the key.
+        let decoded_key = percent_decode_str(key).decode_utf8_lossy().to_string();
 
         Ok(Self {
             url,
             scheme,
             bucket,
-            key,
+            key: decoded_key,
         })
     }
 }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -762,7 +762,7 @@ async fn download(
         }
     }
 
-    progress_bar.finish_with_message(format!("{} downloaded", download_path));
+    progress_bar.finish();
     Ok(())
 }
 
@@ -813,7 +813,7 @@ fn make_output_by_entry(url: Url, output: &Path, entry: DirEntry) -> Result<Path
     let entry_url: Url = entry.url.parse().or_err(ErrorType::ParseError)?;
     let decoded_entry_url = percent_decode_str(entry_url.path()).decode_utf8_lossy();
     Ok(decoded_entry_url
-        .replace(root_dir.as_str(), output_root_dir.as_str())
+        .replacen(root_dir.as_str(), output_root_dir.as_str(), 1)
         .into())
 }
 


### PR DESCRIPTION
As title

## Description

This PR is done by the following task:

- [x] object_storage::ParsedURL will always decode the path string  

## Related Issue

#496 

## Motivation and Context

Solve the problem that download files with non-ascii name will return 404
