### PR TITLE
fix: too_many_pings error for scheduler server

### DIFF
--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -141,6 +141,10 @@ impl super::Backend for HTTP {
                 .bytes_stream()
                 .map_err(|err| IOError::new(ErrorKind::Other, err)),
         ));
+        info!(
+            "get response {} {}: {:?} {:?}",
+            request.task_id, request.piece_id, status_code, header
+        );
 
         Ok(super::GetResponse {
             success: status_code.is_success(),

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -44,10 +44,10 @@ pub const CONCURRENCY_LIMIT_PER_CONNECTION: usize = 8192;
 pub const TCP_KEEPALIVE: Duration = Duration::from_secs(3600);
 
 // HTTP2_KEEP_ALIVE_INTERVAL is the interval for HTTP2 keep alive.
-pub const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(60);
+pub const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(300);
 
 // HTTP2_KEEP_ALIVE_TIMEOUT is the timeout for HTTP2 keep alive.
-pub const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(5);
+pub const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 // MAX_FRAME_SIZE is the max frame size for GRPC, default is 12MB.
 pub const MAX_FRAME_SIZE: u32 = 12 * 1024 * 1024;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix client received, frame: GoAway { error_code: ENHANCE_YOUR_CALM, last_stream_id: StreamId(1), debug_data: b"too_many_pings" }.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
