### PR TITLE
feat: OBS provides error message if endpoint is not provided

### DIFF
--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -373,9 +373,16 @@ impl ObjectStorage {
             .http_client(HttpClient::with(client))
             .bucket(&parsed_url.bucket);
 
-        // Configure the endpoint if provided.
+        // Configure the endpoint, and return an error if it is not provided.
         if let Some(endpoint) = object_storage.endpoint {
             builder.endpoint(&endpoint);
+        } else {
+            error!("need endpoint");
+            return Err(ClientError::BackendError(BackendError {
+                message: "need endpoint".to_string(),
+                status_code: None,
+                header: None,
+            }));
         }
 
         Ok(Operator::new(builder)?.finish())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
An Error Message for missing endpoint for OBS. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
OBS requires endpoint configuration to be mandatory. Thus, an explicit error message shall be provided if the endpoint is not provided. 

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
