### PR TITLE
feat: Add GCS credential path and change GCS url scheme to gs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.0.148"
+version = "2.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963b51f522733563d04a567cc7f21f3e5dd2ae4cb7457e17a6b22f013b6dba37"
+checksum = "8e193cc3ec9d13fd3871a54679951349a34a3e64020ceef41d483f95ecb77839"
 dependencies = [
  "prost 0.13.1",
  "prost-types",
@@ -4116,9 +4116,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.1
 dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.103" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.103" }
 thiserror = "1.0"
-dragonfly-api = "=2.0.148"
+dragonfly-api = "=2.0.154"
 reqwest = { version = "0.12.4", features = ["stream", "native-tls", "default-tls", "rustls-tls"] }
 rcgen = { version = "0.12.1", features = ["x509-parser"] }
 hyper = { version = "1.4", features = ["full"] }

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -56,7 +56,7 @@ pub struct HeadRequest {
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
     // object_storage is the object storage related information.
-    pub object_storage: ObjectStorage,
+    pub object_storage: Option<ObjectStorage>,
 }
 
 // HeadResponse is the head response for backend.
@@ -105,7 +105,7 @@ pub struct GetRequest {
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
     // the object storage related information.
-    pub object_storage: ObjectStorage,
+    pub object_storage: Option<ObjectStorage>,
 }
 
 // GetResponse is the get response for backend.

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -56,7 +56,7 @@ pub struct HeadRequest {
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
     // object_storage is the object storage related information.
-    pub object_storage: Option<ObjectStorage>,
+    pub object_storage: ObjectStorage,
 }
 
 // HeadResponse is the head response for backend.
@@ -105,7 +105,7 @@ pub struct GetRequest {
     pub client_certs: Option<Vec<CertificateDer<'static>>>,
 
     // the object storage related information.
-    pub object_storage: Option<ObjectStorage>,
+    pub object_storage: ObjectStorage,
 }
 
 // GetResponse is the get response for backend.
@@ -250,7 +250,7 @@ impl BackendFactory {
         info!("load [s3] builtin backend");
 
         self.backends.insert(
-            "gcs".to_string(),
+            "gs".to_string(),
             Box::new(object_storage::ObjectStorage::new(
                 object_storage::Scheme::GCS,
             )),

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Scheme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Scheme::S3 => write!(f, "s3"),
-            Scheme::GCS => write!(f, "gcs"),
+            Scheme::GCS => write!(f, "gs"),
             Scheme::ABS => write!(f, "abs"),
             Scheme::OSS => write!(f, "oss"),
             Scheme::OBS => write!(f, "obs"),
@@ -678,14 +678,14 @@ mod tests {
 
         let object_storage = dragonfly_api::common::v2::ObjectStorage {
             endpoint: Some("test-endpoint.local".into()),
-            access_key_id: "access-key-id".into(),
-            access_key_secret: "access-key-secret".into(),
+            access_key_id: Some("access-key-id".into()),
+            access_key_secret: Some("access-key-secret".into()),
             ..Default::default()
         };
 
         let result = ObjectStorage::new(Scheme::OSS).oss_operator(
             &parsed_url,
-            Some(object_storage),
+            object_storage,
             Duration::from_secs(3),
         );
 
@@ -693,12 +693,42 @@ mod tests {
     }
 
     #[test]
-    fn should_return_error_when_oss_aksk_not_provided() {
+    fn should_return_error_when_oss_access_key_id_not_provided() {
         let url: Url = "oss://test-bucket/file".parse().unwrap();
         let parsed_url: ParsedURL = url.try_into().unwrap();
 
-        let result =
-            ObjectStorage::new(Scheme::OSS).oss_operator(&parsed_url, None, Duration::from_secs(3));
+        let object_storage = dragonfly_api::common::v2::ObjectStorage {
+            endpoint: Some("test-endpoint.local".into()),
+            access_key_secret: Some("access-key-secret".into()),
+            ..Default::default()
+        };
+
+        let result = ObjectStorage::new(Scheme::OSS).oss_operator(
+            &parsed_url,
+            object_storage,
+            Duration::from_secs(3),
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ClientError::BackendError(..)));
+    }
+
+    #[test]
+    fn should_return_error_when_oss_access_key_sceret_not_provided() {
+        let url: Url = "oss://test-bucket/file".parse().unwrap();
+        let parsed_url: ParsedURL = url.try_into().unwrap();
+
+        let object_storage = dragonfly_api::common::v2::ObjectStorage {
+            endpoint: Some("test-endpoint.local".into()),
+            access_key_id: Some("access-key-id".into()),
+            ..Default::default()
+        };
+
+        let result = ObjectStorage::new(Scheme::OSS).oss_operator(
+            &parsed_url,
+            object_storage,
+            Duration::from_secs(3),
+        );
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ClientError::BackendError(..)));
@@ -710,14 +740,14 @@ mod tests {
         let parsed_url: ParsedURL = url.try_into().unwrap();
 
         let object_storage = dragonfly_api::common::v2::ObjectStorage {
-            access_key_id: "access-key-id".into(),
-            access_key_secret: "access-key-secret".into(),
+            access_key_id: Some("access-key-id".into()),
+            access_key_secret: Some("access-key-secret".into()),
             ..Default::default()
         };
 
         let result = ObjectStorage::new(Scheme::OSS).oss_operator(
             &parsed_url,
-            Some(object_storage),
+            object_storage,
             Duration::from_secs(3),
         );
 

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -169,9 +169,17 @@ impl ObjectStorage {
     pub fn operator(
         &self,
         parsed_url: &super::object_storage::ParsedURL,
-        object_storage: common::v2::ObjectStorage,
+        object_storage: Option<common::v2::ObjectStorage>,
         timeout: Duration,
     ) -> ClientResult<Operator> {
+        let Some(object_storage) = object_storage else {
+            error!("requires object_storage configuration");
+            return Err(ClientError::BackendError(BackendError {
+                message: "requires object_storage configuration".to_string(),
+                status_code: None,
+                header: None,
+            }));
+        };
         match self.scheme {
             Scheme::S3 => self.s3_operator(parsed_url, object_storage, timeout),
             Scheme::GCS => self.gcs_operator(parsed_url, object_storage, timeout),
@@ -190,7 +198,7 @@ impl ObjectStorage {
         object_storage: common::v2::ObjectStorage,
         timeout: Duration,
     ) -> ClientResult<Operator> {
-        // S3 requires the access key id and the secret access key. 
+        // S3 requires the access key id and the secret access key.
         let (Some(access_key_id), Some(access_key_secret)) = (
             object_storage.access_key_id,
             object_storage.access_key_secret,
@@ -205,11 +213,11 @@ impl ObjectStorage {
 
         // Create a reqwest http client.
         let client = reqwest::Client::builder().timeout(timeout).build()?;
-    
+
         // Initialize the S3 operator with the object storage.
         let mut builder = opendal::services::S3::default();
-        
-        builder = builder 
+
+        builder = builder
             .access_key_id(&access_key_id)
             .secret_access_key(&access_key_secret)
             .http_client(HttpClient::with(client))
@@ -250,11 +258,11 @@ impl ObjectStorage {
             .http_client(HttpClient::with(client))
             .bucket(&parsed_url.bucket);
 
-        // Configure the credentials using the local path to the crendential file if provided. 
+        // Configure the credentials using the local path to the crendential file if provided.
         // Otherwise, configure using the Application Default Credentials (ADC).
         if let Some(credential_path) = object_storage.credential_path.as_deref() {
             builder = builder.credential_path(credential_path);
-        } 
+        }
 
         // Configure the endpoint if it is provided.
         if let Some(endpoint) = object_storage.endpoint.as_deref() {
@@ -289,7 +297,7 @@ impl ObjectStorage {
                 header: None,
             }));
         };
-        
+
         // Create a reqwest http client.
         let client = reqwest::Client::builder().timeout(timeout).build()?;
 
@@ -317,11 +325,11 @@ impl ObjectStorage {
         object_storage: common::v2::ObjectStorage,
         timeout: Duration,
     ) -> ClientResult<Operator> {
-        // OSS requires the access key id, access key secret, and endpoint. 
+        // OSS requires the access key id, access key secret, and endpoint.
         let (Some(access_key_id), Some(access_key_secret), Some(endpoint)) = (
             object_storage.access_key_id,
             object_storage.access_key_secret,
-            object_storage.endpoint
+            object_storage.endpoint,
         ) else {
             error!("need access_key_id, access_key_secret, and endpoint");
             return Err(ClientError::BackendError(BackendError {
@@ -359,7 +367,7 @@ impl ObjectStorage {
         let (Some(access_key_id), Some(access_key_secret), Some(endpoint)) = (
             object_storage.access_key_id,
             object_storage.access_key_secret,
-            object_storage.endpoint
+            object_storage.endpoint,
         ) else {
             error!("need access_key_id, access_key_secret, and endpoint");
             return Err(ClientError::BackendError(BackendError {
@@ -391,11 +399,11 @@ impl ObjectStorage {
         object_storage: common::v2::ObjectStorage,
         timeout: Duration,
     ) -> ClientResult<Operator> {
-        // COS requires the access key id, the access key secret, and the endpoint. 
+        // COS requires the access key id, the access key secret, and the endpoint.
         let (Some(access_key_id), Some(access_key_secret), Some(endpoint)) = (
             object_storage.access_key_id,
             object_storage.access_key_secret,
-            object_storage.endpoint
+            object_storage.endpoint,
         ) else {
             error!("need access_key_id, access_key_secret, and endpoint");
             return Err(ClientError::BackendError(BackendError {
@@ -404,7 +412,7 @@ impl ObjectStorage {
                 header: None,
             }));
         };
-        
+
         // Create a reqwest http client.
         let client = reqwest::Client::builder().timeout(timeout).build()?;
 

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -569,17 +569,16 @@ async fn run(mut args: Args, dfdaemon_download_client: DfdaemonDownloadClient) -
 
 // download_dir downloads all files in the directory.
 async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Result<()> {
-    let mut object_storage = None; 
-    // Initialize object storage.
-    let mut object_storage = Some(ObjectStorage {
-            access_key_id,
-            access_key_secret,
-            session_token: args.storage_session_token.clone(),
-            region: args.storage_region.clone(),
-            endpoint: args.storage_endpoint.clone(),
-            credential_path: args.storage_credential_path.clone(),
-            predefined_acl: args.storage_predefined_acl.clone(),
-        });
+    // Initalize the object storage.
+    let object_storage = Some(ObjectStorage {
+        access_key_id: args.storage_access_key_id.clone(),
+        access_key_secret: args.storage_access_key_secret.clone(),
+        session_token: args.storage_session_token.clone(),
+        region: args.storage_region.clone(),
+        endpoint: args.storage_endpoint.clone(),
+        credential_path: args.storage_credential_path.clone(),
+        predefined_acl: args.storage_predefined_acl.clone(),
+    });
 
     // Get all entries in the directory. If the directory is empty, then return directly.
     let entries = get_entries(args.clone(), object_storage.clone()).await?;
@@ -664,16 +663,20 @@ async fn download(
     progress_bar: ProgressBar,
     download_client: DfdaemonDownloadClient,
 ) -> Result<()> {
-    // Initialize object storage.
-    let mut object_storage = ObjectStorage {
-            access_key_id,
-            access_key_secret,
+    // Only initialize object storage when the scheme is an object storage protocol.
+    let mut object_storage = None;
+    let scheme = args.url.scheme();
+    if object_storage::Scheme::from_str(scheme).is_ok() {
+        object_storage = Some(ObjectStorage {
+            access_key_id: args.storage_access_key_id.clone(),
+            access_key_secret: args.storage_access_key_secret.clone(),
             session_token: args.storage_session_token.clone(),
             region: args.storage_region.clone(),
             endpoint: args.storage_endpoint.clone(),
             credential_path: args.storage_credential_path.clone(),
             predefined_acl: args.storage_predefined_acl.clone(),
-        };
+        });
+    }
 
     // If the `filtered_query_params` is not provided, then use the default value.
     let filtered_query_params = match args.filtered_query_params {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- [x] Add GCS credential path, and remove GCS credential 
- [x] If credential path is not provided, use Application Default Credential (ADC) 
- [x] Change GCS url scheme to gs 
- [x] Add validation of parameters for each object storage services

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Using `credential_path` instead of `credential` avoid users from inputting a long based-64 through command line. In addition, google recommends the use of ADC (https://cloud.google.com/docs/authentication#adc), and by not explicitly inputting a credential path, `opendal` would search and load the ADC internally. One thing to consider is that this may result in error handling issue. Lastly, since google storage url has the format of gs://bucket//path, a `gs` scheme for GCS is thus adopted. 

## Screenshots (if appropriate)
