### PR TITLE
test: add unit tests for `BackendFactory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pki-types",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tonic",

--- a/dragonfly-client-backend/Cargo.toml
+++ b/dragonfly-client-backend/Cargo.toml
@@ -28,3 +28,4 @@ libloading = "0.8.5"
 
 [dev-dependencies]
 wiremock = "0.6.1"
+tempfile = "3.12.0"


### PR DESCRIPTION
Add unit test for dragonfly-client-backend/src/lib.rs, mainly for `BackendFactory`.

## Description

This PR is done by finishing the following tasks:
- [x] add unit tests.
- [x] add a field to store to dynamic libraries to avoid the the use-after-free problem.

Other details are shown in the code. 

## Related Issue

#496 

## Motivation and Context

Dragonfly rust client does not support back-to-source downloading of different object storage protocols. Priority is given to supporting OSS protocol back-to-source downloads. Need to support OSS protocol in dragonfly-client-backend crate, implemented based on trait Backend and it needs to support directory recursive downloading.
