### PR TITLE
fix: Ensure the parent directory of the destination exists

### DIFF
--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -157,9 +157,9 @@ impl Content {
         // Ensure the parent directory of the destination exists
         if let Some(parent) = to.parent() {
             if !parent.exists() {
-                fs::create_dir_all(parent).await.map_err(|e| {
-                    error!("Failed to create directory {:?}: {}", parent, e);
-                    e
+                fs::create_dir_all(parent).await.map_err(|err| {
+                    error!("Failed to create directory {:?}: {}", parent, err);
+                    err
                 })?;
             }
         }

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -154,7 +154,7 @@ impl Content {
     // copy_task copies the task content to the destination.
     #[instrument(skip_all)]
     async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        // Ensure the parent directory of the destination exists
+        // Ensure the parent directory of the destination exists.
         if let Some(parent) = to.parent() {
             if !parent.exists() {
                 fs::create_dir_all(parent).await.map_err(|err| {

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -154,6 +154,15 @@ impl Content {
     // copy_task copies the task content to the destination.
     #[instrument(skip_all)]
     async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
+        // Ensure the parent directory of the destination exists
+        if let Some(parent) = to.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).await.map_err(|e| {
+                    error!("Failed to create directory {:?}: {}", parent, e);
+                    e
+                })?;
+            }
+        }
         fs::copy(self.dir.join(task_id), to).await?;
         Ok(())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To ensure the parent directory are created at the destination path for recursive downloading. If this is not added, Azureblob recursive download would result in 
``` 
Bad Code: Internal error 
Message: No such file or directory (os error 2)
```


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
<img width="1512" alt="Screenshot 2024-09-10 at 1 25 04 AM" src="https://github.com/user-attachments/assets/1146945d-1aff-46c1-b6ed-142dfa096c1f">
