### PR TITLE
test: add unit test for dfget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "tabled",
+ "tempfile",
  "termion",
  "tikv-jemallocator",
  "tokio",

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -92,6 +92,9 @@ termion = "4.0.2"
 tabled = "0.16.0"
 path-absolutize = "3.1.1"
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5.4", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 


### PR DESCRIPTION
Add unit tests for util function in dfget.

## Description

This PR is done by finishing the following tasks:
- [x] Add unit tests for `validate_args`.
- [x] Add unit tests for `make_output_by_entry` 

## Related Issue

#496 

## Motivation and Context

Dragonfly rust client does not support back-to-source downloading of different object storage protocols. Priority is given to supporting OSS protocol back-to-source downloads. Need to support OSS protocol in dragonfly-client-backend crate, implemented based on trait Backend and it needs to support directory recursive downloading.
