### PR TITLE
:sparkles: feat: display detailed version for bin instead of the defa…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
+
+[[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +981,7 @@ version = "0.1.109"
 dependencies = [
  "bytesize",
  "bytesize-serde",
+ "clap",
  "dragonfly-client-core",
  "home",
  "hostname",
@@ -965,6 +992,7 @@ dependencies = [
  "serde",
  "serde_regex",
  "serde_yaml",
+ "shadow-rs",
  "tokio",
  "tracing",
  "validator",
@@ -1310,6 +1338,19 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -1814,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1967,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2336,6 +2396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -3411,9 +3480,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -3681,6 +3750,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca0e9bdc073d7173ba993fb7886477af5df75588b57afcb4b96f21911ab0bfa"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
 ]
 
 [[package]]
@@ -4060,7 +4142,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4504,6 +4588,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654c1ec546942ce0594e8d220e6b8e3899e0a0a8fe70ddd54d32a376dfefe3f8"
+dependencies = [
+ "tz-rs",
 ]
 
 [[package]]

--- a/dragonfly-client-config/Cargo.toml
+++ b/dragonfly-client-config/Cargo.toml
@@ -8,9 +8,11 @@ repository.workspace = true
 keywords.workspace = true
 license.workspace = true
 edition.workspace = true
+build = "build.rs"
 
 [dependencies]
 dragonfly-client-core.workspace = true
+clap.workspace = true
 regex.workspace = true
 serde.workspace = true
 tracing.workspace = true
@@ -25,3 +27,7 @@ local-ip-address = "0.6.3"
 hostname = "^0.4"
 humantime-serde = "1.1.1"
 serde_regex = "1.1.0"
+shadow-rs = "0.35.0"
+
+[build-dependencies]
+shadow-rs = "0.35.0"

--- a/dragonfly-client-config/build.rs
+++ b/dragonfly-client-config/build.rs
@@ -1,0 +1,19 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+use clap::{Arg, Command};
+use shadow_rs::shadow;
 use std::path::PathBuf;
+
+shadow!(build);
 
 pub mod dfcache;
 pub mod dfdaemon;
@@ -98,4 +102,30 @@ pub fn default_cache_dir() -> PathBuf {
 
     #[cfg(target_os = "macos")]
     return home::home_dir().unwrap().join(".dragonfly").join("cache");
+}
+
+#[derive(Debug, Clone)]
+pub struct DetailedVersionParser;
+
+impl clap::builder::TypedValueParser for DetailedVersionParser {
+    type Value = bool;
+    fn parse_ref(
+        &self,
+        cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        if value.to_os_string().eq("true") {
+            println!(
+                "{} {} (@: {}, rust: {}, git: {})",
+                cmd.get_name(),
+                cmd.get_version().unwrap_or("unknown"),
+                &build::COMMIT_DATE[..10],
+                build::RUST_VERSION,
+                build::SHORT_COMMIT
+            );
+            std::process::exit(0);
+        }
+        Ok(false)
+    }
 }

--- a/dragonfly-client-init/src/bin/main.rs
+++ b/dragonfly-client-init/src/bin/main.rs
@@ -17,6 +17,7 @@
 use clap::Parser;
 use dragonfly_client::tracing::init_tracing;
 use dragonfly_client_config::dfinit;
+use dragonfly_client_config::DetailedVersionParser;
 use dragonfly_client_init::container_runtime;
 use std::path::PathBuf;
 use tracing::{error, Level};
@@ -29,7 +30,8 @@ use tracing::{error, Level};
     about = "dfinit is a command line for initializing runtime environment of the dfdaemon",
     long_about = "A command line for initializing runtime environment of the dfdaemon, \
     For example, if the container's runtime is containerd, then dfinit will modify the mirror configuration of containerd and restart the containerd service. \
-    It also supports to change configuration of the other container's runtime, such as cri-o, docker, etc."
+    It also supports to change configuration of the other container's runtime, such as cri-o, docker, etc.",
+    disable_version_flag = true
 )]
 struct Args {
     #[arg(
@@ -68,6 +70,16 @@ struct Args {
         help = "Specify whether to print log"
     )]
     verbose: bool,
+
+    #[arg(
+        short = 'V',
+        long = "version",
+        help = "Print version",
+        default_value_t = false,
+        action = clap::ArgAction::SetTrue,
+        value_parser = DetailedVersionParser
+    )]
+    version: bool,
 }
 
 #[tokio::main]

--- a/dragonfly-client/src/bin/dfcache/main.rs
+++ b/dragonfly-client/src/bin/dfcache/main.rs
@@ -18,6 +18,7 @@ use clap::{Parser, Subcommand};
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
 use dragonfly_client::grpc::health::HealthClient;
 use dragonfly_client::tracing::init_tracing;
+use dragonfly_client_config::DetailedVersionParser;
 use dragonfly_client_config::{dfcache, dfdaemon};
 use dragonfly_client_core::Result;
 use std::path::{Path, PathBuf};
@@ -35,7 +36,8 @@ pub mod stat;
     version,
     about = "dfcache is a cache command line based on P2P technology in Dragonfly.",
     long_about = "A cache command line based on P2P technology in Dragonfly that can import file and export file in P2P network, \
-    and it can copy multiple replicas during import. P2P cache is effectively used for fast read and write cache."
+    and it can copy multiple replicas during import. P2P cache is effectively used for fast read and write cache.",
+    disable_version_flag = true
 )]
 struct Args {
     #[arg(
@@ -74,6 +76,16 @@ struct Args {
         help = "Specify whether to print log"
     )]
     verbose: bool,
+
+    #[arg(
+        short = 'V',
+        long = "version",
+        help = "Print version",
+        default_value_t = false,
+        action = clap::ArgAction::SetTrue,
+        value_parser = DetailedVersionParser
+    )]
+    version: bool,
 
     #[command(subcommand)]
     command: Command,

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -31,6 +31,7 @@ use dragonfly_client::stats::Stats;
 use dragonfly_client::tracing::init_tracing;
 use dragonfly_client_backend::BackendFactory;
 use dragonfly_client_config::dfdaemon;
+use dragonfly_client_config::DetailedVersionParser;
 use dragonfly_client_storage::Storage;
 use dragonfly_client_util::id_generator::IDGenerator;
 use std::net::SocketAddr;
@@ -55,7 +56,8 @@ pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0
     about = "dfdaemon is a high performance P2P download daemon",
     long_about = "A high performance P2P download daemon in Dragonfly that can download resources of different protocols. \
     When user triggers a file downloading task, dfdaemon will download the pieces of file from other peers. \
-    Meanwhile, it will act as an uploader to support other peers to download pieces from it if it owns them."
+    Meanwhile, it will act as an uploader to support other peers to download pieces from it if it owns them.",
+    disable_version_flag = true
 )]
 struct Args {
     #[arg(
@@ -94,6 +96,16 @@ struct Args {
         help = "Specify whether to print log"
     )]
     verbose: bool,
+
+    #[arg(
+        short = 'V',
+        long = "version",
+        help = "Print version",
+        default_value_t = false,
+        action = clap::ArgAction::SetTrue,
+        value_parser = DetailedVersionParser
+    )]
+    version: bool,
 }
 
 #[tokio::main]

--- a/dragonfly-client/src/bin/dfstore/main.rs
+++ b/dragonfly-client/src/bin/dfstore/main.rs
@@ -16,6 +16,7 @@
 
 use clap::{Parser, Subcommand};
 use dragonfly_client::tracing::init_tracing;
+use dragonfly_client_config::DetailedVersionParser;
 use dragonfly_client_config::{dfdaemon, dfstore};
 use std::path::PathBuf;
 use tracing::Level;
@@ -29,7 +30,8 @@ use tracing::Level;
     long_about = "A storage command line based on P2P technology in Dragonfly that can rely on different types of object storage, \
     such as S3 or OSS, to provide stable object storage capabilities. It uses the entire P2P network as a cache when storing objects. \
     Rely on S3 or OSS as the backend to ensure storage reliability. In the process of object storage, \
-    P2P cache is effectively used for fast read and write storage."
+    P2P cache is effectively used for fast read and write storage.",
+    disable_version_flag = true
 )]
 struct Args {
     #[arg(
@@ -68,6 +70,16 @@ struct Args {
         help = "Specify whether to print log"
     )]
     verbose: bool,
+
+    #[arg(
+        short = 'V',
+        long = "version",
+        help = "Print version",
+        default_value_t = false,
+        action = clap::ArgAction::SetTrue,
+        value_parser = DetailedVersionParser
+    )]
+    version: bool,
 
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
## Add more detailed info in flag --version, for easier debug and development
## Description
before:
```bash
root@a1bf4560250a:/# dfget -V
dfget 0.1.108
```

after:
```bash
root@a1bf4560250a:/# ./dfget -V
dfget 0.1.109 (@: 2024-09-30, rust: rustc 1.80.0 (051478957 2024-07-21), git: 2aee427a)
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
