### PR TITLE
feat: avoid the out stream is aborted in proxy and add calculate_interested test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "blake3",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "hyper 1.4.1",
  "hyper-util",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "clap",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "base16ct",
  "blake3",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.1.109"
+version = "0.1.111"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.110"
+version = "0.1.111"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.1.110" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.1.110" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.1.110" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.1.110" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.110" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.110" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.110" }
+dragonfly-client = { path = "dragonfly-client", version = "0.1.111" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.1.111" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.1.111" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.1.111" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.111" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.111" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.111" }
 thiserror = "1.0"
 dragonfly-api = "=2.0.164"
 reqwest = { version = "0.12.4", features = ["stream", "native-tls", "default-tls", "rustls-tls"] }


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files in the `dragonfly-client` project. The changes range from version updates and dependency adjustments to code enhancements and new tests. The most important changes include updating the version numbers in `Cargo.toml`, adding a sleep delay to avoid stream abortion errors, and introducing new tests for the `Piece` struct.

### Version Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated the version of `dragonfly-client` and its dependencies from `0.1.110` to `0.1.111`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Code Enhancements:
* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR714-R717): Added a sleep delay in the `proxy_by_dfdaemon` function to prevent stream abortion errors for small tasks.
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L120): Removed unnecessary `#[instrument(skip_all)]` attribute from the `calculate_interested` method.

### New Tests:
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R642-R744): Added unit tests for the `calculate_interested` method to ensure it correctly calculates interested pieces.

### Minor Changes:
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R147): Added missing newlines for better code readability. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R147) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R200)
* [`dragonfly-client/src/resource/task.rs`](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1239-R1260): Reorganized code by moving the sending of the download piece finished request to a different location. [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1239-R1260) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1266-L1287)