### PR TITLE
ensure proxy connection HTTP/1 to prevent possible failures

### DIFF
--- a/dragonfly-client/src/announcer/mod.rs
+++ b/dragonfly-client/src/announcer/mod.rs
@@ -157,7 +157,7 @@ impl SchedulerAnnouncer {
 
     /// run announces the dfdaemon information to the scheduler.
     #[instrument(skip_all)]
-    pub async fn run(&self) {
+    pub async fn run(&self) -> Result<()> {
         // Clone the shutdown channel.
         let mut shutdown = self.shutdown.clone();
 
@@ -187,7 +187,7 @@ impl SchedulerAnnouncer {
                     }
 
                     info!("announce to scheduler shutting down");
-                    return
+                    return Ok(());
                 }
             }
         }

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -310,27 +310,27 @@ async fn main() -> Result<(), anyhow::Error> {
             info!("stats server exited");
         },
 
-        _ = tokio::spawn(async move { manager_announcer.run().await.unwrap_or_else(|err| error!("announcer manager failed: {}", err))}) => {
+        _ = tokio::spawn(async move { manager_announcer.run().await.unwrap_or_else(|err| error!("announcer manager failed: {}", err))} ) => {
             info!("announcer manager exited");
         },
 
-        _ = tokio::spawn(async move { scheduler_announcer.run().await }) => {
+        _ = tokio::spawn(async move { scheduler_announcer.run().await.unwrap_or_else(|err| error!("announcer scheduler failed: {}", err)) }) => {
             info!("announcer scheduler exited");
         },
 
-        _ = tokio::spawn(async move { dfdaemon_upload_grpc.run().await }) => {
+        _ = tokio::spawn(async move { dfdaemon_upload_grpc.run().await.unwrap_or_else(|err| error!("dfdaemon upload grpc server failed: {}", err)) }) => {
             info!("dfdaemon upload grpc server exited");
         },
 
-        _ = tokio::spawn(async move { dfdaemon_download_grpc.run().await }) => {
+        _ = tokio::spawn(async move { dfdaemon_download_grpc.run().await.unwrap_or_else(|err| error!("dfdaemon download grpc server failed: {}", err)) }) => {
             info!("dfdaemon download grpc unix server exited");
         },
 
-        _ = tokio::spawn(async move { proxy.run().await }) => {
+        _ = tokio::spawn(async move { proxy.run().await.unwrap_or_else(|err| error!("proxy server failed: {}", err)) }) => {
             info!("proxy server exited");
         },
 
-        _ = tokio::spawn(async move { gc.run().await }) => {
+        _ = tokio::spawn(async move { gc.run().await.unwrap_or_else(|err| error!("garbage collector failed: {}", err)) }) => {
             info!("garbage collector exited");
         },
 

--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -71,7 +71,7 @@ impl GC {
 
     /// run runs the garbage collector.
     #[instrument(skip_all)]
-    pub async fn run(&self) {
+    pub async fn run(&self) -> Result<()> {
         // Clone the shutdown channel.
         let mut shutdown = self.shutdown.clone();
 
@@ -103,7 +103,7 @@ impl GC {
                 _ = shutdown.recv() => {
                     // Shutdown the garbage collector.
                     info!("garbage collector shutting down");
-                    return;
+                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
Set the connection between proxy with client HTTP/1
## Description
This pull request ensures that the connection between the proxy and the client is set to HTTP/1. Most public services negotiate to HTTP/1 after protocol negotiation (ALPN). However, the current proxy setup establishes an HTTP/2 connection with clients (e.g., curl), which can lead to request transfer failures. Setting up HTTP/1 is enough for now, may be extension for HTTP/x in the future.

## Related Issue

https://github.com/dragonflyoss/client/issues/771
