### PR TITLE
feat(ops): Update Docker workflow for PRs on main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,15 +26,9 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          # default version is tag when pushing tag, or latest when pushing main
-          # if pushing pull request, version is pr-{PR number}
           VERSION=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
+          if [[ ${GITHUB_REF} == "refs/heads/main" || ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
             VERSION=latest
-          fi
-
-          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
-            VERSION="pr-${BASH_REMATCH[1]}"
           fi
 
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
@@ -114,15 +108,9 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          # default version is tag when pushing tag, or latest when pushing main
-          # if pushing pull request, version is pr-{PR number}
           VERSION=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
+          if [[ ${GITHUB_REF} == "refs/heads/main" || ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
             VERSION=latest
-          fi
-
-          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
-            VERSION="pr-${BASH_REMATCH[1]}"
           fi
 
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,8 +112,8 @@ jobs:
             VERSION=latest
           fi
 
-          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
-            VERSION=pr-${BASH_REMATCH[1]}
+          if [[ ${GITHUB_REF} =~ "refs/pull/([0-9]+)/merge" ]]; then
+            VERSION="pr-${BASH_REMATCH[1]}"
           fi
 
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Docker
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     branches:
       - main
@@ -80,7 +82,8 @@ jobs:
           tags: |
             dragonflyoss/client:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.get_version.outputs.VERSION }}
-          push: true
+          # push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          push: false 
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
@@ -161,7 +164,8 @@ jobs:
           tags: |
             dragonflyoss/dfinit:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/dfinit:${{ steps.get_version.outputs.VERSION }}
-          push: true
+          # push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,10 +105,17 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
+          # default version is tag when pushing tag, or latest when pushing main
+          # if pushing pull request, version is pr-{PR number}
           VERSION=${GITHUB_REF#refs/tags/}
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest
           fi
+
+          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
+            VERSION=pr-${BASH_REMATCH[1]}
+          fi
+
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Get Git Revision

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,17 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
+          # default version is tag when pushing tag, or latest when pushing main
+          # if pushing pull request, version is pr-{PR number}
           VERSION=${GITHUB_REF#refs/tags/}
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest
           fi
+
+          if [[ ${GITHUB_REF} =~ "refs/pull/([0-9]+)/merge" ]]; then
+            VERSION="pr-${BASH_REMATCH[1]}"
+          fi
+
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Get Git Revision

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,13 +25,12 @@ jobs:
         run: |
           # default version is tag when pushing tag, or latest when pushing main
           # if pushing pull request, version is pr-{PR number}
-          echo ${GITHUB_REF}
           VERSION=${GITHUB_REF#refs/tags/}
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest
           fi
 
-          if [[ ${GITHUB_REF} =~ "refs/pull/([0-9]+)/merge" ]]; then
+          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
             VERSION="pr-${BASH_REMATCH[1]}"
           fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,10 @@ name: Docker
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+    paths:
+      - 'ci/Dockerfile*'
   push:
     branches:
       - main
@@ -44,7 +47,7 @@ jobs:
 
       - name: PrepareReg Names
         run: |
-           echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -132,7 +135,7 @@ jobs:
 
       - name: PrepareReg Names
         run: |
-           echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,7 +119,7 @@ jobs:
             VERSION=latest
           fi
 
-          if [[ ${GITHUB_REF} =~ "refs/pull/([0-9]+)/merge" ]]; then
+          if [[ ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
             VERSION="pr-${BASH_REMATCH[1]}"
           fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           # default version is tag when pushing tag, or latest when pushing main
           # if pushing pull request, version is pr-{PR number}
+          echo ${GITHUB_REF}
           VERSION=${GITHUB_REF#refs/tags/}
           if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
             VERSION=latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,8 +89,7 @@ jobs:
           tags: |
             dragonflyoss/client:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.get_version.outputs.VERSION }}
-          # push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-          push: false 
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
@@ -178,8 +177,7 @@ jobs:
           tags: |
             dragonflyoss/dfinit:${{ steps.get_version.outputs.VERSION }}
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/dfinit:${{ steps.get_version.outputs.VERSION }}
-          # push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-          push: false
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,8 +3,8 @@ FROM rust:1.80.0 AS builder
 WORKDIR /app/client
 
 RUN apt-get update && apt-get install -y \
-      openssl libclang-dev pkg-config protobuf-compiler git \
-      && rm -rf /var/lib/apt/lists/*
+    openssl libclang-dev pkg-config protobuf-compiler git \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
 
@@ -63,7 +63,7 @@ COPY --from=builder /app/client/target/release/dfget /usr/local/bin/dfget
 COPY --from=builder /app/client/target/release/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/release/dfstore /usr/local/bin/dfstore
 COPY --from=builder /app/client/target/release/dfcache /usr/local/bin/dfcache
-COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 COPY --from=pprof /go/bin/pprof /bin/pprof
+COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 
 ENTRYPOINT ["/usr/local/bin/dfdaemon"]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for Docker, focusing on adjusting the conditions under which Docker images are pushed. The most important changes include adding a `pull_request` trigger for the workflow and modifying the `push` condition for Docker images.

Workflow configuration updates:

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R4-R5): Added a `pull_request` trigger for the workflow to run on pull requests to the `main` branch.

Docker image push condition adjustments:

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L83-R86): Changed the `push` condition for Docker images to `false` and commented out the previous condition that pushed images when on the `main` branch or tags. [[1]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L83-R86) [[2]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L164-R168)