### PR TITLE
feat: response current replica count for persistent cache task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.0.168"
+version = "2.0.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298b306f4d2ed92b5dd3f232f6ec8ba1453c64199032a6e47f3b97157589f7a"
+checksum = "03d8389a4a380ff44c728cb9dcc46a59dc5b312df41b0d628ee2c8d624b1bede"
 dependencies = [
  "prost 0.13.3",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.1
 dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.115" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.115" }
 thiserror = "1.0"
-dragonfly-api = "=2.0.168"
+dragonfly-api = "=2.0.169"
 reqwest = { version = "0.12.4", features = ["stream", "native-tls", "default-tls", "rustls-tls"] }
 rcgen = { version = "0.12.1", features = ["x509-parser"] }
 hyper = { version = "1.4", features = ["full"] }

--- a/dragonfly-client/src/bin/dfcache/stat.rs
+++ b/dragonfly-client/src/bin/dfcache/stat.rs
@@ -203,8 +203,6 @@ impl StatCommand {
             piece_length: String,
             #[tabled(rename = "PERSISTENT REPLICA COUNT")]
             persistent_replica_count: u64,
-            #[tabled(rename = "REPLICA COUNT")]
-            replica_count: u64,
             ttl: String,
             #[tabled(rename = "CREATED")]
             created_at: String,
@@ -220,7 +218,6 @@ impl StatCommand {
             // Convert piece_length to human readable format.
             piece_length: bytesize::to_string(task.piece_length, true),
             persistent_replica_count: task.persistent_replica_count,
-            replica_count: task.replica_count,
             ..Default::default()
         };
 

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -208,7 +208,8 @@ impl PersistentCacheTask {
                 Ok(CommonPersistentCacheTask {
                     id: task_id.to_string(),
                     persistent_replica_count: request.persistent_replica_count,
-                    replica_count: response.replica_count,
+                    current_persistent_replica_count: response.current_persistent_replica_count,
+                    current_replica_count: response.current_replica_count,
                     digest: digest.to_string(),
                     tag: request.tag,
                     application: request.application,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to dependencies and modifications to the `PersistentCacheTask` struct in the `dragonfly-client` project. The most important changes include updating the version of the `dragonfly-api` dependency and modifying the fields in the `PersistentCacheTask` struct to reflect the current state of replicas.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L33-R33): Updated the `dragonfly-api` dependency from version `2.0.168` to `2.0.169` to ensure compatibility with the latest API changes.

Struct modifications:

* [`dragonfly-client/src/resource/persistent_cache_task.rs`](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L211-R212): Updated the `PersistentCacheTask` struct to include `current_persistent_replica_count` and `current_replica_count` fields, replacing the old `replica_count` field to better reflect the current state of replicas.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
