### PR TITLE
refactor(metadata.rs): simplify is_empty checks for Task and Persiste…

### DIFF
--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -108,13 +108,10 @@ impl Task {
 
     /// is_empty returns whether the task is empty.
     pub fn is_empty(&self) -> bool {
-        if let Some(content_length) = self.content_length() {
-            if content_length == 0 {
-                return true;
-            }
+        match self.content_length() {
+            Some(content_length) => content_length == 0,
+            None => false,
         }
-
-        false
     }
 
     /// piece_length returns the piece length of the task.
@@ -209,11 +206,7 @@ impl PersistentCacheTask {
 
     /// is_empty returns whether the persistent cache task is empty.
     pub fn is_empty(&self) -> bool {
-        if self.content_length == 0 {
-            return true;
-        }
-
-        false
+        self.content_length == 0
     }
 
     /// is_persistent returns whether the persistent cache task is persistent.


### PR DESCRIPTION
This pull request includes refactoring changes to simplify the `is_empty` methods in the `dragonfly-client-storage` crate. The changes aim to make the code more concise and readable by using more idiomatic Rust patterns.

Refactoring for code simplification:

* [`dragonfly-client-storage/src/metadata.rs`](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L111-L119): Simplified the `is_empty` method in the `Task` implementation by replacing nested `if let` statements with a `match` expression.
* [`dragonfly-client-storage/src/metadata.rs`](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L212-R209): Simplified the `is_empty` method in the `PersistentCacheTask` implementation by directly returning the comparison result.