### PR TITLE
Refactor(deps)  update rust and golang versions in dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80 AS builder
+FROM rust:1.82 AS builder
 
 WORKDIR /app/client
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.80 AS builder
 
 WORKDIR /app/client
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     openssl libclang-dev pkg-config protobuf-compiler git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.80 AS builder
 
 WORKDIR /app/client
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl libclang-dev pkg-config protobuf-compiler git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80.0 AS builder
+FROM rust:1.80 AS builder
 
 WORKDIR /app/client
 
@@ -48,7 +48,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi && \
     chmod +x /bin/grpc_health_probe
 
-FROM golang:1.23.0-alpine3.20 AS pprof
+FROM golang:1.23 AS pprof
 
 RUN go install github.com/google/pprof@latest
 


### PR DESCRIPTION

This pull request updates the Dockerfile configurations for the build environment. The changes primarily focus on updating the base images for Rust and Go to their latest versions.

Updates to Dockerfile configurations:

* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL1-R1): Updated the Rust base image from version `1.80.0` to `1.82`.
* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL51-R51): Updated the Go base image from version `1.23.0-alpine3.20` to `1.23`.