### PR TITLE
feat: optimize convert headermap to hashmap

### DIFF
--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -17,7 +17,7 @@
 use chrono::{NaiveDateTime, Utc};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_util::http::reqwest_headermap_to_hashmap;
+use dragonfly_client_util::http::headermap_to_hashmap;
 use rayon::prelude::*;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
@@ -332,7 +332,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
         // Convert the response header to hashmap.
         let response_header = response_header
             .as_ref()
-            .map(reqwest_headermap_to_hashmap)
+            .map(headermap_to_hashmap)
             .unwrap_or_default();
 
         let task = match self.db.get::<Task>(id.as_bytes())? {

--- a/dragonfly-client-util/src/http/mod.rs
+++ b/dragonfly-client-util/src/http/mod.rs
@@ -19,98 +19,55 @@ use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
 };
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 pub mod basic_auth;
 
-/// reqwest_headermap_to_hashmap converts a reqwest headermap to a hashmap.
+/// headermap_to_hashmap converts a headermap to a hashmap.
 #[instrument(skip_all)]
-pub fn reqwest_headermap_to_hashmap(header: &HeaderMap<HeaderValue>) -> HashMap<String, String> {
-    let mut hashmap: HashMap<String, String> = HashMap::new();
+pub fn headermap_to_hashmap(header: &HeaderMap<HeaderValue>) -> HashMap<String, String> {
+    let mut hashmap: HashMap<String, String> = HashMap::with_capacity(header.len());
     for (k, v) in header {
-        let Some(v) = v.to_str().ok() else {
-            continue;
-        };
-
-        hashmap.entry(k.to_string()).or_insert(v.to_string());
+        if let Ok(v) = v.to_str() {
+            hashmap.insert(k.to_string(), v.to_string());
+        }
     }
 
     hashmap
 }
 
-/// hashmap_to_reqwest_headermap converts a hashmap to a reqwest headermap.
+/// hashmap_to_headermap converts a hashmap to a headermap.
 #[instrument(skip_all)]
-pub fn hashmap_to_reqwest_headermap(
-    header: &HashMap<String, String>,
-) -> Result<HeaderMap<HeaderValue>> {
-    let header: HeaderMap = (header).try_into().or_err(ErrorType::ParseError)?;
-    Ok(header)
-}
-
-/// hashmap_to_hyper_header_map converts a hashmap to a hyper header map.
-#[instrument(skip_all)]
-pub fn hashmap_to_hyper_header_map(header: &HashMap<String, String>) -> Result<HeaderMap> {
-    let header: HeaderMap = (header).try_into().or_err(ErrorType::ParseError)?;
-    Ok(header)
-}
-
-/// TODO: Remove the conversion after the http crate version is the same.
-/// Convert the Reqwest header to the Hyper header, because of the http crate
-/// version is different. Reqwest header depends on the http crate
-/// version 0.2, but the Hyper header depends on the http crate version 0.1.
-#[instrument(skip_all)]
-pub fn hyper_headermap_to_reqwest_headermap(hyper_header: &HeaderMap) -> HeaderMap {
-    let mut reqwest_header = HeaderMap::new();
-    for (hyper_header_key, hyper_header_value) in hyper_header.iter() {
-        let reqwest_header_name: reqwest::header::HeaderName =
-            match hyper_header_key.to_string().parse() {
-                Ok(reqwest_header_name) => reqwest_header_name,
-                Err(err) => {
-                    error!("parse header name error: {}", err);
-                    continue;
-                }
-            };
-
-        let reqwest_header_value: reqwest::header::HeaderValue = match hyper_header_value.to_str() {
-            Ok(reqwest_header_value) => match reqwest_header_value.parse() {
-                Ok(reqwest_header_value) => reqwest_header_value,
-                Err(err) => {
-                    error!("parse header value error: {}", err);
-                    continue;
-                }
-            },
-            Err(err) => {
-                error!("parse header value error: {}", err);
-                continue;
-            }
-        };
-
-        reqwest_header.insert(reqwest_header_name, reqwest_header_value);
+pub fn hashmap_to_headermap(header: &HashMap<String, String>) -> Result<HeaderMap<HeaderValue>> {
+    let mut headermap = HeaderMap::with_capacity(header.len());
+    for (k, v) in header {
+        let name = HeaderName::from_bytes(k.as_bytes()).or_err(ErrorType::ParseError)?;
+        let value = HeaderValue::from_str(v).or_err(ErrorType::ParseError)?;
+        headermap.insert(name, value);
     }
 
-    reqwest_header
+    Ok(headermap)
 }
 
 /// header_vec_to_hashmap converts a vector of header string to a hashmap.
 #[instrument(skip_all)]
 pub fn header_vec_to_hashmap(raw_header: Vec<String>) -> Result<HashMap<String, String>> {
-    let mut header = HashMap::new();
+    let mut header = HashMap::with_capacity(raw_header.len());
     for h in raw_header {
-        let mut parts = h.splitn(2, ':');
-        let key = parts.next().unwrap().trim();
-        let value = parts.next().unwrap().trim();
-        header.insert(key.to_string(), value.to_string());
+        if let Some((k, v)) = h.split_once(':') {
+            header.insert(k.trim().to_string(), v.trim().to_string());
+        }
     }
 
     Ok(header)
 }
 
-/// header_vec_to_reqwest_headermap converts a vector of header string to a reqwest headermap.
+/// header_vec_to_headermap converts a vector of header string to a reqwest headermap.
 #[instrument(skip_all)]
-pub fn header_vec_to_reqwest_headermap(raw_header: Vec<String>) -> Result<HeaderMap> {
-    hashmap_to_reqwest_headermap(&header_vec_to_hashmap(raw_header)?)
+pub fn header_vec_to_headermap(raw_header: Vec<String>) -> Result<HeaderMap> {
+    hashmap_to_headermap(&header_vec_to_hashmap(raw_header)?)
 }
 
 /// get_range gets the range from http header.
@@ -152,55 +109,26 @@ mod tests {
     use reqwest::header::{HeaderMap, HeaderValue};
 
     #[test]
-    fn test_reqwest_headermap_to_hashmap() {
+    fn test_headermap_to_hashmap() {
         let mut header = HeaderMap::new();
         header.insert("Content-Type", HeaderValue::from_static("application/json"));
         header.insert("Authorization", HeaderValue::from_static("Bearer token"));
 
-        let hashmap = reqwest_headermap_to_hashmap(&header);
-
+        let hashmap = headermap_to_hashmap(&header);
         assert_eq!(hashmap.get("content-type").unwrap(), "application/json");
         assert_eq!(hashmap.get("authorization").unwrap(), "Bearer token");
         assert_eq!(hashmap.get("foo"), None);
     }
 
     #[test]
-    fn test_hashmap_to_reqwest_headermap() {
+    fn test_hashmap_to_headermap() {
         let mut hashmap = HashMap::new();
         hashmap.insert("Content-Type".to_string(), "application/json".to_string());
         hashmap.insert("Authorization".to_string(), "Bearer token".to_string());
 
-        let header = hashmap_to_reqwest_headermap(&hashmap).unwrap();
-
+        let header = hashmap_to_headermap(&hashmap).unwrap();
         assert_eq!(header.get("Content-Type").unwrap(), "application/json");
         assert_eq!(header.get("Authorization").unwrap(), "Bearer token");
-    }
-
-    #[test]
-    fn test_hashmap_to_hyper_header_map() {
-        let mut hashmap = HashMap::new();
-        hashmap.insert("Content-Type".to_string(), "application/json".to_string());
-        hashmap.insert("Authorization".to_string(), "Bearer token".to_string());
-
-        let header = hashmap_to_hyper_header_map(&hashmap).unwrap();
-
-        assert_eq!(header.get("Content-Type").unwrap(), "application/json");
-        assert_eq!(header.get("Authorization").unwrap(), "Bearer token");
-    }
-
-    #[test]
-    fn test_hyper_headermap_to_reqwest_headermap() {
-        let mut hyper_header = HeaderMap::new();
-        hyper_header.insert("Content-Type", HeaderValue::from_static("application/json"));
-        hyper_header.insert("Authorization", HeaderValue::from_static("Bearer token"));
-
-        let reqwest_header = hyper_headermap_to_reqwest_headermap(&hyper_header);
-
-        assert_eq!(
-            reqwest_header.get("Content-Type").unwrap(),
-            "application/json"
-        );
-        assert_eq!(reqwest_header.get("Authorization").unwrap(), "Bearer token");
     }
 
     #[test]
@@ -211,20 +139,18 @@ mod tests {
         ];
 
         let hashmap = header_vec_to_hashmap(raw_header).unwrap();
-
         assert_eq!(hashmap.get("Content-Type").unwrap(), "application/json");
         assert_eq!(hashmap.get("Authorization").unwrap(), "Bearer token");
     }
 
     #[test]
-    fn test_header_vec_to_reqwest_headermap() {
+    fn test_header_vec_to_headermap() {
         let raw_header = vec![
             "Content-Type: application/json".to_string(),
             "Authorization: Bearer token".to_string(),
         ];
 
-        let header = header_vec_to_reqwest_headermap(raw_header).unwrap();
-
+        let header = header_vec_to_headermap(raw_header).unwrap();
         assert_eq!(header.get("Content-Type").unwrap(), "application/json");
         assert_eq!(header.get("Authorization").unwrap(), "Bearer token");
     }
@@ -238,7 +164,6 @@ mod tests {
         );
 
         let range = get_range(&header, 200).unwrap().unwrap();
-
         assert_eq!(range.start, 0);
         assert_eq!(range.length, 101);
     }
@@ -246,7 +171,6 @@ mod tests {
     #[test]
     fn test_parse_range_header() {
         let range = parse_range_header("bytes=0-100", 200).unwrap();
-
         assert_eq!(range.start, 0);
         assert_eq!(range.length, 101);
     }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -30,7 +30,7 @@ use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{self, dfdaemon, dfget};
 use dragonfly_client_core::error::{BackendError, ErrorType, OrErr};
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_util::http::{header_vec_to_hashmap, header_vec_to_reqwest_headermap};
+use dragonfly_client_util::http::{header_vec_to_hashmap, header_vec_to_headermap};
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use path_absolutize::*;
 use percent_encoding::percent_decode_str;
@@ -786,7 +786,7 @@ async fn get_entries(args: Args, object_storage: Option<ObjectStorage>) -> Resul
             // NOTE: Mock a task id for head request.
             task_id: Uuid::new_v4().to_string(),
             url: args.url.to_string(),
-            http_header: Some(header_vec_to_reqwest_headermap(
+            http_header: Some(header_vec_to_headermap(
                 args.header.clone().unwrap_or_default(),
             )?),
             timeout: args.timeout,

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -43,7 +43,7 @@ use dragonfly_client_core::{
 };
 use dragonfly_client_util::{
     digest::{calculate_file_hash, Algorithm},
-    http::{get_range, hashmap_to_reqwest_headermap, reqwest_headermap_to_hashmap},
+    http::{get_range, hashmap_to_headermap, headermap_to_hashmap},
 };
 use hyper_util::rt::TokioIo;
 use std::path::{Path, PathBuf};
@@ -235,7 +235,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
 
                 match serde_json::to_vec::<Backend>(&Backend {
                     message: err.message.clone(),
-                    header: reqwest_headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                    header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                     status_code: err.status_code.map(|code| code.as_u16() as i32),
                 }) {
                     Ok(json) => {
@@ -301,7 +301,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // If download protocol is not http, use the range of the download.
         if download.range.is_none() {
             // Convert the header.
-            let request_header = match hashmap_to_reqwest_headermap(&download.request_header) {
+            let request_header = match hashmap_to_headermap(&download.request_header) {
                 Ok(header) => header,
                 Err(e) => {
                     // Download task failed.
@@ -431,9 +431,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
 
                         match serde_json::to_vec::<Backend>(&Backend {
                             message: err.message.clone(),
-                            header: reqwest_headermap_to_hashmap(
-                                &err.header.clone().unwrap_or_default(),
-                            ),
+                            header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                             status_code: err.status_code.map(|code| code.as_u16() as i32),
                         }) {
                             Ok(json) => {
@@ -696,7 +694,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
 
                 match serde_json::to_vec::<Backend>(&Backend {
                     message: err.message.clone(),
-                    header: reqwest_headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                    header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                     status_code: err.status_code.map(|code| code.as_u16() as i32),
                 }) {
                     Ok(json) => {

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -38,9 +38,7 @@ use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error as ClientError, Result as ClientResult,
 };
-use dragonfly_client_util::http::{
-    get_range, hashmap_to_reqwest_headermap, reqwest_headermap_to_hashmap,
-};
+use dragonfly_client_util::http::{get_range, hashmap_to_headermap, headermap_to_hashmap};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -230,7 +228,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                 match serde_json::to_vec::<Backend>(&Backend {
                     message: err.message.clone(),
-                    header: reqwest_headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                    header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                     status_code: err.status_code.map(|code| code.as_u16() as i32),
                 }) {
                     Ok(json) => {
@@ -297,7 +295,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         // If download protocol is not http, use the range of the download.
         if download.range.is_none() {
             // Convert the header.
-            let request_header = match hashmap_to_reqwest_headermap(&download.request_header) {
+            let request_header = match hashmap_to_headermap(&download.request_header) {
                 Ok(header) => header,
                 Err(e) => {
                     // Download task failed.
@@ -429,9 +427,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                         match serde_json::to_vec::<Backend>(&Backend {
                             message: err.message.clone(),
-                            header: reqwest_headermap_to_hashmap(
-                                &err.header.clone().unwrap_or_default(),
-                            ),
+                            header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                             status_code: err.status_code.map(|code| code.as_u16() as i32),
                         }) {
                             Ok(json) => {
@@ -896,7 +892,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                 match serde_json::to_vec::<Backend>(&Backend {
                     message: err.message.clone(),
-                    header: reqwest_headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                    header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                     status_code: err.status_code.map(|code| code.as_u16() as i32),
                 }) {
                     Ok(json) => {

--- a/dragonfly-client/src/proxy/header.rs
+++ b/dragonfly-client/src/proxy/header.rs
@@ -54,31 +54,19 @@ pub const DRAGONFLY_PREFETCH_HEADER: &str = "X-Dragonfly-Prefetch";
 /// get_tag gets the tag from http header.
 #[instrument(skip_all)]
 pub fn get_tag(header: &HeaderMap) -> Option<String> {
-    match header.get(DRAGONFLY_TAG_HEADER) {
-        Some(tag) => match tag.to_str() {
-            Ok(tag) => Some(tag.to_string()),
-            Err(err) => {
-                error!("get tag from header failed: {}", err);
-                None
-            }
-        },
-        None => None,
-    }
+    header
+        .get(DRAGONFLY_TAG_HEADER)
+        .and_then(|tag| tag.to_str().ok())
+        .map(|tag| tag.to_string())
 }
 
 /// get_application gets the application from http header.
 #[instrument(skip_all)]
 pub fn get_application(header: &HeaderMap) -> Option<String> {
-    match header.get(DRAGONFLY_APPLICATION_HEADER) {
-        Some(application) => match application.to_str() {
-            Ok(application) => Some(application.to_string()),
-            Err(err) => {
-                error!("get application from header failed: {}", err);
-                None
-            }
-        },
-        None => None,
-    }
+    header
+        .get(DRAGONFLY_APPLICATION_HEADER)
+        .and_then(|application| application.to_str().ok())
+        .map(|application| application.to_string())
 }
 
 /// get_priority gets the priority from http header.
@@ -106,16 +94,10 @@ pub fn get_priority(header: &HeaderMap) -> i32 {
 /// get_registry gets the custom address of container registry from http header.
 #[instrument(skip_all)]
 pub fn get_registry(header: &HeaderMap) -> Option<String> {
-    match header.get(DRAGONFLY_REGISTRY_HEADER) {
-        Some(registry) => match registry.to_str() {
-            Ok(registry) => Some(registry.to_string()),
-            Err(err) => {
-                error!("get registry from header failed: {}", err);
-                None
-            }
-        },
-        None => None,
-    }
+    header
+        .get(DRAGONFLY_REGISTRY_HEADER)
+        .and_then(|registry| registry.to_str().ok())
+        .map(|registry| registry.to_string())
 }
 
 /// get_filters gets the filters from http header.
@@ -126,7 +108,7 @@ pub fn get_filtered_query_params(
 ) -> Vec<String> {
     match header.get(DRAGONFLY_FILTERED_QUERY_PARAMS_HEADER) {
         Some(filters) => match filters.to_str() {
-            Ok(filters) => filters.split(',').map(|s| s.to_string()).collect(),
+            Ok(filters) => filters.split(',').map(|s| s.trim().to_string()).collect(),
             Err(err) => {
                 error!("get filters from header failed: {}", err);
                 default_filtered_query_params

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -44,7 +44,7 @@ use dragonfly_client_core::{
 };
 use dragonfly_client_storage::{metadata, Storage};
 use dragonfly_client_util::{
-    http::{hashmap_to_reqwest_headermap, reqwest_headermap_to_hashmap},
+    http::{hashmap_to_headermap, headermap_to_hashmap},
     id_generator::IDGenerator,
 };
 use reqwest::header::HeaderMap;
@@ -127,11 +127,10 @@ impl Task {
         }
 
         // Handle the request header.
-        let mut request_header =
-            hashmap_to_reqwest_headermap(&request.request_header).map_err(|err| {
-                error!("convert header: {}", err);
-                err
-            })?;
+        let mut request_header = hashmap_to_headermap(&request.request_header).map_err(|err| {
+            error!("convert header: {}", err);
+            err
+        })?;
 
         // Remove the range header to prevent the server from
         // returning a 206 partial content and returning
@@ -1333,7 +1332,7 @@ impl Task {
                                                 response: Some(download_piece_back_to_source_failed_request::Response::Backend(
                                                         Backend{
                                                             message: err.message.clone(),
-                                                            header: reqwest_headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                                                            header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
                                                             status_code: err.status_code.map(|code| code.as_u16() as i32),
                                                         }
                                                 )),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request involves several refactors and improvements across multiple files, primarily focusing on renaming functions and improving the efficiency of certain operations. The key changes include renaming functions for better clarity, removing redundant methods, and optimizing the conversion of header maps.

### Function Renaming and Refactoring:
* Renamed `reqwest_headermap_to_hashmap` to `headermap_to_hashmap` and updated all references accordingly (`dragonfly-client-storage/src/metadata.rs`, `dragonfly-client-util/src/http/mod.rs`, `dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`, `dragonfly-client/src/proxy/mod.rs`). [[1]](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L20-R20) [[2]](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L335-R335) [[3]](diffhunk://#diff-400949f43c53c2d5833a394806a0d9cd7360a7c9f99b9ad101c5f58e3c44e98dL22-R70) [[4]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL46-R46) [[5]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L41-R41) [[6]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL33-R33)
* Renamed `hashmap_to_reqwest_headermap` to `hashmap_to_headermap` and updated all references accordingly (`dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`, `dragonfly-client/src/proxy/mod.rs`). [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL304-R304) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L300-R298) [[3]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL629-R626)

### Code Simplification:
* Simplified the implementation of `get_tag`, `get_application`, and `get_registry` functions by using combinators instead of match statements (`dragonfly-client/src/proxy/header.rs`). [[1]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL57-R69) [[2]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL109-R100)
* Improved the `headermap_to_hashmap` function by pre-allocating the hashmap with the capacity of the header map and using `if let` for better readability (`dragonfly-client-util/src/http/mod.rs`).

### Test Updates:
* Updated test function names to reflect the new function names and removed redundant tests (`dragonfly-client-util/src/http/mod.rs`). [[1]](diffhunk://#diff-400949f43c53c2d5833a394806a0d9cd7360a7c9f99b9ad101c5f58e3c44e98dL155-L205) [[2]](diffhunk://#diff-400949f43c53c2d5833a394806a0d9cd7360a7c9f99b9ad101c5f58e3c44e98dL214-R153) [[3]](diffhunk://#diff-400949f43c53c2d5833a394806a0d9cd7360a7c9f99b9ad101c5f58e3c44e98dL241-L249)

### Additional Changes:
* Trimmed values when splitting strings in `get_filtered_query_params` for better accuracy (`dragonfly-client/src/proxy/header.rs`).
![20241113161651](https://github.com/user-attachments/assets/c0b616a3-0181-4a18-8ad9-a1aaca3eded8)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
