### PR TITLE
feat: remove zstd comperssion in dfdaemon_download server

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -53,7 +53,6 @@ use tokio::fs;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
-use tonic::codec::CompressionEncoding;
 use tonic::{
     transport::{Channel, Endpoint, Server, Uri},
     Code, Request, Response, Status,
@@ -93,8 +92,6 @@ impl DfdaemonDownloadServer {
             task,
             persistent_cache_task,
         })
-        .send_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Zstd)
         .max_decoding_message_size(usize::MAX)
         .max_encoding_message_size(usize::MAX);
 
@@ -1005,8 +1002,6 @@ impl DfdaemonDownloadClient {
             })
             .or_err(ErrorType::ConnectError)?;
         let client = DfdaemonDownloadGRPCClient::new(channel)
-            .send_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Zstd)
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX);
         Ok(Self { client })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
![20241113172430](https://github.com/user-attachments/assets/4616991a-d60c-4f87-88b7-861ed13f02a7)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
