### PR TITLE
fix barrier synchronization on components exit for dfdaemon

### DIFF
--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -347,9 +347,7 @@ async fn main() -> Result<(), anyhow::Error> {
         _ = {
             let barrier = grpc_server_started_barrier.clone();
             tokio::spawn(async move {
-                // Wait for grpc server started.
-                barrier.wait().await;
-                proxy.run().await.unwrap_or_else(|err| error!("proxy server failed: {}", err));
+                proxy.run(barrier).await.unwrap_or_else(|err| error!("proxy server failed: {}", err));
             })
         } => {
             info!("proxy server exited");

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -137,13 +137,19 @@ impl DfdaemonDownloadServer {
             .add_service(health_service)
             .add_service(self.service.clone())
             .serve_with_incoming_shutdown(uds_stream, async move {
-                // Download grpc server shutting down with signals.
+                tokio::select! {
+                    // Notify the download grpc server is started.
+                    _ = grpc_server_started_barrier.wait() => {
+                        info!("proxy download server is ready to start");
+                    }
+                    // Wait for shutdown signal.
+                    _ = shutdown.recv() => {
+                        info!("download grpc server stop to wait");
+                    }
+                }
                 let _ = shutdown.recv().await;
                 info!("download grpc server shutting down");
             });
-
-        // Notify the grpc server is started.
-        grpc_server_started_barrier.wait().await;
 
         // Wait for the download grpc server to shutdown.
         info!(

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -138,13 +138,19 @@ impl DfdaemonUploadServer {
             .add_service(health_service)
             .add_service(self.service.clone())
             .serve_with_shutdown(self.addr, async move {
-                // Upload grpc server shutting down with signals.
+                tokio::select! {
+                    // Notify the upload grpc server is started.
+                    _ = grpc_server_started_barrier.wait() => {
+                        info!("upload server is ready");
+                    }
+                    // Wait for shutdown signal.
+                    _ = shutdown.recv() => {
+                        info!("download grpc server stop to wait");
+                    }
+                }
                 let _ = shutdown.recv().await;
-                info!("upload grpc server shutting down");
+                info!("download grpc server shutting down");
             });
-
-        // Notify the grpc server is started.
-        grpc_server_started_barrier.wait().await;
 
         // Wait for the upload grpc server to shutdown.
         info!("upload server listening on {}", self.addr);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### reproduce the issue:
1. remove the access right of dfdaemon on socket's parent dir. (like ```chown -R root:root  /var/run/dragonfly/```).
2. start dfdaemon.
3. stuck, not able to response for any SIGNAL.

### reason
1. dfdaemon_download_grpc exit  before grpc_server_started_barrier.wait()  (no permission to create socket).
2. proxy.run() will never reach and wait for the missing barrier above.
3. shutdown_complete_tx.clone() for proxy will not be released inside the tokio thread.
4. the missing shutdown_complete_tx above leads to stuck at shutdown_complete_rx.recv().await.
5. game over.


### solution
always listen to shutdown and barrier at the same time.
