### PR TITLE
feat: enhance client otel tracing and linking to scheduler &  manager

### DIFF
--- a/dragonfly-client/src/grpc/health.rs
+++ b/dragonfly-client/src/grpc/health.rs
@@ -21,7 +21,7 @@ use dragonfly_client_core::{
 use hyper_util::rt::TokioIo;
 use std::path::PathBuf;
 use tokio::net::UnixStream;
-use tonic::transport::ClientTlsConfig;
+use tonic::{service::interceptor::InterceptedService, transport::ClientTlsConfig};
 use tonic::transport::{Channel, Endpoint, Uri};
 use tonic_health::pb::{
     health_client::HealthClient as HealthGRPCClient, HealthCheckRequest, HealthCheckResponse,
@@ -29,11 +29,13 @@ use tonic_health::pb::{
 use tower::service_fn;
 use tracing::{error, instrument};
 
+use super::tracing_grpc::TracingInterceptor;
+
 /// HealthClient is a wrapper of HealthGRPCClient.
 #[derive(Clone)]
 pub struct HealthClient {
     /// client is the grpc client of the certificate.
-    client: HealthGRPCClient<Channel>,
+    client: HealthGRPCClient<InterceptedService<Channel, TracingInterceptor>>,
 }
 
 /// HealthClient implements the grpc client of the health.
@@ -73,7 +75,7 @@ impl HealthClient {
                 .or_err(ErrorType::ConnectError)?,
         };
 
-        let client = HealthGRPCClient::new(channel)
+        let client = HealthGRPCClient::with_interceptor(channel, TracingInterceptor)
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX);
         Ok(Self { client })
@@ -99,7 +101,7 @@ impl HealthClient {
                 err
             })
             .or_err(ErrorType::ConnectError)?;
-        let client = HealthGRPCClient::new(channel)
+        let client = HealthGRPCClient::with_interceptor(channel, TracingInterceptor)
             .max_decoding_message_size(usize::MAX)
             .max_encoding_message_size(usize::MAX);
         Ok(Self { client })

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -29,6 +29,7 @@ pub mod dfdaemon_upload;
 pub mod health;
 pub mod manager;
 pub mod scheduler;
+pub mod tracing_grpc;
 
 /// CONNECT_TIMEOUT is the timeout for GRPC connection.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);

--- a/dragonfly-client/src/grpc/tracing_grpc.rs
+++ b/dragonfly-client/src/grpc/tracing_grpc.rs
@@ -1,0 +1,32 @@
+use {tonic::{metadata, service::Interceptor, Request, Status}, tracing_opentelemetry::OpenTelemetrySpanExt};
+
+/// MetadataMap is a tracing meda data map container.
+struct MetadataMap<'a>(&'a mut metadata::MetadataMap);
+
+/// MetadataMap implements the otel tracing Injector.
+impl<'a> opentelemetry::propagation::Injector for MetadataMap<'a> {
+    /// set a key-value pair to the injector.
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = metadata::MetadataKey::from_bytes(key.as_bytes()) {
+            if let Ok(val) = metadata::MetadataValue::try_from(&value) {
+                self.0.insert(key, val);
+            }
+        }
+    }
+}
+
+/// TracingInterceptor is a auto-inject tracing gRPC interceptor.
+#[derive(Clone)]
+pub struct TracingInterceptor;
+
+/// TracingInterceptor implements the tonic Interceptor interface.
+impl Interceptor for TracingInterceptor {
+    /// call and inject tracing context into lgobal propagator.
+    fn call(&mut self, mut request: Request<()>) -> std::result::Result<Request<()>, Status> {
+        let context = tracing::Span::current().context();
+        opentelemetry::global::get_text_map_propagator(|prop| 
+            prop.inject_context(&context, &mut MetadataMap(request.metadata_mut())));
+    
+        Ok(request)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Introduce a grpc_tracing interceptor to inject tracing span context into the global propagator.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The client now cannot pass tracing context to other system conponents. 

Let's enhance it by injecting otel tracing context into the global propagator, then collecting total spans in the same trace.

## Screenshots (if appropriate)
