### PR TITLE
feat: optimize logs for server started

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -151,6 +151,8 @@ impl Proxy {
     pub async fn run(&self, grpc_server_started_barrier: Arc<Barrier>) -> ClientResult<()> {
         let mut shutdown = self.shutdown.clone();
 
+        // When the grpc server is started, notify the barrier. If the shutdown signal is received
+        // before barrier is waited successfully, the server will shutdown immediately.
         tokio::select! {
             // Wait for starting the proxy server
             _ = grpc_server_started_barrier.wait() => {
@@ -171,9 +173,6 @@ impl Proxy {
         info!("proxy server listening on {}", self.addr);
 
         loop {
-            // Clone the shutdown channel.
-            let mut shutdown = self.shutdown.clone();
-
             // Wait for a client connection.
             tokio::select! {
                 tcp_accepted = listener.accept() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several improvements to the gRPC server implementations in the `dragonfly-client` project. The changes focus on enhancing the shutdown process and updating log messages for better clarity.

Enhancements to gRPC server implementations:

* [`dragonfly-client/src/grpc/dfdaemon_download.rs`](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR143-R157): Added comments to explain the behavior when the gRPC server starts and waits for a shutdown signal, and updated log messages for consistency.
* [`dragonfly-client/src/grpc/dfdaemon_upload.rs`](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R144-R160): Added comments to clarify the server startup and shutdown process, and corrected log messages to accurately reflect the upload server context.

Additional improvements to proxy server:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR154-R155): Added comments to describe the notification process when the gRPC server starts and waits for a shutdown signal.
* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL174-L176): Removed redundant cloning of the shutdown channel to simplify the code.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
