### PR TITLE
Fix dfinit issue when containerd config_path have multiple paths

### DIFF
--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -68,7 +68,7 @@ impl Containerd {
         {
             // Rebind config_path to the first entry if multiple paths are present
             let config_path = config_path.split(':').next().unwrap_or(config_path);
-            
+
             info!(
                 "containerd supports config_path mode, config_path: {}",
                 config_path.to_string()

--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -66,6 +66,9 @@ impl Containerd {
             .and_then(|config_path| config_path.as_str())
             .filter(|config_path| !config_path.is_empty())
         {
+            // Rebind config_path to the first entry if multiple paths are present
+            let config_path = config_path.split(':').next().unwrap_or(config_path);
+            
             info!(
                 "containerd supports config_path mode, config_path: {}",
                 config_path.to_string()


### PR DESCRIPTION
Fix dfinit issue when updating registry config when multiple paths are present in config_path.

## Description

Sometimes `config_path` have multiple paths separated by colon e.g

```
[plugins."io.containerd.grpc.v1.cri".registry]
config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
```
In this case dfinit is creating folder at path ```/etc/containerd/certs.d\:/etc/docker/certs.d/```. It can be fixed by picking up the first path if multiple paths are added.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
