### PR TITLE
feat: rename remote peer to parent

### DIFF
--- a/dragonfly-client-core/src/error/errors.rs
+++ b/dragonfly-client-core/src/error/errors.rs
@@ -171,10 +171,10 @@ pub struct BackendError {
     pub header: Option<reqwest::header::HeaderMap>,
 }
 
-/// DownloadFromRemotePeerFailed is the error when the download from remote peer is failed.
+/// DownloadFromParentFailed is the error when the download from parent is failed.
 #[derive(Debug, thiserror::Error)]
-#[error("download piece {piece_number} from remote peer {parent_id} failed")]
-pub struct DownloadFromRemotePeerFailed {
+#[error("download piece {piece_number} from parent {parent_id} failed")]
+pub struct DownloadFromParentFailed {
     /// piece_number is the number of the piece.
     pub piece_number: u32,
 

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -21,7 +21,7 @@ pub use errors::ErrorType;
 pub use errors::ExternalError;
 
 pub use errors::OrErr;
-pub use errors::{BackendError, DownloadFromRemotePeerFailed};
+pub use errors::{BackendError, DownloadFromParentFailed};
 
 /// DFError is the error for dragonfly.
 #[derive(thiserror::Error, Debug)]
@@ -70,9 +70,9 @@ pub enum DFError {
     #[error{"available schedulers not found"}]
     AvailableSchedulersNotFound,
 
-    /// DownloadFromRemotePeerFailed is the error when the download from remote peer is failed.
+    /// DownloadFromParentFailed is the error when the download from parent is failed.
     #[error(transparent)]
-    DownloadFromRemotePeerFailed(DownloadFromRemotePeerFailed),
+    DownloadFromParentFailed(DownloadFromParentFailed),
 
     /// ColumnFamilyNotFound is the error when the column family is not found.
     #[error{"column family {0} not found"}]

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -326,9 +326,9 @@ impl Storage {
         )
     }
 
-    /// download_piece_from_remote_peer_finished is used for downloading piece from remote peer.
+    /// download_piece_from_parent_finished is used for downloading piece from parent.
     #[instrument(skip_all)]
-    pub async fn download_piece_from_remote_peer_finished<R: AsyncRead + Unpin + ?Sized>(
+    pub async fn download_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
         task_id: &str,

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -629,7 +629,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
     /// SyncPiecesStream is the stream of the sync pieces response.
     type SyncPiecesStream = ReceiverStream<Result<SyncPiecesResponse, Status>>;
 
-    /// sync_pieces provides the piece metadata for remote peer.
+    /// sync_pieces provides the piece metadata for parent.
     #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
     async fn sync_pieces(
         &self,
@@ -760,7 +760,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         Ok(Response::new(ReceiverStream::new(out_stream_rx)))
     }
 
-    /// download_piece provides the piece content for remote peer.
+    /// download_piece provides the piece content for parent.
     #[instrument(skip_all, fields(host_id, remote_host_id, task_id, piece_id))]
     async fn download_piece(
         &self,
@@ -1183,7 +1183,7 @@ impl DfdaemonUploadClient {
         Ok(response)
     }
 
-    /// sync_pieces provides the piece metadata for remote peer.
+    /// sync_pieces provides the piece metadata for parent.
     #[instrument(skip_all)]
     pub async fn sync_pieces(
         &self,
@@ -1194,7 +1194,7 @@ impl DfdaemonUploadClient {
         Ok(response)
     }
 
-    /// download_piece provides the piece content for remote peer.
+    /// download_piece provides the piece content for parent.
     #[instrument(skip_all)]
     pub async fn download_piece(
         &self,

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -389,10 +389,10 @@ impl Piece {
         );
     }
 
-    /// download_from_remote_peer downloads a single piece from a remote peer.
+    /// download_from_parent downloads a single piece from a parent.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all, fields(piece_id))]
-    pub async fn download_from_remote_peer(
+    pub async fn download_from_parent(
         &self,
         piece_id: &str,
         host_id: &str,
@@ -455,7 +455,7 @@ impl Piece {
         // Record the finish of downloading piece.
         match self
             .storage
-            .download_piece_from_remote_peer_finished(
+            .download_piece_from_parent_finished(
                 piece_id,
                 task_id,
                 offset,

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -29,7 +29,7 @@ use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{error, info, instrument, Instrument};
 
-/// CollectedParent is the parent peer collected from the remote peer.
+/// CollectedParent is the parent peer collected from the parent.
 #[derive(Clone, Debug)]
 pub struct CollectedParent {
     /// id is the id of the parent.
@@ -110,7 +110,7 @@ impl PieceCollector {
         let (collected_piece_tx, collected_piece_rx) = mpsc::channel(10 * 1024);
         tokio::spawn(
             async move {
-                Self::collect_from_remote_peers(
+                Self::collect_from_parents(
                     config,
                     &host_id,
                     &task_id,
@@ -131,10 +131,10 @@ impl PieceCollector {
         collected_piece_rx
     }
 
-    /// collect_from_remote_peers collects pieces from remote peers.
+    /// collect_from_parents collects pieces from parents.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
-    async fn collect_from_remote_peers(
+    async fn collect_from_parents(
         config: Arc<Config>,
         host_id: &str,
         task_id: &str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request primarily involves renaming various functions, structs, and comments to replace references to "remote peer" with "parent" in the `dragonfly-client` project. The changes span multiple files and affect error handling, documentation, and function names to ensure consistency with the new terminology.

### Renaming for Consistency:

* [`dragonfly-client-core/src/error/errors.rs`](diffhunk://#diff-5e06c855f1badd99103531909125c85aa23b8e19c1fba34a112dc0a0e6bc47e5L174-R177): Renamed `DownloadFromRemotePeerFailed` struct to `DownloadFromParentFailed` and updated associated error messages.
* [`dragonfly-client-core/src/error/mod.rs`](diffhunk://#diff-30b34d1fd4f012f66569fffc95749e5627c7a8bb3720dbcea2fa6659a7a5f85bL24-R24): Updated references to `DownloadFromRemotePeerFailed` to `DownloadFromParentFailed` in error definitions and usage. [[1]](diffhunk://#diff-30b34d1fd4f012f66569fffc95749e5627c7a8bb3720dbcea2fa6659a7a5f85bL24-R24) [[2]](diffhunk://#diff-30b34d1fd4f012f66569fffc95749e5627c7a8bb3720dbcea2fa6659a7a5f85bL73-R75)
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL329-R331): Renamed function `download_piece_from_remote_peer_finished` to `download_piece_from_parent_finished`.
* [`dragonfly-client/src/grpc/dfdaemon_upload.rs`](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L632-R632): Updated function names and comments to replace "remote peer" with "parent" in `DfdaemonUpload` and `DfdaemonUploadClient` implementations. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L632-R632) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L763-R763) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1186-R1186) [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1197-R1197)
* [`dragonfly-client/src/resource/persistent_cache_task.rs`](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L39-R39): Updated function names and comments to replace "remote peer" with "parent" in `PersistentCacheTask` implementation. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L39-R39) [[2]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L646-R646) [[3]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L686-R688) [[4]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L701-R709) [[5]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L764-R764) [[6]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L790-R793) [[7]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L826-R828) [[8]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L846-R852) [[9]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L864-R869) [[10]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L935-R943) [[11]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L975-R977) [[12]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1010-R1010)
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L392-R395): Renamed function `download_from_remote_peer` to `download_from_parent` and updated comments accordingly. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L392-R395) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L458-R458)
* [`dragonfly-client/src/resource/piece_collector.rs`](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L32-R32): Updated comments and function names to replace "remote peer" with "parent" in `PieceCollector` implementation. [[1]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L32-R32) [[2]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L113-R113) [[3]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L134-R137)
* [`dragonfly-client/src/resource/task.rs`](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L42-R42): Updated function names and comments to replace "remote peer" with "parent" in `Task` implementation. [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L42-R42) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L630-R630) [[3]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L670-R672) [[4]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L686-R694)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
