### PR TITLE
feat: replace redirect_stderr with args.verbose

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ lru = "0.12.5"
 opt-level = "z"
 lto = true
 codegen-units = 1
-panic = "abort"
 strip = "symbols"
 
 [profile.bench]

--- a/dragonfly-client-init/src/bin/main.rs
+++ b/dragonfly-client-init/src/bin/main.rs
@@ -95,7 +95,6 @@ async fn main() -> Result<(), anyhow::Error> {
         args.log_max_files,
         None,
         false,
-        false,
         args.verbose,
     );
 

--- a/dragonfly-client/src/bin/dfcache/main.rs
+++ b/dragonfly-client/src/bin/dfcache/main.rs
@@ -157,7 +157,6 @@ async fn main() -> anyhow::Result<()> {
         args.log_max_files,
         None,
         false,
-        false,
         args.verbose,
     );
 

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -152,7 +152,6 @@ async fn main() -> Result<(), anyhow::Error> {
         args.log_max_files,
         config.tracing.addr.to_owned(),
         config.tracing.flamegraph,
-        true,
         args.verbose,
     );
 

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -276,7 +276,6 @@ async fn main() -> anyhow::Result<()> {
         args.log_max_files,
         None,
         false,
-        false,
         args.verbose,
     );
 

--- a/dragonfly-client/src/bin/dfstore/main.rs
+++ b/dragonfly-client/src/bin/dfstore/main.rs
@@ -127,7 +127,6 @@ fn main() {
         args.log_max_files,
         None,
         false,
-        false,
         args.verbose,
     );
 }

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -40,7 +40,6 @@ pub fn init_tracing(
     log_max_files: usize,
     jaeger_addr: Option<String>,
     flamegraph: bool,
-    redirect_stderr: bool,
     verbose: bool,
 ) -> Vec<WorkerGuard> {
     let mut guards = vec![];
@@ -135,7 +134,7 @@ pub fn init_tracing(
     );
 
     // Redirect stderr to file.
-    if redirect_stderr {
+    if !verbose {
         redirect_stderr_to_file(log_dir);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the `dragonfly-client` project, focusing on improving logging and updating dependencies. The most important changes include updating the `lru` crate version, adding a new logging statement, and modifying the tracing initialization logic.

### Dependency Update:
* Updated the `lru` crate version to `0.12.5` in `Cargo.toml`.

### Logging Enhancements:
* Added a new logging statement using `tracing::info` in `dragonfly-client/src/proxy/cache.rs`.

### Tracing Initialization:
* Removed the `redirect_stderr` parameter from the `init_tracing` function in `dragonfly-client/src/tracing/mod.rs`.
* Changed the logic to redirect `stderr` to a file only if `verbose` is not enabled in `dragonfly-client/src/tracing/mod.rs`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
