### PR TITLE
feat: calculate piece range and store the actual piece reader

### DIFF
--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -423,6 +423,54 @@ impl Storage {
         }
     }
 
+    /// upload_piece_with_dual_read returns the dual reader of the piece, one is the range reader, and the other is the
+    /// full reader of the piece. It is used for cache the piece content to the proxy cache.
+    #[instrument(skip_all)]
+    pub async fn upload_piece_with_dual_read(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        range: Option<Range>,
+    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
+        // Wait for the piece to be finished.
+        self.wait_for_piece_finished(piece_id).await?;
+
+        // Start uploading the task.
+        self.metadata.upload_task_started(task_id)?;
+
+        // Get the piece metadata and return the content of the piece.
+        match self.metadata.get_piece(piece_id) {
+            Ok(Some(piece)) => {
+                match self
+                    .content
+                    .read_piece_with_dual_read(task_id, piece.offset, piece.length, range)
+                    .await
+                {
+                    Ok(dual_reader) => {
+                        // Finish uploading the task.
+                        self.metadata.upload_task_finished(task_id)?;
+                        Ok(dual_reader)
+                    }
+                    Err(err) => {
+                        // Failed uploading the task.
+                        self.metadata.upload_task_failed(task_id)?;
+                        Err(err)
+                    }
+                }
+            }
+            Ok(None) => {
+                // Failed uploading the task.
+                self.metadata.upload_task_failed(task_id)?;
+                Err(Error::PieceNotFound(piece_id.to_string()))
+            }
+            Err(err) => {
+                // Failed uploading the task.
+                self.metadata.upload_task_failed(task_id)?;
+                Err(err)
+            }
+        }
+    }
+
     /// get_piece returns the piece metadata.
     #[instrument(skip_all)]
     pub fn get_piece(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -812,7 +812,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let mut reader = self
             .task
             .piece
-            .upload_from_local_peer_into_async_read(
+            .upload_from_local_into_async_read(
                 piece_id.as_str(),
                 task_id.as_str(),
                 piece.length,

--- a/dragonfly-client/src/proxy/cache.rs
+++ b/dragonfly-client/src/proxy/cache.rs
@@ -15,8 +15,10 @@
  */
 
 use crate::resource::task::Task;
+use dragonfly_api::common::v2::Range;
 use dragonfly_api::dfdaemon::v2::DownloadTaskRequest;
 use dragonfly_client_core::{Error, Result};
+use dragonfly_client_util::http::{get_range, hashmap_to_headermap};
 use lru::LruCache;
 use std::cmp::{max, min};
 use std::num::NonZeroUsize;
@@ -67,7 +69,14 @@ impl Cache {
             return Ok(None);
         };
 
-        let range = download.range;
+        let Ok(request_header) = hashmap_to_headermap(&download.request_header) else {
+            return Ok(None);
+        };
+
+        let Ok(range) = get_range(&request_header, content_length) else {
+            return Ok(None);
+        };
+
         let interested_pieces =
             self.task
                 .piece
@@ -84,38 +93,64 @@ impl Cache {
             };
 
             // Calculate the target offset and length based on the range.
-            let (target_offset, target_length) = if let Some(range) = range {
-                let target_offset =
-                    max(interested_piece.offset, range.start) - interested_piece.offset;
-                let target_length = min(
-                    interested_piece.offset + interested_piece.length - 1,
-                    range.start + range.length - 1,
-                ) - target_offset
-                    + 1;
-                (target_offset as usize, target_length as usize)
-            } else {
-                (0, interested_piece.length as usize)
-            };
+            let (target_offset, target_length) =
+                self.calculate_piece_range(interested_piece.offset, interested_piece.length, range);
 
-            let piece_content = piece_content.slice(target_offset..target_offset + target_length);
+            let begin = target_offset;
+            let end = target_offset + target_length;
+            if begin >= piece_content.len() || end > piece_content.len() {
+                return Err(Error::InvalidParameter);
+            }
+
+            let piece_content = piece_content.slice(begin..end);
             content.extend_from_slice(&piece_content);
         }
 
         Ok(Some(content.freeze()))
     }
 
-    /// get gets the piece content from the cache.
+    /// calculate_piece_range calculates the target offset and length based on the piece range and
+    /// request range.
+    fn calculate_piece_range(
+        &self,
+        piece_offset: u64,
+        piece_length: u64,
+        range: Option<Range>,
+    ) -> (usize, usize) {
+        if let Some(range) = range {
+            let target_offset = max(piece_offset, range.start) - piece_offset;
+
+            let interested_piece_end = piece_offset + piece_length - 1;
+            let range_end = range.start + range.length - 1;
+            let target_length =
+                min(interested_piece_end, range_end) - target_offset - piece_offset + 1;
+
+            (target_offset as usize, target_length as usize)
+        } else {
+            (0, piece_length as usize)
+        }
+    }
+
+    /// get_piece gets the piece content from the cache.
     pub fn get_piece(&self, id: &str) -> Option<bytes::Bytes> {
         let mut pieces = self.pieces.lock().unwrap();
         pieces.get(id).cloned()
     }
 
-    /// add create the piece content into the cache, if the key already exists, no operation will
+    /// add_piece create the piece content into the cache, if the key already exists, no operation will
     /// be performed.
     pub fn add_piece(&self, id: &str, content: bytes::Bytes) {
         let mut pieces = self.pieces.lock().unwrap();
-        if !pieces.contains(id) {
-            pieces.put(id.to_string(), content);
+        if pieces.contains(id) {
+            return;
         }
+
+        pieces.put(id.to_string(), content);
+    }
+
+    /// contains_piece checks whether the piece exists in the cache.
+    pub fn contains_piece(&self, id: &str) -> bool {
+        let pieces = self.pieces.lock().unwrap();
+        pieces.contains(id)
     }
 }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -55,13 +55,13 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, Barrier};
 use tokio::time::sleep;
 use tokio_rustls::TlsAcceptor;
-use tokio_util::io::{InspectReader, ReaderStream};
+use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument, Instrument, Span};
 
 pub mod cache;
@@ -821,9 +821,9 @@ async fn proxy_via_dfdaemon(
                                 return;
                             };
 
-                            let piece_reader = match task
+                            let (piece_range_reader, piece_reader) = match task
                                 .piece
-                                .download_from_local_peer_into_async_read(
+                                .download_from_local_into_dual_async_read(
                                     task.piece
                                         .id(message.task_id.as_str(), piece.number)
                                         .as_str(),
@@ -835,7 +835,7 @@ async fn proxy_via_dfdaemon(
                                 )
                                 .await
                             {
-                                Ok(piece_reader) => piece_reader,
+                                Ok(dual_reader) => dual_reader,
                                 Err(err) => {
                                     error!("download piece reader error: {}", err);
                                     if let Err(err) = writer.shutdown().await {
@@ -847,24 +847,22 @@ async fn proxy_via_dfdaemon(
                             };
 
                             // Use a buffer to read the piece.
-                            let piece_reader =
-                                BufReader::with_capacity(read_buffer_size, piece_reader);
+                            let piece_range_reader =
+                                BufReader::with_capacity(read_buffer_size, piece_range_reader);
 
                             // Write the piece data to the pipe in order and store the piece reader
                             // in the cache.
-                            finished_piece_readers.insert(piece.number, piece_reader);
-                            while let Some(piece_reader) =
-                                finished_piece_readers.get_mut(&need_piece_number)
+                            finished_piece_readers
+                                .insert(piece.number, (piece_range_reader, piece_reader));
+                            while let Some((mut piece_range_reader, piece_reader)) =
+                                finished_piece_readers
+                                    .get_mut(&need_piece_number)
+                                    .map(|(range_reader, reader)| (range_reader, reader))
                             {
                                 debug!("copy piece {} to stream", need_piece_number);
-                                let mut content =
-                                    bytes::BytesMut::with_capacity(piece.length as usize);
-
-                                let mut tee = InspectReader::new(piece_reader, |bytes| {
-                                    content.extend_from_slice(bytes);
-                                });
-
-                                if let Err(err) = tokio::io::copy(&mut tee, &mut writer).await {
+                                if let Err(err) =
+                                    tokio::io::copy(&mut piece_range_reader, &mut writer).await
+                                {
                                     error!("download piece reader error: {}", err);
                                     if let Err(err) = writer.shutdown().await {
                                         error!("writer shutdown error: {}", err);
@@ -873,10 +871,28 @@ async fn proxy_via_dfdaemon(
                                     return;
                                 }
 
-                                cache.add_piece(
-                                    &task.piece.id(&message.task_id, need_piece_number),
-                                    content.freeze(),
-                                );
+                                // If the piece is not in the cache, add it to the cache.
+                                let piece_id =
+                                    task.piece.id(message.task_id.as_str(), need_piece_number);
+
+                                if !cache.contains_piece(&piece_id) {
+                                    let mut content =
+                                        bytes::BytesMut::with_capacity(piece.length as usize);
+                                    loop {
+                                        let n = match piece_reader.read_buf(&mut content).await {
+                                            Ok(n) => n,
+                                            Err(err) => {
+                                                error!("read piece reader error: {}", err);
+                                                break;
+                                            }
+                                        };
+
+                                        if n == 0 {
+                                            cache.add_piece(&piece_id, content.freeze());
+                                            break;
+                                        }
+                                    }
+                                }
 
                                 need_piece_number += 1;
                             }

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -384,10 +384,10 @@ impl PersistentCacheTask {
                 err
             })?;
 
-        // Download the pieces from the local peer.
-        debug!("download the pieces from local peer");
+        // Download the pieces from the local.
+        debug!("download the pieces from local");
         let finished_pieces = match self
-            .download_partial_from_local_peer(
+            .download_partial_from_local(
                 task,
                 host_id,
                 peer_id,
@@ -398,7 +398,7 @@ impl PersistentCacheTask {
         {
             Ok(finished_pieces) => finished_pieces,
             Err(err) => {
-                error!("download from local peer error: {:?}", err);
+                error!("download from local error: {:?}", err);
                 download_progress_tx
                     .send_timeout(Err(Status::internal(err.to_string())), REQUEST_TIMEOUT)
                     .await
@@ -422,7 +422,7 @@ impl PersistentCacheTask {
 
         // Check if all pieces are downloaded.
         if interested_pieces.is_empty() {
-            info!("all pieces are downloaded from local peer");
+            info!("all pieces are downloaded from local");
             return Ok(());
         };
         debug!("download the pieces with scheduler");
@@ -1015,10 +1015,10 @@ impl PersistentCacheTask {
         Ok(finished_pieces)
     }
 
-    /// download_partial_from_local_peer downloads a partial persistent cache task from a local peer.
+    /// download_partial_from_local downloads a partial persistent cache task from a local.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
-    async fn download_partial_from_local_peer(
+    async fn download_partial_from_local(
         &self,
         task: &metadata::PersistentCacheTask,
         host_id: &str,
@@ -1029,7 +1029,7 @@ impl PersistentCacheTask {
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
 
-        // Download the piece from the local peer.
+        // Download the piece from the local.
         for interested_piece in interested_pieces {
             let piece_id = self
                 .storage
@@ -1048,10 +1048,10 @@ impl PersistentCacheTask {
                 }
             };
 
-            // Fake the download from the local peer.
+            // Fake the download from the local.
             self.piece
-                .download_from_local_peer(task.id.as_str(), piece.length);
-            info!("finished piece {} from local peer", piece_id);
+                .download_from_local(task.id.as_str(), piece.length);
+            info!("finished piece {} from local", piece_id);
 
             // Construct the piece.
             let piece = Piece {

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -319,9 +319,9 @@ impl Piece {
         (content_length as f64 / piece_length as f64).ceil() as u32
     }
 
-    /// upload_from_local_peer_into_async_read uploads a single piece from a local peer.
+    /// upload_from_local_into_async_read uploads a single piece from local cache.
     #[instrument(skip_all, fields(piece_id))]
-    pub async fn upload_from_local_peer_into_async_read(
+    pub async fn upload_from_local_into_async_read(
         &self,
         piece_id: &str,
         task_id: &str,
@@ -349,9 +349,40 @@ impl Piece {
             })
     }
 
-    /// download_from_local_peer_into_async_read downloads a single piece from a local peer.
+    /// upload_from_local_into_async_read. It will return two readers, one is the range reader, and the other is the
+    /// full reader of the piece.
     #[instrument(skip_all, fields(piece_id))]
-    pub async fn download_from_local_peer_into_async_read(
+    pub async fn upload_from_local_into_dual_async_read(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        length: u64,
+        range: Option<Range>,
+        disable_rate_limit: bool,
+    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+
+        // Acquire the upload rate limiter.
+        if !disable_rate_limit {
+            self.upload_rate_limiter.acquire(length as usize).await;
+        }
+
+        // Upload the piece content.
+        self.storage
+            .upload_piece_with_dual_read(piece_id, task_id, range)
+            .await
+            .inspect(|_reader| {
+                collect_upload_piece_traffic_metrics(
+                    self.id_generator.task_type(task_id) as i32,
+                    length,
+                );
+            })
+    }
+
+    /// download_from_local_into_async_read downloads a single piece from local cache.
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_from_local_into_async_read(
         &self,
         piece_id: &str,
         task_id: &str,
@@ -378,10 +409,42 @@ impl Piece {
         self.storage.upload_piece(piece_id, task_id, range).await
     }
 
-    /// download_from_local_peer downloads a single piece from a local peer. Fake the download piece
-    /// from the local peer, just collect the metrics.
+    /// download_from_local_into_dual_async_read returns two readers, one is the range reader, and
+    /// the other is the full reader of the piece.
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_from_local_into_dual_async_read(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        length: u64,
+        range: Option<Range>,
+        disable_rate_limit: bool,
+        is_prefetch: bool,
+    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+
+        // Acquire the download rate limiter.
+        if !disable_rate_limit {
+            if is_prefetch {
+                // Acquire the prefetch rate limiter.
+                self.prefetch_rate_limiter.acquire(length as usize).await;
+            } else {
+                // Acquire the download rate limiter.
+                self.download_rate_limiter.acquire(length as usize).await;
+            }
+        }
+
+        // Upload the piece content.
+        self.storage
+            .upload_piece_with_dual_read(piece_id, task_id, range)
+            .await
+    }
+
+    /// download_from_local downloads a single piece from local cache. Fake the download piece
+    /// from the local cache, just collect the metrics.
     #[instrument(skip_all)]
-    pub fn download_from_local_peer(&self, task_id: &str, length: u64) {
+    pub fn download_from_local(&self, task_id: &str, length: u64) {
         collect_download_piece_traffic_metrics(
             &TrafficType::LocalPeer,
             self.id_generator.task_type(task_id) as i32,

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -342,10 +342,10 @@ impl Task {
                 err
             })?;
 
-        // Download the pieces from the local peer.
-        debug!("download the pieces from local peer");
+        // Download the pieces from the local.
+        debug!("download the pieces from local");
         let finished_pieces = match self
-            .download_partial_from_local_peer(
+            .download_partial_from_local(
                 task,
                 host_id,
                 peer_id,
@@ -356,7 +356,7 @@ impl Task {
         {
             Ok(finished_pieces) => finished_pieces,
             Err(err) => {
-                error!("download from local peer error: {:?}", err);
+                error!("download from local error: {:?}", err);
                 return Err(err);
             }
         };
@@ -375,7 +375,7 @@ impl Task {
 
         // Check if all pieces are downloaded.
         if interested_pieces.is_empty() {
-            info!("all pieces are downloaded from local peer");
+            info!("all pieces are downloaded from local");
             return Ok(());
         };
         debug!("download the pieces with scheduler");
@@ -1202,7 +1202,7 @@ impl Task {
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
 
-        // Download the piece from the local peer.
+        // Download the piece from the local.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
             self.config.download.concurrent_piece_count as usize,
@@ -1436,10 +1436,10 @@ impl Task {
         Ok(finished_pieces)
     }
 
-    /// download_partial_from_local_peer downloads a partial task from a local peer.
+    /// download_partial_from_local downloads a partial task from a local.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
-    async fn download_partial_from_local_peer(
+    async fn download_partial_from_local(
         &self,
         task: &metadata::Task,
         host_id: &str,
@@ -1453,7 +1453,7 @@ impl Task {
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
 
-        // Download the piece from the local peer.
+        // Download the piece from the local.
         for interested_piece in interested_pieces {
             let piece_id = self.storage.piece_id(task_id, interested_piece.number);
 
@@ -1470,9 +1470,9 @@ impl Task {
                 }
             };
 
-            // Fake the download from the local peer.
-            self.piece.download_from_local_peer(task_id, piece.length);
-            info!("finished piece {} from local peer", piece_id,);
+            // Fake the download from the local.
+            self.piece.download_from_local(task_id, piece.length);
+            info!("finished piece {} from local", piece_id,);
 
             // Construct the piece.
             let piece = Piece {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several changes to the `dragonfly-client-storage` and related modules to enhance the reading and caching mechanisms, as well as to improve the upload functionality. The most important changes include adding dual read functionality, refactoring existing read methods to use buffered readers, and updating the cache logic.

### Enhancements to Reading and Caching Mechanisms:
* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL215-R229): Added `BufReader` to improve reading performance and introduced a new method `read_piece_with_dual_read` to support dual read functionality. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL215-R229) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL254-R259) [[3]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL269-R335)
* [`dragonfly-client/src/proxy/cache.rs`](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95R18-R26): Added methods to calculate piece ranges and updated the cache logic to handle HTTP range requests. [[1]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95R18-R26) [[2]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L70-R80) [[3]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L87-R160)

### Improvements to Upload Functionality:
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR426-R473): Added `upload_piece_with_dual_read` method to support dual read during upload operations.

### Refactoring and Code Simplification:
* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL58-R64): Refactored the proxy logic to utilize the new dual read functionality and updated the cache handling logic. [[1]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL58-R64) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL824-R826) [[3]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL838-R838) [[4]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL850-R865)

### Miscellaneous Updates:
* [`dragonfly-client/src/resource/persistent_cache_task.rs`](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L387-R390): Renamed methods to remove the term "peer" and updated related log messages for clarity. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L387-R390) [[2]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L401-R401) [[3]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L425-R425) [[4]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1018-R1021) [[5]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1032-R1032) [[6]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1051-R1054)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
