### PR TITLE
test: add unit tests for calculate_piece_range

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -887,6 +887,8 @@ async fn proxy_via_dfdaemon(
                                             }
                                         };
 
+                                        // When the piece reader reads to the end, add the piece
+                                        // to the cache.
                                         if n == 0 {
                                             cache.add_piece(&piece_id, content.freeze());
                                             break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes aimed at refactoring the code for calculating piece ranges and improving the test coverage. The main changes involve extracting the `calculate_piece_range` function into a standalone function and updating the related code to use this new function.

Refactoring and code improvement:

* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR255-L270): Extracted the logic for calculating the target offset and length based on the range into a new function `calculate_piece_range`. This function is now called in the `impl Content` block instead of the inline logic. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR255-L270) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL295-R289) [[3]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR595-R687)
* [`dragonfly-client/src/proxy/cache.rs`](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L96-R100): Similarly, extracted the logic for calculating the target offset and length into the `calculate_piece_range` function and updated the `impl Cache` block to use this function. [[1]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L96-R100) [[2]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L112-L133) [[3]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95R135-R227)

Test coverage:

* Added unit tests for the `calculate_piece_range` function in both `dragonfly-client-storage` and `dragonfly-client` to ensure the correctness of the calculations. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR595-R687) [[2]](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95R135-R227)

Dependency update:

* [`dragonfly-client-storage/Cargo.toml`](diffhunk://#diff-646c14b277a6afe2521324f3047193b744dfb61e924e1e1c6a1c71e7d12dd302R35): Added `tempfile.workspace = true` to the `dev-dependencies` section to support the new tests.

Minor improvement:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR890-R891): Added a comment to clarify the logic for adding a piece to the cache when the piece reader reaches the end.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
