### PR TITLE
chore: update cargo version to 0.1.126

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "blake3",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.5.1",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "clap",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.125"
+version = "0.1.126"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.1.125" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.1.125" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.1.125" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.1.125" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.125" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.125" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.125" }
+dragonfly-client = { path = "dragonfly-client", version = "0.1.126" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.1.126" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.1.126" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.1.126" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.1.126" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.1.126" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.1.126" }
 thiserror = "1.0"
 dragonfly-api = "=2.0.177"
 reqwest = { version = "0.12.4", features = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes version updates for the `dragonfly-client` and its dependencies in the `Cargo.toml` file. 

Version updates:

* Updated `version` from "0.1.125" to "0.1.126" in the `[workspace.package]` section.
* Updated the versions of `dragonfly-client` and its related dependencies from "0.1.125" to "0.1.126" in the `[workspace.dependencies]` section.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
