### PR TITLE
fix: when the task has started and did not download the data, gc is failed

### DIFF
--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -182,12 +182,21 @@ impl GC {
                 break;
             }
 
-            // If the task has no content length, skip it.
+            // If the task has downloaded finished, task has the content length, evicted space is the
+            // content length. If the task has started and did not download the data, and content
+            // length is 0, evicted space is 0.
             let task_space = match task.content_length() {
                 Some(content_length) => content_length,
                 None => {
-                    error!("task {} has no content length", task.id);
-                    continue;
+                    // If the task has no content length, skip it.
+                    if !task.is_failed() {
+                        error!("task {} has no content length", task.id);
+                        continue;
+                    }
+
+                    // If the task has started and did not download the data, and content length is 0.
+                    info!("task {} is failed, has no content length", task.id);
+                    0
                 }
             };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the garbage collection logic in the `dragonfly-client` project. The changes improve the handling of tasks based on their download status and content length.

Key updates to garbage collection logic:

* Enhanced logic to handle tasks with different download statuses, ensuring that tasks with finished downloads and valid content lengths have their space correctly evicted.
* Added conditions to skip tasks without content length unless the task has failed, in which case it logs the failure and assigns an evicted space of 0.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
