### PR TITLE
feat: rename proxy_request_by_dfdaemon_total metric to proxy_request_via_dfdaemon_total

### DIFF
--- a/dragonfly-client/src/metrics/mod.rs
+++ b/dragonfly-client/src/metrics/mod.rs
@@ -181,7 +181,7 @@ lazy_static! {
     /// PROXY_REQUEST_VIA_DFDAEMON_COUNT is used to count the number of proxy requset via dfdaemon.
     pub static ref PROXY_REQUEST_VIA_DFDAEMON_COUNT: IntCounterVec =
         IntCounterVec::new(
-            Opts::new("proxy_request_by_dfdaemon_total", "Counter of the number of the proxy request by dfdaemon.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
+            Opts::new("proxy_request_via_dfdaemon_total", "Counter of the number of the proxy request via dfdaemon.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
             &[]
         ).expect("metric can be created");
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a small but important change to the `dragonfly-client/src/metrics/mod.rs` file. The change corrects the metric name for counting proxy requests via dfdaemon.

* [`dragonfly-client/src/metrics/mod.rs`](diffhunk://#diff-2bed13877d63556b6f5d2e6bbe266693bd6e448b818486df45c9539e173f0888L184-R184): Corrected the metric name from "proxy_request_by_dfdaemon_total" to "proxy_request_via_dfdaemon_total" in the `PROXY_REQUEST_VIA_DFDAEMON_COUNT` static reference.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
