### PR TITLE
feat: add cache configuration support for preheat tasks

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -188,12 +188,6 @@ fn default_storage_read_buffer_size() -> usize {
     128 * 1024
 }
 
-/// default_storage_cache_enable is the default value for the cache enable flag.
-/// The cache is disabled by default.
-#[inline]
-fn default_storage_cache_enable() -> bool {
-    false
-}
 /// default_storage_cache_capacity is the default cache capacity for the preheat task, default is
 /// 100.
 #[inline]
@@ -911,20 +905,20 @@ impl Default for StorageServer {
     }
 }
 
-/// CacheConfig represents the configuration settings for the cache.
+/// Cache represents the configuration settings for the cache.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
-pub struct CacheConfig {
+pub struct Cache {
     /// enable determines whether the cache is enabled.
     pub enable: bool,
     /// capacity specifies the maximum number of entries the cache can hold.
     pub capacity: usize,
 }
 /// Default implementation for CacheConfig.
-impl Default for CacheConfig {
+impl Default for Cache {
     fn default() -> Self {
-        CacheConfig {
-            enable: default_storage_cache_enable(),
+        Cache {
+            enable: false,
             capacity: default_storage_cache_capacity(),
         }
     }
@@ -938,7 +932,7 @@ pub struct Storage {
     pub server: StorageServer,
 
     /// cache is the configuration for the cache.
-    pub cache: CacheConfig,
+    pub cache: Cache,
 
     /// dir is the directory to store task's metadata and content.
     #[serde(default = "crate::default_storage_dir")]
@@ -962,7 +956,7 @@ impl Default for Storage {
     fn default() -> Self {
         Storage {
             server: StorageServer::default(),
-            cache: CacheConfig::default(),
+            cache: Cache::default(),
             dir: crate::default_storage_dir(),
             keep: default_storage_keep(),
             write_buffer_size: default_storage_write_buffer_size(),

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -905,11 +905,36 @@ impl Default for StorageServer {
     }
 }
 
-/// Cache represents the configuration settings for the cache.
+/// Cache represents the configuration settings for the cache. 
+/// When a user triggers a preheat request, and if the peer has the cache storage feature enabled, 
+/// the downloaded piece content will be stored in the cache. Subsequently, when other peers request 
+/// downloading the same content, the preheated peer can upload the piece content directly from memory, 
+/// bypassing disk I/O.
+/// 
+/// The workflow diagram is as follows:
+///                                                   |
+///                                                preheat
+///                                                   |
+///                                                   v
+///                                    +--------------------------------+
+///                                    |             Peer               |
+///                                    |         +-----------+          |
+///   +---------------+                |    |--->|   cache   |          |
+///   |               |                |    |    +-----------+          |
+///   |    source     |                |    |        |    |             |                +-------------+
+///   |               |<-- download -->|----|      miss   --- hit ----->|<-- download -->|    Peer     |
+///   |     local     |                |    |        |               |  |                +-------------+
+///   |               |                |    |        v               |  |
+///   |  other peers  |                |    |    +-----------+       |  |
+///   |               |                |    |--->|   disk    |-------|  |
+///   +---------------+                |         +-----------+          |
+///                                    |                                |
+///                                    +--------------------------------+ 
+///
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Cache {
-    /// enable determines whether the cache is enabled.
+    /// enable determines whether the cache feature is enabled.
     pub enable: bool,
     /// capacity specifies the maximum number of entries the cache can hold.
     pub capacity: usize,
@@ -932,7 +957,7 @@ pub struct Storage {
     /// server is the storage server configuration for dfdaemon.
     pub server: StorageServer,
 
-    /// cache is the configuration for the cache.
+    /// cache is the configuration for the cache storage.
     pub cache: Cache,
 
     /// dir is the directory to store task's metadata and content.

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -914,7 +914,8 @@ pub struct Cache {
     /// capacity specifies the maximum number of entries the cache can hold.
     pub capacity: usize,
 }
-/// Default implementation for CacheConfig.
+
+/// Default implementation for Cache.
 impl Default for Cache {
     fn default() -> Self {
         Cache {

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -188,6 +188,19 @@ fn default_storage_read_buffer_size() -> usize {
     128 * 1024
 }
 
+/// default_storage_cache_enable is the default value for the cache enable flag.
+/// The cache is disabled by default.
+#[inline]
+fn default_storage_cache_enable() -> bool {
+    false
+}
+/// default_storage_cache_capacity is the default cache capacity for the preheat task, default is
+/// 100.
+#[inline]
+fn default_storage_cache_capacity() -> usize {
+    100
+}
+
 /// default_seed_peer_cluster_id is the default cluster id of seed peer.
 #[inline]
 fn default_seed_peer_cluster_id() -> u64 {
@@ -898,12 +911,34 @@ impl Default for StorageServer {
     }
 }
 
+/// CacheConfig represents the configuration settings for the cache.
+#[derive(Debug, Clone, Validate, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CacheConfig {
+    /// enable determines whether the cache is enabled.
+    pub enable: bool,
+    /// capacity specifies the maximum number of entries the cache can hold.
+    pub capacity: usize,
+}
+/// Default implementation for CacheConfig.
+impl Default for CacheConfig {
+    fn default() -> Self {
+        CacheConfig {
+            enable: default_storage_cache_enable(),
+            capacity: default_storage_cache_capacity(),
+        }
+    }
+}
+
 /// Storage is the storage configuration for dfdaemon.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Storage {
     /// server is the storage server configuration for dfdaemon.
     pub server: StorageServer,
+
+    /// cache is the configuration for the cache.
+    pub cache: CacheConfig,
 
     /// dir is the directory to store task's metadata and content.
     #[serde(default = "crate::default_storage_dir")]
@@ -927,6 +962,7 @@ impl Default for Storage {
     fn default() -> Self {
         Storage {
             server: StorageServer::default(),
+            cache: CacheConfig::default(),
             dir: crate::default_storage_dir(),
             keep: default_storage_keep(),
             write_buffer_size: default_storage_write_buffer_size(),

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -188,7 +188,7 @@ fn default_storage_read_buffer_size() -> usize {
     128 * 1024
 }
 
-/// default_storage_cache_capacity is the default cache capacity for the preheat task, default is
+/// default_storage_cache_capacity is the default cache capacity for the preheat job, default is
 /// 100.
 #[inline]
 fn default_storage_cache_capacity() -> usize {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
**Cache storage**: When a user triggers a preheat task request, the downloaded piece content will be stored in the cache. Subsequently, when other peers request downloading the same content, the preheated peer can upload the piece content directly from memory, bypassing disk I/O and reducing the overhead associated with disk reads.
```yaml
storage:
  # cache_capacity: Specifies the maximum number of entries the cache can hold. The default value is 100 entries.
  # Adjust this value based on the expected number of piece content entries for preheat tasks that need to be cached.
  cache_capacity: 100
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/dragonfly/issues/3742

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
