### PR TITLE
feat: remove crc32 iso3309 from write piece func

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.5.2",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1090,13 +1090,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base16ct",
  "bincode",
  "chrono",
  "crc32c",
- "crc32fast",
  "dragonfly-api",
  "dragonfly-client-config",
  "dragonfly-client-core",
@@ -1116,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1506,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.1" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.1" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.1" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.1" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.1" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.1" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.1" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.2" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.2" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.2" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.2" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.2" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.2" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.2" }
 thiserror = "1.0"
 dragonfly-api = "=2.1.3"
 reqwest = { version = "0.12.4", features = [
@@ -61,7 +61,6 @@ rustls-pki-types = "1.10.1"
 rustls-pemfile = "2.2.0"
 sha2 = "0.10"
 blake3 = "1.5.5"
-crc32fast = "1.4.2"
 crc32c = "0.6.8"
 uuid = { version = "1.11", features = ["v4"] }
 hex = "0.4"

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -23,7 +23,6 @@ prost-wkt-types.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 sha2.workspace = true
-crc32fast.workspace = true
 crc32c.workspace = true
 base16ct.workspace = true
 num_cpus = "1.0"

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -16,10 +16,7 @@
 
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
-use dragonfly_client_core::{
-    error::{ErrorType, OrErr},
-    Error, Result,
-};
+use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::digest::{Algorithm, Digest};
 use reqwest::header::HeaderMap;
 use std::path::Path;
@@ -337,17 +334,10 @@ impl Storage {
         parent_id: &str,
         reader: &mut R,
     ) -> Result<metadata::Piece> {
-        let digest: Digest = expected_digest.parse().or_err(ErrorType::ParseError)?;
-        let response = if digest.is_crc32_iso3309() {
-            // Compatible with the old version.
-            self.content
-                .write_piece_with_crc32_iso3309(task_id, offset, reader)
-                .await?
-        } else {
-            self.content
-                .write_piece_with_crc32_castagnoli(task_id, offset, reader)
-                .await?
-        };
+        let response = self
+            .content
+            .write_piece_with_crc32_castagnoli(task_id, offset, reader)
+            .await?;
 
         let length = response.length;
         let digest = Digest::new(Algorithm::Crc32, response.hash);

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -27,10 +27,10 @@ uuid.workspace = true
 hex.workspace = true
 openssl.workspace = true
 blake3.workspace = true
-crc32fast.workspace = true
 crc32c.workspace = true
 base16ct.workspace = true
 base64 = "0.22.1"
+crc32fast = "1.4.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-util/src/digest/mod.rs
+++ b/dragonfly-client-util/src/digest/mod.rs
@@ -95,16 +95,6 @@ impl Digest {
     pub fn encoded(&self) -> &str {
         &self.encoded
     }
-
-    // is_crc32_iso3309 checks if the crc32 encoded string uses the ISO 3309 polynomial.
-    pub fn is_crc32_iso3309(&self) -> bool {
-        self.algorithm == Algorithm::Crc32 && self.encoded.len() == 8
-    }
-
-    // is_crc32_castagnoli checks if the crc32 encoded string uses the Castagnoli polynomial.
-    pub fn is_crc32_castagnoli(&self) -> bool {
-        self.algorithm == Algorithm::Crc32 && self.encoded.len() == 10
-    }
 }
 
 /// Digest implements the Display.
@@ -234,27 +224,5 @@ mod tests {
         let digest =
             calculate_file_hash(Algorithm::Crc32, path).expect("failed to calculate Sha512 hash");
         assert_eq!(digest.encoded(), expected_crc32);
-    }
-
-    #[test]
-    fn test_is_crc32_iso3309() {
-        let mut hasher = crc32fast::Hasher::new();
-        hasher.update(b"test");
-        let hash = hasher.finalize();
-
-        let digest = Digest::new(
-            Algorithm::Crc32,
-            base16ct::lower::encode_string(&hash.to_be_bytes()),
-        );
-        assert!(digest.is_crc32_iso3309());
-    }
-
-    #[test]
-    fn test_is_crc32_castagnoli() {
-        let crc = crc32c::crc32c(b"test");
-        let encoded = crc.to_string();
-
-        let digest = Digest::new(Algorithm::Crc32, encoded);
-        assert!(digest.is_crc32_castagnoli());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the `dragonfly-client` project, focusing on version updates and the removal of CRC32 ISO 3309 support. The most important changes include updating the version numbers in `Cargo.toml`, removing dependencies and methods related to CRC32 ISO 3309, and simplifying the codebase by eliminating unnecessary checks.

### Version updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated the version of `dragonfly-client` and its dependencies from `0.2.1` to `0.2.2`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Removal of CRC32 ISO 3309 support:
* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL365-L414): Removed the `write_piece_with_crc32_iso3309` method and its associated logic.
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL340-R340): Simplified the `write_piece` method by removing the check for CRC32 ISO 3309 and directly using CRC32 Castagnoli.
* [`dragonfly-client-util/src/digest/mod.rs`](diffhunk://#diff-ea568ae62bf4348b87e881bf2fb475aa5fcdc1ce21df03919e59aa8931847718L98-L107): Removed the `is_crc32_iso3309` and `is_crc32_castagnoli` methods from the `Digest` implementation.

### Dependency cleanup:
* [`dragonfly-client-storage/Cargo.toml`](diffhunk://#diff-646c14b277a6afe2521324f3047193b744dfb61e924e1e1c6a1c71e7d12dd302L26): Removed `crc32fast` from the workspace dependencies.
* [`dragonfly-client-util/Cargo.toml`](diffhunk://#diff-1c96c45400d8ecf785eb0acb8bced3fbd8838ce5882e449bb66aceaf5497021dL30-R33): Removed `crc32fast` from the workspace dependencies and re-added it under regular dependencies.

### Code simplification:
* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL27): Removed the unused import of `InspectReader` from `tokio_util::io`.
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL19-R19): Removed the unused `OrErr` import from `dragonfly_client_core`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
