### PR TITLE
feat: use InspectReader to calculate crc32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.5.2",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.3" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.3" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.3" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.3" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.3" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.3" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.3" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.4" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.4" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.4" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.4" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.4" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.4" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.4" }
 thiserror = "1.0"
 dragonfly-api = "=2.1.3"
 reqwest = { version = "0.12.4", features = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `Cargo.toml` file and improvements to the `dragonfly-client-storage` module. The most important changes include version updates for dependencies and the refactoring of content handling to use `tokio_util::io::InspectReader`.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated the version of the workspace package and dependencies from "0.2.3" to "0.2.4". [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

Content handling improvements:

* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR28): Added `use tokio_util::io::InspectReader` to improve content handling.
* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR341-R356): Refactored the `impl Content` methods to use `InspectReader` for updating CRC32 values and copying content more efficiently. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR341-R356) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR460-R475)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
