### PR TITLE
feat: add max for ratelimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.5.2",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.4" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.4" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.4" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.4" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.4" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.4" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.4" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.5" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.5" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.5" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.5" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.5" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.5" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.5" }
 thiserror = "1.0"
 dragonfly-api = "=2.1.3"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -103,6 +103,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.download.rate_limit.as_u64() as usize)
                     .refill(config.download.rate_limit.as_u64() as usize)
+                    .max(MAX_PIECE_LENGTH as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),
@@ -111,14 +112,18 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.upload.rate_limit.as_u64() as usize)
                     .refill(config.upload.rate_limit.as_u64() as usize)
+                    .max(MAX_PIECE_LENGTH as usize)
                     .interval(Duration::from_secs(1))
+                    .fair(false)
                     .build(),
             ),
             prefetch_rate_limiter: Arc::new(
                 RateLimiter::builder()
                     .initial(config.proxy.prefetch_rate_limit.as_u64() as usize)
                     .refill(config.proxy.prefetch_rate_limit.as_u64() as usize)
+                    .max(MAX_PIECE_LENGTH as usize)
                     .interval(Duration::from_secs(1))
+                    .fair(false)
                     .build(),
             ),
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `Cargo.toml` file and enhancements to the rate limiter configuration in the `dragonfly-client` project. The most important changes include updating the version of the dependencies and adding a maximum limit to the rate limiter.

Version updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated the version of the package from `0.2.4` to `0.2.5`.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31): Updated the version of multiple dependencies from `0.2.4` to `0.2.5`.

Rate limiter enhancements:

* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R106): Added a maximum limit (`max(MAX_PIECE_LENGTH as usize)`) to the rate limiter configuration for download, upload, and prefetch operations. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R106) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R115-R126)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
