### PR TITLE
feat: upload persistent cache task by piece level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.3"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ce0486d3b9c5a8cfa137f9180807d2079aee1b86464d28847e548dc8c3f9c"
+checksum = "4cc74bdb827031beb5d5ab3856a7469790e46bf70a978846d1248b7e30d19706"
 dependencies = [
  "prost 0.13.4",
  "prost-types",
@@ -4589,9 +4589,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4607,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.5
 dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.5" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.5" }
 thiserror = "1.0"
-dragonfly-api = "=2.1.3"
+dragonfly-api = "=2.1.6"
 reqwest = { version = "0.12.4", features = [
     "stream",
     "native-tls",

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -277,10 +277,6 @@ impl ImportCommand {
                 ttl: Some(
                     prost_wkt_types::Duration::try_from(self.ttl).or_err(ErrorType::ParseError)?,
                 ),
-                timeout: Some(
-                    prost_wkt_types::Duration::try_from(self.timeout)
-                        .or_err(ErrorType::ParseError)?,
-                ),
             })
             .await?;
 

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -757,6 +757,7 @@ async fn download(
                 need_piece_content,
                 object_storage,
                 hdfs,
+                load_to_cache: false,
             }),
         })
         .await

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1109,6 +1109,7 @@ fn make_download_task_request(
             hdfs: None,
             is_prefetch: false,
             need_piece_content: false,
+            load_to_cache: false,
         }),
     })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several significant changes to the `dragonfly-client` project, primarily focusing on refactoring and adding new functionalities related to persistent cache tasks. The most important changes include updating dependencies, modifying method signatures and implementations, and adding new methods to handle persistent cache pieces.

### Dependency Updates:
* Updated the version of `dragonfly-api` from `2.1.3` to `2.1.6` in `Cargo.toml`.

### Refactoring and Method Changes:
* Renamed and refactored the `create_persistent_persistent_cache_task` method to `create_persistent_cache_task` in `dragonfly-client-storage/src/lib.rs` and `dragonfly-client-storage/src/metadata.rs`. This change also involved removing the `digest` parameter and related logic. [[1]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL172-R193) [[2]](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L534-L552)
* Added a new method `create_persistent_cache_task_failed` to delete a persistent cache task if its creation fails in `dragonfly-client-storage/src/lib.rs`.
* Added a new method `create_persistent_cache_piece` to handle the creation of persistent cache pieces in `dragonfly-client-storage/src/lib.rs` and `dragonfly-client-storage/src/metadata.rs`. [[1]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR281-R306) [[2]](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9R706-R736)

### Metadata and Struct Changes:
* Removed the `digest` field from the `PersistentCacheTask` struct in `dragonfly-client-storage/src/metadata.rs`.
* Updated the `PersistentCacheTask` struct initialization to exclude the `digest` field in `dragonfly-client/src/resource/persistent_cache_task.rs`.

### gRPC and API Changes:
* Added new gRPC methods `write_persistent_cache_task` and `read_persistent_cache_task` in `dragonfly-client/src/grpc/dfdaemon_download.rs`.
* Removed the calculation of file hash using the `blake3` algorithm from the `upload_persistent_cache_task` method in `dragonfly-client/src/grpc/dfdaemon_download.rs`.

These changes collectively enhance the functionality and maintainability of the `dragonfly-client` project, particularly in handling persistent cache tasks and pieces more effectively.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
