### PR TITLE
bug: Remove download server UDS file on client startup if UDS file al…

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -127,6 +127,11 @@ impl DfdaemonDownloadServer {
 
         // Start download grpc server with unix domain socket.
         fs::create_dir_all(self.socket_path.parent().unwrap()).await?;
+
+        if self.socket_path.is_file() {
+            // Remove the old unix domain socket file if it exists.
+            fs::remove_file(&self.socket_path).await?;
+        }
         let uds = UnixListener::bind(&self.socket_path)?;
         let uds_stream = UnixListenerStream::new(uds);
 


### PR DESCRIPTION
…ready exists...

On dfdaemon startup, check if the UDS file exists. If it does, remove it.

This helps in the cases where dfdaemon process has a non-graceful tear down and the UDS is mounted on hostpath. When dfdaemon restarts, it will never be able to bind to the UDS. Update the start up to check and delete the UDS if it exists...

## Description

<!--- Describe your changes in detail -->
^

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/dragonfly/issues/3782

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allows us to gracefully handle unexpected restarts.

## Screenshots (if appropriate)
