### PR TITLE
fix: the maximum download speed is less than 16M/s in v0.2.5 client

### DIFF
--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -103,7 +103,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.download.rate_limit.as_u64() as usize)
                     .refill(config.download.rate_limit.as_u64() as usize)
-                    .max(MAX_PIECE_LENGTH as usize)
+                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),
@@ -112,7 +112,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.upload.rate_limit.as_u64() as usize)
                     .refill(config.upload.rate_limit.as_u64() as usize)
-                    .max(MAX_PIECE_LENGTH as usize)
+                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),
@@ -121,7 +121,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.proxy.prefetch_rate_limit.as_u64() as usize)
                     .refill(config.proxy.prefetch_rate_limit.as_u64() as usize)
-                    .max(MAX_PIECE_LENGTH as usize)
+                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),


### PR DESCRIPTION
This pull request includes changes to the `RateLimiter` configuration in the `Piece` implementation within the `dragonfly-client` project. The primary change involves adjusting the maximum limit for rate limiting by incorporating the `MAX_PIECE_COUNT` constant.

Changes to rate limiting configuration:

* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L106-R106): Updated the `max` parameter in the `RateLimiter` builder for download, upload, and proxy prefetch rate limits to use `(MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize` instead of `MAX_PIECE_LENGTH as usize`. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L106-R106) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L115-R115) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L124-R124)