### PR TITLE
feat: set max of the RateLimiter to the rate limit in config

### DIFF
--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -103,7 +103,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.download.rate_limit.as_u64() as usize)
                     .refill(config.download.rate_limit.as_u64() as usize)
-                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
+                    .max(config.download.rate_limit.as_u64() as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),
@@ -112,7 +112,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.upload.rate_limit.as_u64() as usize)
                     .refill(config.upload.rate_limit.as_u64() as usize)
-                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
+                    .max(config.upload.rate_limit.as_u64() as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),
@@ -121,7 +121,7 @@ impl Piece {
                 RateLimiter::builder()
                     .initial(config.proxy.prefetch_rate_limit.as_u64() as usize)
                     .refill(config.proxy.prefetch_rate_limit.as_u64() as usize)
-                    .max((MAX_PIECE_LENGTH * MAX_PIECE_COUNT) as usize)
+                    .max(config.proxy.prefetch_rate_limit.as_u64() as usize)
                     .interval(Duration::from_secs(1))
                     .fair(false)
                     .build(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes modifications to the rate limiter configuration in the `dragonfly-client/src/resource/piece.rs` file. The changes aim to make the rate limiter's maximum value configurable based on the provided configuration rather than using hardcoded constants.

Rate limiter configuration changes:

* Updated the download rate limiter to use `config.download.rate_limit` for the maximum value instead of hardcoded constants.
* Updated the upload rate limiter to use `config.upload.rate_limit` for the maximum value instead of hardcoded constants.
* Updated the proxy prefetch rate limiter to use `config.proxy.prefetch_rate_limit` for the maximum value instead of hardcoded constants.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
