### PR TITLE
feat: add iperf3 for Dockerfile and change is_expired for PersistentCacheTask

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -54,7 +54,7 @@ RUN go install github.com/google/pprof@latest
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget curl \
+RUN apt-get update && apt-get install -y --no-install-recommends iperf3 wget curl \
     bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools \
     dnsutils iputils-ping vim linux-perf llvm graphviz \
     && rm -rf /var/lib/apt/lists/*

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -185,10 +185,7 @@ impl PersistentCacheTask {
 
     /// is_expired returns whether the persistent cache task is expired.
     pub fn is_expired(&self) -> bool {
-        // When scheduler runs garbage collection, it will trigger dfdaemon to evict the persistent cache task.
-        // But sometimes the dfdaemon may not evict the persistent cache task in time, so we select the ttl * 1.2
-        // as the expired time to force evict the persistent cache task.
-        self.created_at + self.ttl * 2 < Utc::now().naive_utc()
+        self.created_at + self.ttl < Utc::now().naive_utc()
     }
 
     /// is_failed returns whether the persistent cache task downloads failed.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `ci/Dockerfile` and the `dragonfly-client-storage/src/metadata.rs` file. The most important changes are the addition of a new package to the Dockerfile and the simplification of the expiration logic in the `PersistentCacheTask` implementation.

### Dockerfile Update:
* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL57-R57): Added `iperf3` to the list of packages installed during the Docker image build process. This addition ensures that `iperf3` is available in the Docker image for network performance testing.

### PersistentCacheTask Logic Simplification:
* [`dragonfly-client-storage/src/metadata.rs`](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L188-R188): Simplified the expiration check in the `is_expired` method of the `PersistentCacheTask` struct by removing the additional time buffer previously used to force eviction. Now, the task is considered expired strictly based on the `ttl` value.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
