### PR TITLE
feat: calculate digest of the persistent cache piece to check the integrity of the metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.25"
+version = "2.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303e4462081b03a42316ec8569d9ce5fc6a220a4489d2029bf6120311a9dd2a8"
+checksum = "eb145fdba5fa39c2506f2f85baa8157b8703add719b329e35ab4337cf5635ce7"
 dependencies = [
  "prost 0.13.4",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.1
 dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.11" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.11" }
 thiserror = "1.0"
-dragonfly-api = "=2.1.25"
+dragonfly-api = "=2.1.27"
 reqwest = { version = "0.12.4", features = [
     "stream",
     "native-tls",

--- a/dragonfly-client-util/src/digest/mod.rs
+++ b/dragonfly-client-util/src/digest/mod.rs
@@ -129,7 +129,7 @@ impl FromStr for Digest {
     }
 }
 
-/// calculate_file_hash calculates the hash of a file.
+/// calculate_file_digest calculates the digest of a file.
 #[instrument(skip_all)]
 pub fn calculate_file_digest(algorithm: Algorithm, path: &Path) -> ClientResult<Digest> {
     let f = std::fs::File::open(path)?;

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -882,6 +882,8 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                 cost: None,
                 created_at: None,
             }),
+            // Calculate the digest of the piece metadata, including the number, offset, length and
+            // content digest. The digest is used to verify the integrity of the piece metadata.
             digest: Some(piece.calculate_digest()),
         }))
     }
@@ -1409,15 +1411,18 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         Ok(Response::new(DownloadPersistentCachePieceResponse {
             piece: Some(Piece {
                 number: piece.number,
-                parent_id: piece.parent_id,
+                parent_id: piece.parent_id.clone(),
                 offset: piece.offset,
                 length: piece.length,
-                digest: piece.digest,
+                digest: piece.digest.clone(),
                 content: Some(content),
                 traffic_type: None,
                 cost: None,
                 created_at: None,
             }),
+            // Calculate the digest of the piece metadata, including the number, offset, length and
+            // content digest. The digest is used to verify the integrity of the piece metadata.
+            digest: Some(piece.calculate_digest()),
         }))
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to improve the calculation and verification of piece metadata digests in the `dragonfly-client` project. The key changes involve updating the `calculate_digest` method, ensuring the integrity of piece metadata, and updating dependencies.

### Digest Calculation and Verification:

* [`dragonfly-client-storage/src/metadata.rs`](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L306-R318): Enhanced the `calculate_digest` method to include additional metadata fields and ensure the integrity of piece metadata.
* [`dragonfly-client/src/grpc/dfdaemon_upload.rs`](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R885-R886): Added digest calculation and verification in the `DfdaemonUpload` implementation to ensure the integrity of piece metadata. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R885-R886) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1423-R1425)
* [`dragonfly-client/src/resource/piece_downloader.rs`](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R124-L146): Added digest calculation and comparison to verify the integrity of piece metadata in the `Downloader` implementation. [[1]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R124-L146) [[2]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R183-R202)

### Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L33-R33): Updated the `dragonfly-api` dependency version from `2.1.25` to `2.1.27`.

### Documentation Updates:

* [`dragonfly-client-util/src/digest/mod.rs`](diffhunk://#diff-ea568ae62bf4348b87e881bf2fb475aa5fcdc1ce21df03919e59aa8931847718L132-R132): Updated the documentation for the `calculate_file_digest` function to reflect the correct terminology.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3811
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
