### PR TITLE
feat: add concurrency limit for grpc server

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -60,6 +60,12 @@ pub fn default_download_unix_socket_path() -> PathBuf {
     crate::default_root_dir().join("dfdaemon.sock")
 }
 
+/// default_download_request_rate_limit is the default rate limit of the download request in the
+/// download grpc server, default is 4000 req/s.
+pub fn default_download_request_rate_limit() -> u64 {
+    4000
+}
+
 /// default_parent_selector_sync_interval is the default interval to sync host information.
 #[inline]
 fn default_parent_selector_sync_interval() -> Duration {
@@ -93,6 +99,12 @@ fn default_dfdaemon_cache_dir() -> PathBuf {
 /// default_upload_grpc_server_port is the default port of the upload gRPC server.
 #[inline]
 fn default_upload_grpc_server_port() -> u16 {
+    4000
+}
+
+/// default_upload_request_rate_limit is the default rate limit of the upload request in the
+/// upload grpc server, default is 4000 req/s.
+pub fn default_upload_request_rate_limit() -> u64 {
     4000
 }
 
@@ -426,6 +438,11 @@ pub struct DownloadServer {
     /// socket_path is the unix socket path for dfdaemon gRPC service.
     #[serde(default = "default_download_unix_socket_path")]
     pub socket_path: PathBuf,
+
+    /// request_rate_limit is the rate limit of the download request in the download grpc server,
+    /// default is 4000 req/s.
+    #[serde(default = "default_download_request_rate_limit")]
+    pub request_rate_limit: u64,
 }
 
 /// DownloadServer implements Default.
@@ -433,6 +450,7 @@ impl Default for DownloadServer {
     fn default() -> Self {
         DownloadServer {
             socket_path: default_download_unix_socket_path(),
+            request_rate_limit: default_download_request_rate_limit(),
         }
     }
 }
@@ -496,6 +514,11 @@ pub struct UploadServer {
     /// key is the server key path with PEM format for the upload server and it is used for
     /// mutual TLS.
     pub key: Option<PathBuf>,
+
+    /// request_rate_limit is the rate limit of the upload request in the upload grpc server,
+    /// default is 4000 req/s.
+    #[serde(default = "default_upload_request_rate_limit")]
+    pub request_rate_limit: u64,
 }
 
 /// UploadServer implements Default.
@@ -507,6 +530,7 @@ impl Default for UploadServer {
             ca_cert: None,
             cert: None,
             key: None,
+            request_rate_limit: default_upload_request_rate_limit(),
         }
     }
 }

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -79,7 +79,7 @@ prometheus = { version = "0.13", features = ["process"] }
 tonic-health = "0.12.3"
 bytes = "1.10"
 sysinfo = "0.32.1"
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["limit", "load-shed", "buffer"] }
 indicatif = "0.17.11"
 dashmap = "6.1.0"
 hashring = "0.3.6"

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -292,6 +292,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Initialize download grpc server.
     let mut dfdaemon_download_grpc = DfdaemonDownloadServer::new(
+        config.clone(),
         config.download.server.socket_path.clone(),
         task.clone(),
         persistent_cache_task.clone(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces new rate limiting features for the download and upload gRPC servers in the `dragonfly-client-config` and makes associated updates to the `dragonfly-client` codebase. The most important changes include adding default rate limits, updating server structures to include these limits, and incorporating the `ServiceBuilder` to apply concurrency limits and load shedding.

### Rate Limiting Features:

* [`dragonfly-client-config/src/dfdaemon.rs`](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR63-R68): Added functions `default_download_request_rate_limit` and `default_upload_request_rate_limit` to define default rate limits for download and upload requests. Updated `DownloadServer` and `UploadServer` structs to include `request_rate_limit` fields with default values. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR63-R68) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR105-R110) [[3]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR441-R453) [[4]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR517-R521) [[5]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR533)

### Dependency Updates:

* [`dragonfly-client/Cargo.toml`](diffhunk://#diff-651fbc571d827abadd8e14ed21f83bc11941b8733f2d9704b93ae13b4dbfbb31L82-R82): Updated the `tower` dependency to include additional features: `limit`, `load-shed`, and `buffer`.

### Codebase Updates:

* [`dragonfly-client/src/grpc/dfdaemon_download.rs`](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR39): Modified `DfdaemonDownloadServer` to include the `config` field, and used `ServiceBuilder` to apply concurrency limits and load shedding in the gRPC server setup. [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR39) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL59-R69) [[3]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR88) [[4]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR105) [[5]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR139-R157)
* [`dragonfly-client/src/grpc/dfdaemon_upload.rs`](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R58): Incorporated `ServiceBuilder` to apply concurrency limits and load shedding in the gRPC server setup for the upload server. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R58) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R131-R137) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R154)
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3811
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
