### PR TITLE
test(dragonfly-client-storage): add test case for has_enough_space

### DIFF
--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -653,7 +653,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn should_calculate_piece_range() {
+    async fn test_calculate_piece_range() {
         let test_cases = vec![
             (1, 4, None, 1, 4),
             (
@@ -724,5 +724,18 @@ mod tests {
             assert_eq!(target_offset, expected_offset);
             assert_eq!(target_length, expected_length);
         }
+    }
+
+    #[tokio::test]
+    async fn test_has_enough_space() {
+        let config = Arc::new(Config::default());
+        let dir = PathBuf::from("/tmp/dragonfly_test");
+        let content = Content::new(config, &dir).await.unwrap();
+
+        let has_space = content.has_enough_space(1).unwrap();
+        assert!(has_space);
+
+        let has_space = content.has_enough_space(u64::MAX).unwrap();
+        assert!(!has_space);
     }
 }

--- a/dragonfly-client/src/proxy/cache.rs
+++ b/dragonfly-client/src/proxy/cache.rs
@@ -152,7 +152,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn should_calculate_piece_range() {
+    async fn test_calculate_piece_range() {
         let test_cases = vec![
             (1, 4, None, 0, 4),
             (

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -925,7 +925,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
-    async fn should_calculate_interested() {
+    async fn test_calculate_interested() {
         let temp_dir = tempdir().unwrap();
 
         let config = Config::default();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several updates to test functions in the `dragonfly-client-storage` and `dragonfly-client` modules. The changes primarily involve renaming test functions for consistency and adding new tests.

Test function updates:

* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL656-R656): Renamed `should_calculate_piece_range` to `test_calculate_piece_range` for consistency.
* [`dragonfly-client/src/proxy/cache.rs`](diffhunk://#diff-fe6d2a7cd174669b339e84d9662fd7b5e8af3ac35a7bc0a4e780f811d63dec95L155-R155): Renamed `should_calculate_piece_range` to `test_calculate_piece_range` for consistency.
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L928-R928): Renamed `should_calculate_interested` to `test_calculate_interested` for consistency.

New test addition:

* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdR728-R740): Added a new test function `test_has_enough_space` to verify if there is enough space available.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
