### PR TITLE
feat: add piece length for calculating task id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,11 +923,11 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.27"
+version = "2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb145fdba5fa39c2506f2f85baa8157b8703add719b329e35ab4337cf5635ce7"
+checksum = "4a81cbf95fbfad7eb333dcde1ce5b17c67642a86d42e3360eaaa382fae079edb"
 dependencies = [
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-types",
  "prost-wkt-types",
  "serde",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
@@ -3259,12 +3259,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.4",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -3281,7 +3281,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-types",
  "regex",
  "syn 2.0.90",
@@ -3303,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3320,7 +3320,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost 0.13.4",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -3331,7 +3331,7 @@ checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
 dependencies = [
  "chrono",
  "inventory",
- "prost 0.13.4",
+ "prost 0.13.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3345,7 +3345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
  "heck",
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-build",
  "prost-types",
  "quote",
@@ -3358,7 +3358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
 dependencies = [
  "chrono",
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-build",
  "prost-types",
  "prost-wkt",
@@ -4750,7 +4750,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.4",
+ "prost 0.13.5",
  "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
@@ -4782,7 +4782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
- "prost 0.13.4",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4794,7 +4794,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost 0.13.4",
+ "prost 0.13.5",
  "prost-types",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,15 +22,15 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.12" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.12" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.12" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.12" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.12" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.12" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.12" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.13" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.13" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.13" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.13" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.13" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.13" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.13" }
 thiserror = "1.0"
-dragonfly-api = "=2.1.27"
+dragonfly-api = "=2.1.28"
 reqwest = { version = "0.12.4", features = [
     "stream",
     "native-tls",

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
+use crc::*;
 use dragonfly_api::common::v2::TaskType;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Result,
 };
 use sha2::{Digest, Sha256};
-use std::hash::Hasher;
 use std::io::Read;
 use std::path::PathBuf;
 use tracing::instrument;
 use url::Url;
 use uuid::Uuid;
-use wyhash::WyHash;
 
 /// SEED_PEER_SUFFIX is the suffix of the seed peer.
 const SEED_PEER_SUFFIX: &str = "seed";
@@ -76,6 +75,7 @@ impl IDGenerator {
     pub fn task_id(
         &self,
         url: &str,
+        piece_length: Option<u64>,
         tag: Option<&str>,
         application: Option<&str>,
         filtered_query_params: Vec<String>,
@@ -116,6 +116,11 @@ impl IDGenerator {
             hasher.update(application);
         }
 
+        // Add the piece length to generate the task id.
+        if let Some(piece_length) = piece_length {
+            hasher.update(piece_length.to_string());
+        }
+
         // Generate the task id.
         Ok(hex::encode(hasher.finalize()))
     }
@@ -126,6 +131,7 @@ impl IDGenerator {
     pub fn persistent_cache_task_id(
         &self,
         path: &PathBuf,
+        piece_length: Option<u64>,
         tag: Option<&str>,
         application: Option<&str>,
     ) -> Result<String> {
@@ -133,35 +139,34 @@ impl IDGenerator {
         let f = std::fs::File::open(path)?;
         let mut buffer = [0; 4096];
         let mut reader = std::io::BufReader::with_capacity(buffer.len(), f);
-        let mut hasher = WyHash::default();
+        let crc = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
+        let mut digest = crc.digest();
         loop {
             let n = reader.read(&mut buffer)?;
             if n == 0 {
                 break;
             }
 
-            hasher.write(&buffer[..n]);
+            digest.update(&buffer[..n]);
         }
 
         // Add the tag to generate the persistent cache task id.
         if let Some(tag) = tag {
-            hasher.write(tag.as_bytes());
+            digest.update(tag.as_bytes());
         }
 
         // Add the application to generate the persistent cache task id.
         if let Some(application) = application {
-            hasher.write(application.as_bytes());
+            digest.update(application.as_bytes());
         }
 
-        // Generate the task id by wyhash.
-        let id = hasher.finish().to_string();
+        // Add the piece length to generate the persistent cache task id.
+        if let Some(piece_length) = piece_length {
+            digest.update(piece_length.to_string().as_bytes());
+        }
 
-        // Generate the persistent cache task ID. The original ID is too short, so we calculate the SHA-256
-        // hash to ensure it can be prefix-searched by the storage engine.
-        let mut hasher = Sha256::new();
-        hasher.update(id);
-
-        Ok(hex::encode(hasher.finalize()))
+        // Generate the task id by crc32.
+        Ok(digest.finalize().to_string())
     }
 
     /// peer_id generates the peer id.
@@ -223,6 +228,16 @@ mod tests {
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "https://example.com",
+                Some(1024_u64),
+                Some("foo"),
+                Some("bar"),
+                vec![],
+                "99a47b38e9d3321aebebd715bea0483c1400cef2f767f84d97458f9dcedff221",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                "https://example.com",
+                None,
                 Some("foo"),
                 Some("bar"),
                 vec![],
@@ -231,6 +246,7 @@ mod tests {
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "https://example.com",
+                None,
                 Some("foo"),
                 None,
                 vec![],
@@ -240,13 +256,24 @@ mod tests {
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "https://example.com",
                 None,
+                None,
                 Some("bar"),
                 vec![],
                 "63dee2822037636b0109876b58e95692233840753a882afa69b9b5ee82a6c57d",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                "https://example.com",
+                Some(1024_u64),
+                None,
+                None,
+                vec![],
+                "40c21de3ad2f1470ca1a19a2ad2577803a1829851f6cf862ffa2d4577ae51d38",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "https://example.com?foo=foo&bar=bar",
+                None,
                 None,
                 None,
                 vec!["foo".to_string(), "bar".to_string()],
@@ -254,9 +281,11 @@ mod tests {
             ),
         ];
 
-        for (generator, url, tag, application, filtered_query_params, expected_id) in test_cases {
+        for (generator, url, piece_length, tag, application, filtered_query_params, expected_id) in
+            test_cases
+        {
             let task_id = generator
-                .task_id(url, tag, application, filtered_query_params)
+                .task_id(url, piece_length, tag, application, filtered_query_params)
                 .unwrap();
             assert_eq!(task_id, expected_id);
         }
@@ -268,34 +297,45 @@ mod tests {
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "This is a test file",
+                Some(1024_u64),
                 Some("tag1"),
                 Some("app1"),
-                "ed401a8aa6b9a47b426d2aa01245127d9ac2d1b7974ca866719da59b5456ac4d",
+                "1692841488",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "This is a test file",
                 None,
+                None,
                 Some("app1"),
-                "4cbb2c5142f609e98a7d9a887c6404c7432475a52d6c64c52d543b5614a99c63",
+                "1232797642",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 "This is a test file",
+                None,
                 Some("tag1"),
                 None,
-                "65094f31f9997904f779a27ed0d1ce460c9c4082f214e7626a179f2ea491d34e",
+                "2519859852",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                "This is a test file",
+                Some(1024_u64),
+                None,
+                None,
+                "561935167",
             ),
         ];
 
-        for (generator, file_content, tag, application, expected_id) in test_cases {
+        for (generator, file_content, piece_length, tag, application, expected_id) in test_cases {
             let dir = tempdir().unwrap();
             let file_path = dir.path().join("testfile");
             let mut f = File::create(&file_path).unwrap();
             f.write_all(file_content.as_bytes()).unwrap();
 
             let task_id = generator
-                .persistent_cache_task_id(&file_path, tag, application)
+                .persistent_cache_task_id(&file_path, piece_length, tag, application)
                 .unwrap();
             assert_eq!(task_id, expected_id);
         }

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+use bytesize::ByteSize;
 use clap::Parser;
 use dragonfly_api::dfdaemon::v2::UploadPersistentCacheTaskRequest;
+use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
 use dragonfly_client_config::dfcache::default_dfcache_persistent_replica_count;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -54,9 +56,16 @@ pub struct ImportCommand {
     persistent_replica_count: u64,
 
     #[arg(
+        long = "piece-length",
+        required = false,
+        help = "Specify the piece length for downloading file. If the piece length is not specified, the piece length will be calculated according to the file size. Different piece lengths will be divided into different persistent cache tasks. The value needs to be set with human readable format and needs to be greater than or equal to 4mib, for example: 4mib, 1gib"
+    )]
+    piece_length: Option<ByteSize>,
+
+    #[arg(
         long = "application",
         required = false,
-        help = "Caller application which is used for statistics and access control"
+        help = "Different applications for the same url will be divided into different persistent cache tasks"
     )]
     application: Option<String>,
 
@@ -338,6 +347,7 @@ impl ImportCommand {
                 persistent_replica_count: self.persistent_replica_count,
                 tag: self.tag.clone(),
                 application: self.application.clone(),
+                piece_length: self.piece_length.map(|piece_length| piece_length.as_u64()),
                 ttl: Some(
                     prost_wkt_types::Duration::try_from(self.ttl).or_err(ErrorType::ParseError)?,
                 ),
@@ -384,6 +394,16 @@ impl ImportCommand {
                 "path {} does not exist",
                 self.path.display()
             )));
+        }
+
+        if let Some(piece_length) = self.piece_length {
+            if piece_length.as_u64() < MIN_PIECE_LENGTH {
+                return Err(Error::ValidationError(format!(
+                    "piece length {} bytes is less than the minimum piece length {} bytes",
+                    piece_length.as_u64(),
+                    MIN_PIECE_LENGTH
+                )));
+            }
         }
 
         Ok(())

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -234,6 +234,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             .id_generator
             .task_id(
                 download.url.as_str(),
+                download.piece_length,
                 download.tag.as_deref(),
                 download.application.as_deref(),
                 download.filtered_query_params.clone(),
@@ -902,6 +903,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 .id_generator
                 .persistent_cache_task_id(
                     &path.to_path_buf(),
+                    request.piece_length,
                     request.tag.as_deref(),
                     request.application.as_deref(),
                 )

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -223,6 +223,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             .id_generator
             .task_id(
                 download.url.as_str(),
+                download.piece_length,
                 download.tag.as_deref(),
                 download.application.as_deref(),
                 download.filtered_query_params.clone(),

--- a/dragonfly-client/src/proxy/cache.rs
+++ b/dragonfly-client/src/proxy/cache.rs
@@ -54,6 +54,7 @@ impl Cache {
 
         let task_id = self.task.id_generator.task_id(
             &download.url,
+            download.piece_length,
             download.tag.as_deref(),
             download.application.as_deref(),
             download.filtered_query_params.clone(),

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -137,10 +137,17 @@ impl PersistentCacheTask {
             .len();
 
         // Get the piece length of the file.
-        let piece_length = self.piece.calculate_piece_length(
-            piece::PieceLengthStrategy::OptimizeByFileLength,
-            content_length,
-        );
+        let piece_length = match request.piece_length {
+            Some(piece_length) => self
+                .piece
+                .calculate_piece_length(piece::PieceLengthStrategy::FixedPieceLength(piece_length)),
+            None => {
+                self.piece
+                    .calculate_piece_length(piece::PieceLengthStrategy::OptimizeByFileLength(
+                        content_length,
+                    ))
+            }
+        };
 
         // Notify the scheduler that the persistent cache task is started.
         match self

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -201,10 +201,17 @@ impl Task {
             None => return Err(Error::InvalidContentLength),
         };
 
-        let piece_length = self.piece.calculate_piece_length(
-            piece::PieceLengthStrategy::OptimizeByFileLength,
-            content_length,
-        );
+        let piece_length = match request.piece_length {
+            Some(piece_length) => self
+                .piece
+                .calculate_piece_length(piece::PieceLengthStrategy::FixedPieceLength(piece_length)),
+            None => {
+                self.piece
+                    .calculate_piece_length(piece::PieceLengthStrategy::OptimizeByFileLength(
+                        content_length,
+                    ))
+            }
+        };
 
         // If the task is not finished, check if the storage has enough space to
         // store the task.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several updates and improvements to the `dragonfly-client` project, mainly focusing on the introduction of piece length handling for task IDs and cache tasks, as well as some dependency updates and refactoring.

### Dependency Updates:
* Updated the version of `dragonfly-client` and related dependencies from `0.2.12` to `0.2.13` in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R33)
* Updated the `dragonfly-api` dependency from `2.1.27` to `2.1.28` in `Cargo.toml`.

### Piece Length Handling:
* Added `piece_length` parameter to `IDGenerator` methods (`task_id` and `persistent_cache_task_id`) to include piece length in the task ID generation. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R78) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R119-R123) [[3]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R134-R169)
* Updated tests for `IDGenerator` to include scenarios with and without `piece_length`. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R231-R240) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R249) [[3]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R259-R288) [[4]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R300-R338)
* Modified `DfdaemonDownloadServerHandler` and `DfdaemonUploadServerHandler` to pass `piece_length` to `task_id` and `persistent_cache_task_id` methods. [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR237) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR906) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R226)
* Added `piece_length` handling in the `Cache` implementation.

### Header and Validation:
* Introduced a new header `X-Dragonfly-Piece-Length` to specify piece length in HTTP requests.
* Added a function to retrieve piece length from HTTP headers and included validation to ensure the piece length meets the minimum requirement. [[1]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccR173-R192) [[2]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccR310-R325) [[3]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR1095-R1105) [[4]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL1110-R1121)

### Piece Length Strategy:
* Refactored `PieceLengthStrategy` to include a fixed piece length option and updated the `calculate_piece_length` method accordingly. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L140-R150) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L42-R56) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L300-R305)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
