### PR TITLE
feat: cleaning up Unix Domain Sockets to avoid crashes

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -131,10 +131,11 @@ impl DfdaemonDownloadServer {
 
         // Start download grpc server with unix domain socket.
         fs::create_dir_all(self.socket_path.parent().unwrap()).await?;
-        if self.socket_path.is_file() {
-            // Remove the old unix domain socket file if it exists.
-            fs::remove_file(&self.socket_path).await?;
-        }
+        fs::remove_file(self.socket_path.clone())
+            .await
+            .unwrap_or_else(|err| {
+                info!("remove {:?} failed: {}", self.socket_path, err);
+            });
 
         // Bind the unix domain socket and set the permissions for the socket.
         let uds = UnixListener::bind(&self.socket_path)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a change to the `DfdaemonDownloadServer` implementation in the `dragonfly-client` project to improve error handling when removing an old Unix domain socket file.

Error handling improvement:

* [`dragonfly-client/src/grpc/dfdaemon_download.rs`](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL134-R138): Modified the code to handle errors gracefully when removing an old Unix domain socket file by using `unwrap_or_else` to log an informational message if the removal fails.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
