### PR TITLE
chore(release): set toolchain to 1.82.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Install dependencies
         run: |
@@ -163,3 +165,4 @@ jobs:
         with:
            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
            ignore-unpublished-changes: true
+           args: --locked

--- a/dragonfly-client-storage/src/storage_engine/mod.rs
+++ b/dragonfly-client-storage/src/storage_engine/mod.rs
@@ -65,6 +65,7 @@ pub trait Operations {
     fn iter<O: DatabaseObject>(&self) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>>;
 
     /// iter_raw iterates all objects without serialization.
+    #[allow(clippy::type_complexity)]
     fn iter_raw<O: DatabaseObject>(
         &self,
     ) -> Result<impl Iterator<Item = Result<(Box<[u8]>, Box<[u8]>)>>>;
@@ -76,6 +77,7 @@ pub trait Operations {
     ) -> Result<impl Iterator<Item = Result<(Box<[u8]>, O)>>>;
 
     /// prefix_iter_raw iterates all objects with prefix without serialization.
+    #[allow(clippy::type_complexity)]
     fn prefix_iter_raw<O: DatabaseObject>(
         &self,
         prefix: &[u8],

--- a/dragonfly-client-storage/src/storage_engine/rocksdb.rs
+++ b/dragonfly-client-storage/src/storage_engine/rocksdb.rs
@@ -246,7 +246,7 @@ impl Operations for RocksdbStorageEngine {
 }
 
 /// RocksdbStorageEngine implements the rocksdb of the storage engine.
-impl<'db> StorageEngine<'db> for RocksdbStorageEngine {}
+impl StorageEngine<'_> for RocksdbStorageEngine {}
 
 /// cf_handle returns the column family handle for the given object.
 fn cf_handle<T>(db: &rocksdb::DB) -> Result<&rocksdb::ColumnFamily>

--- a/dragonfly-client/src/grpc/interceptor.rs
+++ b/dragonfly-client/src/grpc/interceptor.rs
@@ -21,7 +21,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 struct MetadataMap<'a>(&'a mut metadata::MetadataMap);
 
 /// MetadataMap implements the otel tracing Injector.
-impl<'a> opentelemetry::propagation::Injector for MetadataMap<'a> {
+impl opentelemetry::propagation::Injector for MetadataMap<'_> {
     /// set a key-value pair to the injector.
     fn set(&mut self, key: &str, value: String) {
         if let Ok(key) = metadata::MetadataKey::from_bytes(key.as_bytes()) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a small change to the `.github/workflows/release.yml` file. The change specifies the Rust toolchain version to be installed during the release workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R156-R157): Added the `toolchain` parameter with the value `1.82.0` to the Rust installation step.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
