### PR TITLE
feat(dragonfly-client/proxy): remove finished_piece_readers when copy finished

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -919,6 +919,7 @@ async fn proxy_via_dfdaemon(
                                     }
                                 };
 
+                                finished_piece_readers.remove(&need_piece_number);
                                 need_piece_number += 1;
                             }
                         } else {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
This pull request includes a small change to the `async fn proxy_via_dfdaemon` function in the `dragonfly-client/src/proxy/mod.rs` file. The change removes the `finished_piece_readers` entry for the current `need_piece_number` after it has been processed. 

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR922): Added a line to remove the `finished_piece_readers` entry for the current `need_piece_number` after processing.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
