### PR TITLE
chore(workflows/docker.yaml): add debug suffix for trivy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run Trivy vulnerability scanner in tarball mode
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0
         with:
-          image-ref: dragonflyoss/client:${{ steps.get_version.outputs.VERSION }}
+          image-ref: dragonflyoss/client:${{ steps.get_version.outputs.VERSION }}-debug
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           output: 'trivy-results.sarif'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a minor change to the `.github/workflows/docker.yml` file. The change updates the `image-ref` parameter for the Trivy vulnerability scanner to use a debug version of the image.

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L186-R186): Updated `image-ref` parameter to `dragonflyoss/client:${{ steps.get_version.outputs.VERSION }}-debug` for the Trivy vulnerability scanner.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
