### PR TITLE
feat(dragonfly-client/proxy): eliminate potential memory leak in piece reader handling

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -766,7 +766,7 @@ async fn proxy_via_dfdaemon(
     };
 
     // Write the task data to the reader.
-    let (reader, mut writer) = tokio::io::duplex(256 * 1024);
+    let (reader, mut writer) = tokio::io::duplex(512 * 1024);
 
     // Write the status code to the writer.
     let (sender, mut receiver) = mpsc::channel(10 * 1024);
@@ -873,10 +873,8 @@ async fn proxy_via_dfdaemon(
                             // in the cache.
                             finished_piece_readers
                                 .insert(piece.number, (piece_range_reader, piece_reader));
-                            while let Some((mut piece_range_reader, piece_reader)) =
-                                finished_piece_readers
-                                    .get_mut(&need_piece_number)
-                                    .map(|(range_reader, reader)| (range_reader, reader))
+                            while let Some((mut piece_range_reader, mut piece_reader)) =
+                                finished_piece_readers.remove(&need_piece_number)
                             {
                                 debug!("copy piece {} to stream", need_piece_number);
                                 if let Err(err) =
@@ -919,7 +917,6 @@ async fn proxy_via_dfdaemon(
                                     }
                                 };
 
-                                finished_piece_readers.remove(&need_piece_number);
                                 need_piece_number += 1;
                             }
                         } else {


### PR DESCRIPTION
This pull request includes several changes to the `async fn proxy_via_dfdaemon` function in the `dragonfly-client/src/proxy/mod.rs` file. The changes focus on improving the efficiency and correctness of the proxy function.

### Efficiency Improvements:
* Increased the buffer size for the `tokio::io::duplex` from 256 KB to 512 KB to enhance data throughput.

### Correctness Improvements:
* Modified the loop to remove the `piece_reader` from `finished_piece_readers` when it is being processed, ensuring that each piece is only processed once.
* Removed redundant `finished_piece_readers.remove(&need_piece_number)` call since the reader is already removed within the loop condition.
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
