### PR TITLE
fix(dragonfly-client/resource/piece_collector.rs): remove download piece number

### DIFF
--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -56,7 +56,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio wget curl \
     iotop bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools \
-    dnsutils iputils-ping vim linux-perf llvm graphviz \
+    dnsutils iputils-ping vim linux-perf llvm graphviz lsof socat strace \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/client/target/debug/dfget /usr/local/bin/dfget

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -32,7 +32,7 @@ pub mod manager;
 pub mod scheduler;
 
 /// CONNECT_TIMEOUT is the timeout for GRPC connection.
-pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// REQUEST_TIMEOUT is the timeout for GRPC requests.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -104,7 +104,8 @@ impl Downloader for GRPCDownloader {
         task_id: &str,
     ) -> Result<(Vec<u8>, u64, String)> {
         let dfdaemon_upload_client =
-            DfdaemonUploadClient::new(self.config.clone(), format!("http://{}", addr)).await?;
+            DfdaemonUploadClient::new(self.config.clone(), format!("http://{}", addr), true)
+                .await?;
 
         let response = dfdaemon_upload_client
             .download_piece(
@@ -159,7 +160,8 @@ impl Downloader for GRPCDownloader {
         task_id: &str,
     ) -> Result<(Vec<u8>, u64, String)> {
         let dfdaemon_upload_client =
-            DfdaemonUploadClient::new(self.config.clone(), format!("http://{}", addr)).await?;
+            DfdaemonUploadClient::new(self.config.clone(), format!("http://{}", addr), true)
+                .await?;
 
         let response = dfdaemon_upload_client
             .download_persistent_cache_piece(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes multiple changes to the `dragonfly-client` and `ci/Dockerfile.debug` to enhance functionality and improve performance. The most important changes are summarized below:

### Enhancements to `DfdaemonUploadClient`:

* Added a new parameter `is_download_piece` to the `DfdaemonUploadClient::new` method, allowing the client to use different timeouts based on the type of request. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1447-R1451) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1460-R1467) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1468-R1480) [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1483-R1495)

### Timeout and Buffer Size Adjustments:

* Increased the GRPC connection timeout from 2 seconds to 3 seconds.
* Increased the buffer size for the `PieceCollector` from 10,240 to 128,000.

### Refactoring `PieceCollector` and `PersistentCachePieceCollector`:

* Removed the `parents` parameter from several methods to simplify the code. [[1]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L156) [[2]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L250) [[3]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L388) [[4]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L488)
* Modified the logic to remove collected pieces from `collected_pieces` to avoid collecting the same piece from different parents. [[1]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L203-L222) [[2]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L233-L238) [[3]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L441-L460) [[4]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L471-L476)

### Dockerfile Update:

* Added additional utilities (`lsof`, `socat`, `strace`) to the `ci/Dockerfile.debug` for debugging purposes.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
