### PR TITLE
chore(ci/Dockerfile.debug): add flamegraph for debug image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
-          path: /tmp/.buildx-cache-debug
+          path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-debug-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-debug-
@@ -195,8 +195,8 @@ jobs:
 
       - name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache-debug
-          mv /tmp/.buildx-cache-new-debug /tmp/.buildx-cache-debug
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   push_dfinit_image_to_registry:
     name: Push Dfinit Image

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -35,6 +35,9 @@ COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
 RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
 
+RUN git clone https://github.com/flamegraph-rs/flamegraph.git
+RUN (cd flamegraph && cargo build --release)
+
 FROM alpine:3.20 AS health
 
 ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
@@ -63,6 +66,7 @@ COPY --from=builder /app/client/target/debug/dfget /usr/local/bin/dfget
 COPY --from=builder /app/client/target/debug/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/debug/dfstore /usr/local/bin/dfstore
 COPY --from=builder /app/client/target/debug/dfcache /usr/local/bin/dfcache
+COPY --from=builder /app/flamegraph/target/release/flamegraph /usr/local/bin
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -36,7 +36,7 @@ COPY dragonfly-client-init/src ./dragonfly-client-init/src
 RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
 
 RUN git clone https://github.com/flamegraph-rs/flamegraph.git
-RUN (cd flamegraph && cargo build --release)
+RUN (cd /app/flamegraph && cargo build --release)
 
 FROM alpine:3.20 AS health
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -35,7 +35,7 @@ COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
 RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
 
-RUN git clone https://github.com/flamegraph-rs/flamegraph.git
+RUN git clone https://github.com/flamegraph-rs/flamegraph.git /app
 RUN (cd /app/flamegraph && cargo build --release)
 
 FROM alpine:3.20 AS health

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -35,8 +35,7 @@ COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
 RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
 
-RUN git clone https://github.com/flamegraph-rs/flamegraph.git /app
-RUN (cd /app/flamegraph && cargo build --release)
+RUN cargo install flamegraph --root /usr/local
 
 FROM alpine:3.20 AS health
 
@@ -66,7 +65,7 @@ COPY --from=builder /app/client/target/debug/dfget /usr/local/bin/dfget
 COPY --from=builder /app/client/target/debug/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/debug/dfstore /usr/local/bin/dfstore
 COPY --from=builder /app/client/target/debug/dfcache /usr/local/bin/dfcache
-COPY --from=builder /app/flamegraph/target/release/flamegraph /usr/local/bin
+COPY --from=builder /usr/local/bin/flamegraph /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the Docker workflow and the debug Dockerfile. The most important changes involve updating cache paths in the workflow and adding a new tool to the debug Dockerfile.

### Workflow Updates:
* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L145-R145): Updated the cache path for Docker layers from `/tmp/.buildx-cache-debug` to `/tmp/.buildx-cache` to streamline caching.
* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L198-R199): Modified the cache move step to reflect the new cache path, ensuring the cache is correctly moved and cleaned up.

### Debug Dockerfile Enhancements:
* [`ci/Dockerfile.debug`](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R38-R40): Added a step to clone and build the `flamegraph` tool from GitHub, enhancing the debugging capabilities.
* [`ci/Dockerfile.debug`](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R69): Included the `flamegraph` binary in the final image, making it available for use in the container.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
