### PR TITLE
refactor(dragonfly-client-storage): optimize buffer creation sequence for better readability

### DIFF
--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -359,8 +359,10 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
-        // Copy the piece to the file while updating the CRC32 value.
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
+        let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
+
+        // Copy the piece to the file while updating the CRC32 value.
         let crc = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
         let mut digest = crc.digest();
 
@@ -368,7 +370,6 @@ impl Content {
             digest.update(bytes);
         });
 
-        let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;
@@ -579,8 +580,10 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
-        // Copy the piece to the file while updating the CRC32 value.
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
+        let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
+
+        // Copy the piece to the file while updating the CRC32 value.
         let crc = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
         let mut digest = crc.digest();
 
@@ -588,7 +591,6 @@ impl Content {
             digest.update(bytes);
         });
 
-        let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -783,18 +783,18 @@ async fn proxy_via_dfdaemon(
         ));
     };
 
+    // Write the status code to the writer.
+    let (sender, mut receiver) = mpsc::channel(10 * 1024);
+
     // Get the read buffer size from the config.
     let read_buffer_size = config.proxy.read_buffer_size;
 
     // Write the task data to the reader.
     let (reader, writer) = tokio::io::duplex(read_buffer_size);
     let mut writer = BufWriter::with_capacity(read_buffer_size, writer);
-
-    // Write the status code to the writer.
-    let (sender, mut receiver) = mpsc::channel(10 * 1024);
+    let reader_stream = ReaderStream::with_capacity(reader, read_buffer_size);
 
     // Construct the response body.
-    let reader_stream = ReaderStream::with_capacity(reader, read_buffer_size);
     let stream_body = StreamBody::new(reader_stream.map_ok(Frame::data).map_err(ClientError::from));
     let boxed_body = stream_body.boxed();
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the `dragonfly-client-storage` and `dragonfly-client` projects to improve the handling of I/O operations and ensure proper ordering of buffer initialization. The most important changes include reordering buffer initialization in the `Content` implementation and modifying the `proxy_via_dfdaemon` function to correctly initialize the status code writer.

Improvements to buffer initialization:

* [`dragonfly-client-storage/src/content.rs`](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL362-L371): Reordered the initialization of `BufWriter` to occur before the CRC32 calculation and piece copying in the `Content` implementation. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL362-L371) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL582-L591)

Enhancements to proxy handling:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR786-L797): Moved the initialization of the status code writer to occur before the reader and writer setup in the `proxy_via_dfdaemon` function.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
