### PR TITLE
chore(ci/Dockerfile): add bottom for client image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -34,7 +34,7 @@ COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
 RUN cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
-RUN cargo install --git https://github.com/bvaisvil/zenith.git --root /usr/local
+RUN cargo install bottom --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
@@ -63,7 +63,7 @@ COPY --from=builder /app/client/target/release/dfget /usr/local/bin/dfget
 COPY --from=builder /app/client/target/release/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/release/dfstore /usr/local/bin/dfstore
 COPY --from=builder /app/client/target/release/dfcache /usr/local/bin/dfcache
-COPY --from=builder /usr/local/bin/zenith /usr/local/bin/
+COPY --from=builder /usr/local/bin/btm /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -36,7 +36,7 @@ COPY dragonfly-client-init/src ./dragonfly-client-init/src
 RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfstore --bin dfcache
 
 RUN cargo install flamegraph --root /usr/local
-RUN cargo install --git https://github.com/bvaisvil/zenith.git --root /usr/local
+RUN cargo install bottom --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
@@ -67,7 +67,7 @@ COPY --from=builder /app/client/target/debug/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/debug/dfstore /usr/local/bin/dfstore
 COPY --from=builder /app/client/target/debug/dfcache /usr/local/bin/dfcache
 COPY --from=builder /usr/local/bin/flamegraph /usr/local/bin/
-COPY --from=builder /usr/local/bin/zenith /usr/local/bin/
+COPY --from=builder /usr/local/bin/btm /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to the `ci/Dockerfile` and `ci/Dockerfile.debug` files to replace the `zenith` tool with the `bottom` tool. The changes ensure that the new tool is installed and copied to the appropriate locations in the Docker images.

Changes in `ci/Dockerfile`:

* Replaced the installation of `zenith` with `bottom` using the `cargo install` command.
* Updated the `COPY` command to copy the `btm` binary instead of the `zenith` binary.

Changes in `ci/Dockerfile.debug`:

* Replaced the installation of `zenith` with `bottom` using the `cargo install` command.
* Updated the `COPY` command to copy the `btm` binary instead of the `zenith` binary.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
