### PR TITLE
fix(dragonfly-client-storage): improve hard link handling in content storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "blake3",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.18"
+version = "0.2.19"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.18" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.18" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.18" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.18" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.18" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.18" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.18" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.19" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.19" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.19" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.19" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.19" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.19" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.19" }
 thiserror = "1.0"
 dragonfly-api = "=2.1.30"
 reqwest = { version = "0.12.4", features = [


### PR DESCRIPTION
- Bumped version from 0.2.18 to 0.2.19 across all packages
- Modified hard link logic in content.rs to:
  - Move existence check after initial hard link attempt
  - Handle AlreadyExists error case more gracefully
  - Apply consistent behavior for both regular and persistent cache tasks
- Maintains original functionality while improving error handling flow

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
