### PR TITLE
refactor(dragonfly-client-storage): optimize lru_cache for storage

### DIFF
--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -121,7 +121,6 @@ impl Cache {
     /// new creates a new cache with the specified capacity.
     pub fn new(capacity: usize, tasks_capacity: usize) -> Result<Self> {
         let capacity = NonZeroUsize::new(capacity).ok_or(Error::InvalidParameter)?;
-        let tasks_capacity = NonZeroUsize::new(tasks_capacity).ok_or(Error::InvalidParameter)?;
         let tasks = Arc::new(RwLock::new(LruCache::new(tasks_capacity)));
 
         Ok(Cache {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the `dragonfly-client-storage` crate, specifically focusing on the `lru_cache.rs` file. The changes aim to improve code documentation, simplify the implementation, and refactor the `LruCache` structure.

### Documentation and Comments:
* Added Apache License 2.0 header to `lru_cache.rs` file.
* Added documentation comments for `KeyRef`, `KeyWrapper`, `Entry`, and `LruCache` structs and their methods. [[1]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R35) [[2]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R46-R68) [[3]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R77-R86) [[4]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R95-R105) [[5]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R116-R137)

### Refactoring:
* Changed the `LruCache` struct to use a plain `usize` for capacity instead of `NonZeroUsize`.
* Simplified the `put` method in `LruCache` by removing the use of `ptr` and using `std::mem::swap` for value replacement.
* Removed unnecessary `unsafe` blocks in `detach` and `attach` methods of `LruCache`. [[1]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L177-R195) [[2]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R212-R222)

### Testing:
* Updated test cases to use the new `LruCache` constructor with `usize` for capacity. [[1]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L272-R292) [[2]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L299-R319) [[3]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L321-R341) [[4]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L340-R368) [[5]](diffhunk://#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231L360-R380)

### Other Changes:
* Removed the `NonZeroUsize` creation for `tasks_capacity` in `mod.rs`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
