### PR TITLE
test(dragonfly-client-storage): add unit tests for content and fix doctest syntax

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -605,7 +605,8 @@ impl UploadClient {
 /// the host info in real-time from the parents and then select the parents for downloading.
 ///
 /// The workflow diagram is as follows:
-///```
+///
+///```text
 ///                              +----------+
 ///              ----------------|  Parent  |---------------
 ///              |               +----------+              |
@@ -954,8 +955,8 @@ pub struct Storage {
     ///    For more details, refer to https://github.com/dragonflyoss/api/blob/main/proto/common.proto#L443.
     /// 2. If the download hits the memory cache, it will be faster than reading from the disk, because there is no
     ///    page cache for the first read.
-    /// ```
     ///
+    /// ```text
     ///     1.Preheat
     ///         |
     ///         |

--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -84,8 +84,8 @@ impl Task {
 ///    For more details, refer to https://github.com/dragonflyoss/api/blob/main/proto/common.proto#L443.
 /// 2. If the download hits the memory cache, it will be faster than reading from the disk, because there is no
 ///    page cache for the first read.
-/// ```
 ///
+/// ```text
 ///     1.Preheat
 ///         |
 ///         |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several changes to improve the `dragonfly-client` project, focusing on documentation formatting and enhancing the test coverage for the `content` module. The most important changes include updating documentation comments to specify the text format and adding comprehensive tests for various functionalities in the `content` module.

Documentation improvements:

* Updated documentation comments to specify the text format in `dragonfly-client-config/src/dfdaemon.rs` and `dragonfly-client-storage/src/cache/mod.rs`. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL608-R609) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL957-R959) [[3]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL87-R88)

Test coverage enhancements:

* Added multiple asynchronous tests for the `content` module in `dragonfly-client-storage/src/content.rs`, covering functionalities such as task creation, hard linking, copying, deletion, and reading/writing pieces.
* Removed duplicate `test_has_enough_space` function to avoid redundancy in the `content` module tests.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
