### PR TITLE
feat(dragonfly-client/src/proxy): add port parameter to HTTPS proxy handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "base16ct",
  "bincode",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "base16ct",
  "base64 0.22.1",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.21"
+version = "0.2.22"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.21" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.21" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.21" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.21" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.21" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.21" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.21" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.22" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.22" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.22" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.22" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.22" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.22" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.22" }
 thiserror = "1.0"
 dragonfly-api = "=2.1.36"
 reqwest = { version = "0.12.4", features = [


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces changes to the `dragonfly-client/src/proxy/mod.rs` file to handle the port number in HTTPS requests. The most important changes include adding the port number to various function parameters and updating the URI formatting to include the port.

Handling port number in HTTPS requests:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR433): Added a default port number (443) to the `https_handler` function.
* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR472): Included the port number in the parameters for the `upgraded_tunnel` function.
* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR541): Modified the `upgraded_handler` function to accept the port number and updated the URI formatting to include the port. [[1]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR541) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL561-R566)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
