### PR TITLE
feat(dragonfly-client/src/proxy): add X-Dragonfly-Force-Hard-Link header for proxy

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1066,7 +1066,7 @@ fn make_download_task_request(
             is_prefetch: false,
             need_piece_content: false,
             load_to_cache: false,
-            force_hard_link: false,
+            force_hard_link: header::get_force_hard_link(&header),
         }),
     })
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request to the `dragonfly-client` project includes changes to add support for the "force hard link" feature in HTTP requests. The most important changes include the addition of a new header constant, a function to retrieve the header value, and modifications to the download task request to utilize this new feature.

### Header Management Enhancements:

* [`dragonfly-client/src/proxy/header.rs`](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccR63-R68): Added a new constant `DRAGONFLY_FORCE_HARD_LINK_HEADER` for the "X-Dragonfly-Force-Hard-Link" header. This header indicates whether the downloaded file must be hard linked to the output path.

* [`dragonfly-client/src/proxy/header.rs`](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccR181-R195): Introduced a new function `get_force_hard_link` to retrieve the value of the "X-Dragonfly-Force-Hard-Link" header from HTTP requests. This function checks if the header is present and whether its value is "true".

### Download Task Request Modifications:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL1069-R1069): Modified the `make_download_task_request` function to use the `get_force_hard_link` function to set the `force_hard_link` field in the download task request. This ensures that the new header is properly handled during the download process.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
