### PR TITLE
feat: add cache support for piece download/upload.

### DIFF
--- a/dragonfly-client-storage/benches/cache.rs
+++ b/dragonfly-client-storage/benches/cache.rs
@@ -60,7 +60,13 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::mb(10),
         |b, size| {
             b.iter_batched(
-                || Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap(),
+                || {
+                    rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
+                            .await
+                            .unwrap()
+                    })
+                },
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -76,7 +82,13 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::mb(100),
         |b, size| {
             b.iter_batched(
-                || Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap(),
+                || {
+                    rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
+                            .await
+                            .unwrap()
+                    })
+                },
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -92,7 +104,13 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::gb(1),
         |b, size| {
             b.iter_batched(
-                || Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap(),
+                || {
+                    rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
+                            .await
+                            .unwrap()
+                    })
+                },
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -116,10 +134,13 @@ pub fn write_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(4) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(4) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache
@@ -155,10 +176,13 @@ pub fn write_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(10) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(10) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache
@@ -194,10 +218,13 @@ pub fn write_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(16) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(16) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache
@@ -240,10 +267,13 @@ pub fn read_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(4) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(4) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache
@@ -292,10 +322,13 @@ pub fn read_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(10) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(10) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache
@@ -344,10 +377,13 @@ pub fn read_piece(c: &mut Criterion) {
         |b, data| {
             b.iter_batched(
                 || {
-                    let mut cache = Cache::new(Arc::new(create_config(
-                        ByteSize::mb(16) * PIECE_COUNT as u64 * 2u64,
-                    )))
-                    .unwrap();
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(
+                            ByteSize::mb(16) * PIECE_COUNT as u64,
+                        )))
+                        .await
+                        .unwrap()
+                    });
 
                     rt.block_on(async {
                         cache

--- a/dragonfly-client-storage/benches/cache.rs
+++ b/dragonfly-client-storage/benches/cache.rs
@@ -62,9 +62,7 @@ pub fn put_task(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
-                            .await
-                            .unwrap()
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
                     })
                 },
                 |mut cache| {
@@ -84,9 +82,7 @@ pub fn put_task(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
-                            .await
-                            .unwrap()
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
                     })
                 },
                 |mut cache| {
@@ -106,14 +102,91 @@ pub fn put_task(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2))))
-                            .await
-                            .unwrap()
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
                     })
                 },
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
+                    });
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
+pub fn delete_task(c: &mut Criterion) {
+    let rt: Runtime = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("Delete Task");
+
+    group.bench_with_input(
+        BenchmarkId::new("Delete Task", "10MB"),
+        &ByteSize::mb(10),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
+                    });
+                    rt.block_on(async {
+                        cache.put_task("task", black_box(size.as_u64())).await;
+                    });
+                    cache
+                },
+                |mut cache| {
+                    rt.block_on(async {
+                        cache.delete_task("task").await.unwrap();
+                    });
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Delete Task", "100MB"),
+        &ByteSize::mb(100),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
+                    });
+                    rt.block_on(async {
+                        cache.put_task("task", black_box(size.as_u64())).await;
+                    });
+                    cache
+                },
+                |mut cache| {
+                    rt.block_on(async {
+                        cache.delete_task("task").await.unwrap();
+                    });
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Delete Task", "1GB"),
+        &ByteSize::gb(1),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = rt.block_on(async {
+                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
+                    });
+                    rt.block_on(async {
+                        cache.put_task("task", black_box(size.as_u64())).await;
+                    });
+                    cache
+                },
+                |mut cache| {
+                    rt.block_on(async {
+                        cache.delete_task("task").await.unwrap();
                     });
                 },
                 criterion::BatchSize::SmallInput,
@@ -136,9 +209,8 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(4) * PIECE_COUNT as u64,
+                            ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -178,9 +250,8 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(10) * PIECE_COUNT as u64,
+                            ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -220,9 +291,8 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(16) * PIECE_COUNT as u64,
+                            ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -269,9 +339,8 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(4) * PIECE_COUNT as u64,
+                            ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -324,9 +393,8 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(10) * PIECE_COUNT as u64,
+                            ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -379,9 +447,8 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(16) * PIECE_COUNT as u64,
+                            ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .await
                         .unwrap()
                     });
 
@@ -429,6 +496,6 @@ pub fn read_piece(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, put_task, write_piece, read_piece,);
+criterion_group!(benches, put_task, delete_task, write_piece, read_piece,);
 
 criterion_main!(benches);

--- a/dragonfly-client-storage/benches/lru_cache.rs
+++ b/dragonfly-client-storage/benches/lru_cache.rs
@@ -291,6 +291,78 @@ pub fn lru_cache_contains(c: &mut Criterion) {
     group.finish();
 }
 
+pub fn lru_cache_pop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Lru Cache Pop");
+
+    group.bench_with_input(
+        BenchmarkId::new("Lru Cache Pop", "4MB"),
+        &ByteSize::mb(4),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = LruCache::new(OPERATION_COUNT);
+                    for i in 0..OPERATION_COUNT {
+                        cache.put(format!("key{}", i), size.as_u64());
+                    }
+                    cache
+                },
+                |mut cache| {
+                    for i in 0..OPERATION_COUNT {
+                        black_box(cache.pop(&format!("key{}", i)));
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Lru Cache Pop", "10MB"),
+        &ByteSize::mb(10),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = LruCache::new(OPERATION_COUNT);
+                    for i in 0..OPERATION_COUNT {
+                        cache.put(format!("key{}", i), size.as_u64());
+                    }
+                    cache
+                },
+                |mut cache| {
+                    for i in 0..OPERATION_COUNT {
+                        black_box(cache.pop(&format!("key{}", i)));
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Lru Cache Pop", "16MB"),
+        &ByteSize::mb(16),
+        |b, size| {
+            b.iter_batched(
+                || {
+                    let mut cache = LruCache::new(OPERATION_COUNT);
+                    for i in 0..OPERATION_COUNT {
+                        cache.put(format!("key{}", i), size.as_u64());
+                    }
+                    cache
+                },
+                |mut cache| {
+                    for i in 0..OPERATION_COUNT {
+                        black_box(cache.pop(&format!("key{}", i)));
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
 pub fn lru_cache_pop_lru(c: &mut Criterion) {
     let mut group = c.benchmark_group("Lru Cache Pop Lru");
 
@@ -369,6 +441,7 @@ criterion_group!(
     lru_cache_get,
     lru_cache_peek,
     lru_cache_contains,
+    lru_cache_pop,
     lru_cache_pop_lru,
 );
 

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -471,6 +471,7 @@ impl Piece {
         length: u64,
         parent: piece_collector::CollectedParent,
         is_prefetch: bool,
+        load_to_cache: bool,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
@@ -529,9 +530,11 @@ impl Piece {
                 piece_id,
                 task_id,
                 offset,
+                length,
                 digest.as_str(),
                 parent.id.as_str(),
                 &mut reader,
+                load_to_cache,
             )
             .await
         {
@@ -568,6 +571,7 @@ impl Piece {
         length: u64,
         request_header: HeaderMap,
         is_prefetch: bool,
+        load_to_cache: bool,
         object_storage: Option<ObjectStorage>,
         hdfs: Option<Hdfs>,
     ) -> Result<metadata::Piece> {
@@ -691,6 +695,7 @@ impl Piece {
                 offset,
                 length,
                 &mut response.reader,
+                load_to_cache,
             )
             .await
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR introduces cache support for piece storage in Dragonfly client to improve performance. Key changes include:
1. Modified Cache initialization to be async and added task deletion support.
2. Added cache integration in storage operations: 
    - Added load_to_cache parameter to control caching behavior.
    - Implemented cache upload/download operations for pieces.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
### Modifications
#### New Methods:
`pop` in `dragonfly-client-storage/src/cache/lru_cache.rs`[[1]](https://github.com/dragonflyoss/client/pull/1074/files#diff-7d8f8ec7e65a57ac5bd1ee29f70410b71e2be0be94491e27d25af24e7a086231R269): Pop entry from cache.
`delete_task` in `dragonfly-client-storage/src/cache/mod.rs`[[2]](https://github.com/dragonflyoss/client/pull/1074/files#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aR250): Remove task from cache and updates size tracking

#### Modified Methods:
`new()` in `dragonfly-client-storage/src/cache/mod.rs`[[3]](https://github.com/dragonflyoss/client/pull/1074/files#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aR127): Converted to async initialization.

`dragonfly-client-storage/src/lib.rs`:
- `download_task_started`[[4]](https://github.com/dragonflyoss/client/pull/1074/files#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR128): If `load_to_cache` equals `true`, put task to cache.
- `download_piece_from_source_finished` & `download_piece_from_parent_finished`[[5]](https://github.com/dragonflyoss/client/pull/1074/files#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR426)[[6]](https://github.com/dragonflyoss/client/pull/1074/files#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR476): If `load_to_cache` equals `true`, write piece to both cache and disk.
-  `upload_piece`[[7]](https://github.com/dragonflyoss/client/pull/1074/files#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR546): If cache contains piece, upload piece content from cache.

Refactored cache initialization capacity in `dragonfly-client-storage/benches/cache.rs`.
## Screenshots (if appropriate)
