### PR TITLE
refactor(dragonfly-client-storage): lru cache support for piece download/upload

### DIFF
--- a/dragonfly-client-storage/benches/cache.rs
+++ b/dragonfly-client-storage/benches/cache.rs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+use bytes::Bytes;
 use bytesize::ByteSize;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use dragonfly_client_config::dfdaemon::{Config, Storage};
 use dragonfly_client_storage::{cache::Cache, metadata::Piece};
-use std::io::Cursor;
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Runtime;
@@ -60,11 +60,7 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::mb(10),
         |b, size| {
             b.iter_batched(
-                || {
-                    rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    })
-                },
+                || rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) }),
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -80,11 +76,7 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::mb(100),
         |b, size| {
             b.iter_batched(
-                || {
-                    rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    })
-                },
+                || rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) }),
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -100,11 +92,7 @@ pub fn put_task(c: &mut Criterion) {
         &ByteSize::gb(1),
         |b, size| {
             b.iter_batched(
-                || {
-                    rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    })
-                },
+                || rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) }),
                 |mut cache| {
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
@@ -128,9 +116,8 @@ pub fn delete_task(c: &mut Criterion) {
         |b, size| {
             b.iter_batched(
                 || {
-                    let mut cache = rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    });
+                    let mut cache =
+                        rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) });
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
                     });
@@ -152,9 +139,8 @@ pub fn delete_task(c: &mut Criterion) {
         |b, size| {
             b.iter_batched(
                 || {
-                    let mut cache = rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    });
+                    let mut cache =
+                        rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) });
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
                     });
@@ -176,9 +162,8 @@ pub fn delete_task(c: &mut Criterion) {
         |b, size| {
             b.iter_batched(
                 || {
-                    let mut cache = rt.block_on(async {
-                        Cache::new(Arc::new(create_config(ByteSize::gb(2)))).unwrap()
-                    });
+                    let mut cache =
+                        rt.block_on(async { Cache::new(Arc::new(create_config(ByteSize::gb(2)))) });
                     rt.block_on(async {
                         cache.put_task("task", black_box(size.as_u64())).await;
                     });
@@ -211,7 +196,6 @@ pub fn write_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -224,13 +208,11 @@ pub fn write_piece(c: &mut Criterion) {
                 |cache| {
                     rt.block_on(async {
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();
@@ -252,7 +234,6 @@ pub fn write_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -265,13 +246,11 @@ pub fn write_piece(c: &mut Criterion) {
                 |cache| {
                     rt.block_on(async {
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();
@@ -293,7 +272,6 @@ pub fn write_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -306,13 +284,11 @@ pub fn write_piece(c: &mut Criterion) {
                 |cache| {
                     rt.block_on(async {
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();
@@ -341,7 +317,6 @@ pub fn read_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -349,13 +324,11 @@ pub fn read_piece(c: &mut Criterion) {
                             .put_task("task", (ByteSize::mb(4) * PIECE_COUNT as u64).as_u64())
                             .await;
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();
@@ -395,7 +368,6 @@ pub fn read_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -403,13 +375,11 @@ pub fn read_piece(c: &mut Criterion) {
                             .put_task("task", (ByteSize::mb(10) * PIECE_COUNT as u64).as_u64())
                             .await;
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();
@@ -449,7 +419,6 @@ pub fn read_piece(c: &mut Criterion) {
                         Cache::new(Arc::new(create_config(
                             ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
                         )))
-                        .unwrap()
                     });
 
                     rt.block_on(async {
@@ -457,13 +426,11 @@ pub fn read_piece(c: &mut Criterion) {
                             .put_task("task", (ByteSize::mb(16) * PIECE_COUNT as u64).as_u64())
                             .await;
                         for i in 0..PIECE_COUNT {
-                            let mut cursor = Cursor::new(data);
                             cache
                                 .write_piece(
                                     "task",
                                     &format!("piece{}", i),
-                                    &mut cursor,
-                                    data.len() as u64,
+                                    Bytes::copy_from_slice(data),
                                 )
                                 .await
                                 .unwrap();

--- a/dragonfly-client-storage/src/cache/lru_cache.rs
+++ b/dragonfly-client-storage/src/cache/lru_cache.rs
@@ -274,7 +274,7 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         match self.map.remove(KeyWrapper::from_ref(k)) {
             None => None,
             Some(entry) => {
-                let entry_ptr: *mut Entry<K, V> = Box::into_raw(entry);
+                let entry_ptr = Box::into_raw(entry);
                 self.detach(entry_ptr);
 
                 unsafe {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to the `dragonfly-client-storage` module, primarily focusing on refactoring the `cache.rs` and `mod.rs` files to simplify the code and improve performance. The changes include the removal of unnecessary unwraps, the use of `Bytes` instead of `Cursor`, and the elimination of redundant code.

### Refactoring and Simplification:

* [`dragonfly-client-storage/benches/cache.rs`](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deR17-L21): Replaced `Cursor` with `Bytes` for handling data, and removed unnecessary unwraps in cache operations. [[1]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deR17-L21) [[2]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL227-R215) [[3]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL344-R331)
* [`dragonfly-client-storage/src/cache/mod.rs`](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL127-R132): Simplified the `Cache::new` method by removing the `Result` return type and unnecessary unwraps. [[1]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL127-R132) [[2]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL318-R297)
* [`dragonfly-client-storage/src/cache/mod.rs`](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL185-L213): Updated the `write_piece` method to accept `Bytes` directly, removing the need for an intermediate buffer.

### Code Cleanup:

* [`dragonfly-client-storage/src/cache/mod.rs`](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL26-L37): Removed unused imports and redundant fields from the `Task` struct. [[1]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL26-L37) [[2]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL48-L50)
* [`dragonfly-client-storage/src/cache/mod.rs`](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL223-R203): Removed debug logging for task eviction and adjusted the task size comparison logic. [[1]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL223-R203) [[2]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL237-R234)

These changes collectively enhance the code readability and performance of the `dragonfly-client-storage` module.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
