### PR TITLE
test(dragonfly-client-storage/benches): remove 1u64 when create cache

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -201,10 +201,10 @@ fn default_storage_read_buffer_size() -> usize {
 }
 
 /// default_storage_cache_capacity is the default cache capacity for the storage server, default is
-/// 128MiB.
+/// 64MiB.
 #[inline]
 fn default_storage_cache_capacity() -> ByteSize {
-    ByteSize::mb(128)
+    ByteSize::mib(64)
 }
 
 /// default_seed_peer_cluster_id is the default cluster id of seed peer.

--- a/dragonfly-client-storage/benches/cache.rs
+++ b/dragonfly-client-storage/benches/cache.rs
@@ -194,7 +194,7 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(4) * PIECE_COUNT as u64,
                         )))
                     });
 
@@ -232,7 +232,7 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(10) * PIECE_COUNT as u64,
                         )))
                     });
 
@@ -270,7 +270,7 @@ pub fn write_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(16) * PIECE_COUNT as u64,
                         )))
                     });
 
@@ -315,7 +315,7 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(4) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(4) * PIECE_COUNT as u64,
                         )))
                     });
 
@@ -366,7 +366,7 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(10) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(10) * PIECE_COUNT as u64,
                         )))
                     });
 
@@ -417,7 +417,7 @@ pub fn read_piece(c: &mut Criterion) {
                 || {
                     let mut cache = rt.block_on(async {
                         Cache::new(Arc::new(create_config(
-                            ByteSize::mb(16) * PIECE_COUNT as u64 + 1u64,
+                            ByteSize::mb(16) * PIECE_COUNT as u64,
                         )))
                     });
 

--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -265,19 +265,19 @@ mod tests {
     #[tokio::test]
     async fn test_new() {
         let test_cases = vec![
-            // Default configuration with 128MB capacity.
-            (Config::default(), 0, ByteSize::mb(128).as_u64()),
-            // Custom configuration with 100MB capacity.
+            // Default configuration with 64MiB capacity.
+            (Config::default(), 0, ByteSize::mib(64).as_u64()),
+            // Custom configuration with 100MiB capacity.
             (
                 Config {
                     storage: Storage {
-                        cache_capacity: ByteSize::mb(100),
+                        cache_capacity: ByteSize::mib(100),
                         ..Default::default()
                     },
                     ..Default::default()
                 },
                 0,
-                ByteSize::mb(100).as_u64(),
+                ByteSize::mib(100).as_u64(),
             ),
             // Zero capacity configuration.
             (

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -125,7 +125,6 @@ impl Storage {
         )?;
 
         self.content.create_task(id).await?;
-
         if load_to_cache {
             if let Some(content_length) = content_length {
                 let mut cache = self.cache.clone();

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -348,7 +348,7 @@ impl Piece {
         self.storage
             .upload_piece(piece_id, task_id, range)
             .await
-            .inspect(|_reader| {
+            .inspect(|_| {
                 collect_upload_piece_traffic_metrics(
                     self.id_generator.task_type(task_id) as i32,
                     length,
@@ -379,7 +379,7 @@ impl Piece {
         self.storage
             .upload_piece_with_dual_read(piece_id, task_id, range)
             .await
-            .inspect(|_reader| {
+            .inspect(|_| {
                 collect_upload_piece_traffic_metrics(
                     self.id_generator.task_type(task_id) as i32,
                     length,
@@ -767,7 +767,7 @@ impl Piece {
         self.storage
             .upload_persistent_cache_piece(piece_id, task_id, range)
             .await
-            .inspect(|_reader| {
+            .inspect(|_| {
                 collect_upload_piece_traffic_metrics(
                     self.id_generator.task_type(task_id) as i32,
                     length,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several changes to optimize cache configurations and improve code readability in the `dragonfly-client` project. The most important changes include adjusting the cache capacity values, removing unnecessary additions in cache size calculations, and simplifying code in the `Piece` implementation.

### Cache Configuration Adjustments:
* [`dragonfly-client-config/src/dfdaemon.rs`](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL204-R207): Reduced the default storage cache capacity from 128MiB to 64MiB.

### Cache Size Calculation Simplifications:
* [`dragonfly-client-storage/benches/cache.rs`](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL197-R197): Removed unnecessary additions in cache size calculations for `write_piece` and `read_piece` functions. [[1]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL197-R197) [[2]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL235-R235) [[3]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL273-R273) [[4]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL318-R318) [[5]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL369-R369) [[6]](diffhunk://#diff-d5e95539e480417a81ef44c3c271689760e0eb23dd969c8409e30af7df7d27deL420-R420)

### Code Readability Improvements:
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL128): Removed an unnecessary blank line in the `Storage` implementation.
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L351-R351): Simplified the `inspect` method calls by removing unused `_reader` parameters in the `Piece` implementation. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L351-R351) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L382-R382) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L770-R770)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
