### PR TITLE
fix: modify ut logic which is incorrect under macOS

### DIFF
--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -436,9 +436,15 @@ mod tests {
 
         let result = BackendFactory::new(Some(&plugin_dir));
         assert!(result.is_err());
-        assert_eq!(
-            format!("{}", result.err().unwrap()),
-            format!("PluginError cause: {}: file too short", lib_path.display()),
+        let err_msg = format!("{}", result.err().unwrap());
+
+        assert!(
+            err_msg.starts_with("PluginError cause:"),
+            "error message should start with 'PluginError cause:'"
+        );
+        assert!(
+            err_msg.contains(&lib_path.display().to_string()),
+            "error message should contain library path"
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Error under MacOS is different(```not a mach-o file```). Let's modify the assert logic.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
