### PR TITLE
feat(dragonfly-client-storage): Change error log to info for cache task deletion failure

### DIFF
--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use tokio::io::AsyncRead;
 use tokio_util::either::Either;
 use tokio_util::io::InspectReader;
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 pub mod cache;
 pub mod content;
@@ -201,7 +201,7 @@ impl Storage {
 
         let mut cache = self.cache.clone();
         cache.delete_task(id).await.unwrap_or_else(|err| {
-            error!("delete task from cache failed: {}", err);
+            info!("delete task from cache failed: {}", err);
         });
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes minor changes to the `dragonfly-client-storage` crate, specifically around logging. The changes replace error-level logging with informational-level logging for a specific scenario and add the `info` macro to the list of imports.

Logging updates:

* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL30-R30): Added the `info` logging macro to the `tracing` imports.
* [`dragonfly-client-storage/src/lib.rs`](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL204-R204): Changed the log level from `error!` to `info!` for a failed cache deletion task in the `Storage` implementation.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
