### PR TITLE
feat(dragonfly-client): add support for content-based task ID generation in Dragonfly client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.36"
+version = "2.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3f32ea719a832f5df4f0d87231c04e7e76d9c7748c3618e6810af4cbdfb1e0"
+checksum = "4ef3a36f55cedea2a004d17cff39bcfe906fc94579cb0b440cf185a0663b645d"
 dependencies = [
  "prost 0.13.5",
  "prost-types",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bincode",
  "bytes",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.24"
+version = "0.2.25"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,14 +22,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.24" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.24" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.24" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.24" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.24" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.24" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.24" }
-dragonfly-api = "=2.1.36"
+dragonfly-client = { path = "dragonfly-client", version = "0.2.25" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.25" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.25" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.25" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.25" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.25" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.25" }
+dragonfly-api = "=2.1.39"
 thiserror = "1.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -42,11 +42,10 @@ pub struct ImportCommand {
     path: PathBuf,
 
     #[arg(
-        long = "id",
-        required = false,
-        help = "Specify the id of the persistent cache task. If id is none, dfdaemon will generate the new task id based on the file content, tag and application by crc32 algorithm."
+        long = "content-for-calculating-task-id",
+        help = "Specify the content used to calculate the persistent cache task ID. If it is set, use its value to calculate the task ID, Otherwise, calculate the persistent cache task ID based on url, piece-length, tag, application, and filtered-query-params."
     )]
-    id: Option<String>,
+    content_for_calculating_task_id: Option<String>,
 
     #[arg(
         long = "persistent-replica-count",
@@ -341,7 +340,7 @@ impl ImportCommand {
 
         let persistent_cache_task = dfdaemon_download_client
             .upload_persistent_cache_task(UploadPersistentCacheTaskRequest {
-                task_id: self.id.clone(),
+                content_for_calculating_task_id: self.content_for_calculating_task_id.clone(),
                 path: absolute_path.to_string_lossy().to_string(),
                 persistent_replica_count: self.persistent_replica_count,
                 tag: self.tag.clone(),
@@ -370,15 +369,6 @@ impl ImportCommand {
                 "ttl must be between 5 minutes and 7 days, but got {}",
                 self.ttl.as_secs()
             )));
-        }
-
-        if let Some(id) = self.id.as_ref() {
-            if id.len() != 64 {
-                return Err(Error::ValidationError(format!(
-                    "id length must be 64 bytes, but got {}",
-                    id.len()
-                )));
-            }
         }
 
         if self.path.is_dir() {

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -109,6 +109,12 @@ struct Args {
     force_hard_link: bool,
 
     #[arg(
+        long = "content-for-calculating-task-id",
+        help = "Specify the content used to calculate the task ID. If it is set, use its value to calculate the task ID, Otherwise, calculate the task ID based on url, piece-length, tag, application, and filtered-query-params."
+    )]
+    content_for_calculating_task_id: Option<String>,
+
+    #[arg(
         short = 'O',
         long = "output",
         help = "Specify the output path of downloading file"
@@ -774,6 +780,7 @@ async fn download(
                 hdfs,
                 load_to_cache: false,
                 force_hard_link: args.force_hard_link,
+                content_for_calculating_task_id: args.content_for_calculating_task_id,
             }),
         })
         .await

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1067,6 +1067,7 @@ fn make_download_task_request(
             need_piece_content: false,
             load_to_cache: false,
             force_hard_link: header::get_force_hard_link(&header),
+            content_for_calculating_task_id: header::get_content_for_calculating_task_id(&header),
         }),
     })
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces significant refactoring and enhancements to the `dragonfly-client` codebase, focusing on improving task ID generation by introducing parameterized enums, updating method signatures, and adding support for content-based task ID calculation. Additionally, it updates dependencies and introduces new headers for flexibility in task ID calculation.

### Task ID Generation Refactor:
* Introduced `TaskIDParameter` and `PersistentCacheTaskIDParameter` enums to encapsulate parameters for task ID generation, replacing the previous method signatures that required multiple arguments. (`dragonfly-client-util/src/id_generator/mod.rs`) [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R35-R62) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L74-R115) [[3]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R158-R179) [[4]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R212-R213)
* Updated the `IDGenerator` methods (`task_id` and `persistent_cache_task_id`) to use these enums, simplifying the interface and improving readability. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L74-R115) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R158-R179)

### Dependency and Header Updates:
* Upgraded the `dragonfly-api` dependency version from `2.1.36` to `2.1.39` in `Cargo.toml`.
* Added a new HTTP header, `X-Dragonfly-Content-For-Calculating-Task-ID`, to support content-based task ID generation. (`dragonfly-client/src/proxy/header.rs`)
* Implemented a helper function `get_content_for_calculating_task_id` to retrieve the new header value.

### Integration with gRPC Modules:
* Updated gRPC handlers to support the new task ID generation approach by leveraging `TaskIDParameter` and `PersistentCacheTaskIDParameter` enums. (`dragonfly-client/src/grpc/dfdaemon_download.rs` and `dragonfly-client/src/grpc/dfdaemon_upload.rs`) [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL237-R249) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL953-R974) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L238-R248)

### Test Suite Enhancements:
* Revised existing tests and added new test cases to validate the refactored task ID generation logic and the new HTTP header functionality. (`dragonfly-client-util/src/id_generator/mod.rs` and `dragonfly-client/src/proxy/header.rs`) [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L228-R406) [[2]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccR382-R397)

### Proxy Module Update:
* Integrated the new header-based task ID calculation into the proxy module's `make_download_task_request` function. (`dragonfly-client/src/proxy/mod.rs`)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
