### PR TITLE
chore(.github/workflows): add stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Close stale issues and PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        id: stale
+        with:
+          delete-branch: true
+          days-before-close: 60
+          days-before-stale: 90
+          stale-issue-label: "stale"
+          exempt-issue-labels: bug,wip,on-hold
+          exempt-pr-labels: bug,wip,on-hold
+          exempt-all-milestones: true
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 60 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 60 days with no activity.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests. The workflow identifies and labels inactive issues and PRs, and eventually closes them after a defined period of inactivity.

### Automation for stale issues and PRs:
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R1-R29): Added a new workflow named "Close stale issues and PRs" that runs on a schedule and can also be triggered manually. It uses the `actions/stale` action to label issues and PRs as stale after 90 days of inactivity, and closes them after an additional 60 days. The workflow includes customizable messages and exemptions for specific labels and milestones.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
