### PR TITLE
chore(.github/workflows): add auto assign action

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,16 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - gaius-qi
+  - yxxhero
+  - chlins
+  - CormickKneey
+  - xujihui1985
+
+# A number of reviewers added to the pull request
+numberOfReviewers: 3

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,11 @@
+name: "Auto Assign"
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-assignee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@248761c4feb3917c1b0444e33fad1a50093b9847


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces an auto-assignment feature for pull requests by configuring reviewer and assignee behavior and adding a corresponding GitHub Actions workflow. The changes aim to streamline the review process by automatically assigning reviewers and the pull request author as the assignee.

### Configuration for auto-assignment:

* [`.github/auto_assign.yml`](diffhunk://#diff-3214716232c018d09082c4cd4c04d984d220c107fc126bc240c8b3bc53d8df73R1-R16): Added configuration to enable automatic assignment of reviewers and the pull request author. It specifies a list of reviewers and limits the number of reviewers to three.

### GitHub Actions workflow:

* [`.github/workflows/auto-assign.yml`](diffhunk://#diff-3df58dd42b351a284a19d2c3d3fe8c50db1cc811bb690ebbf402d1282bce9757R1-R11): Added a new workflow to trigger the auto-assignment process when a pull request is opened, reopened, or marked as ready for review. It uses the `kentaro-m/auto-assign-action` GitHub Action.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
