### PR TITLE
chore(.github/workflows): add pr labels action

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,20 @@
+name: PR Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    name: Classify PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR impact specified
+        uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'bug, enhancement, documentation, dependencies'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new GitHub Actions workflow to ensure pull requests are properly labeled with one of the predefined labels. 

### Workflow Automation:

* [`.github/workflows/pr-labels.yml`](diffhunk://#diff-cc6cdcc79d6a4cb86fb60d52a99f98fa1241bf2da9b359dd211e4f67d72edd19R1-R20): Added a new workflow named "PR Label" that triggers on pull request events (e.g., opened, labeled, unlabeled, synchronize). It uses the `mheap/github-action-required-labels` action to enforce that exactly one label from the set `bug`, `enhancement`, `documentation`, or `dependencies` is applied to the pull request.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
