### PR TITLE
feat: support fallocate for creating task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,11 +1162,13 @@ dependencies = [
  "pnet",
  "rcgen",
  "reqwest",
+ "rustix 1.0.5",
  "rustls 0.22.4",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "sha2",
  "tempfile",
+ "tokio",
  "tracing",
  "url",
  "uuid",
@@ -4067,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -4623,7 +4625,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix 1.0.1",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -1,8 +1,8 @@
 FROM public.ecr.aws/docker/library/rust:1.82.0 AS builder
 
 RUN apt-get update && apt-get install -y \
-      openssl libclang-dev pkg-config protobuf-compiler \
-      && rm -rf /var/lib/apt/lists/*
+    openssl libclang-dev pkg-config protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app/client
 

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -30,6 +30,8 @@ crc32fast.workspace = true
 lazy_static.workspace = true
 bytesize.workspace = true
 lru.workspace = true
+tokio.workspace = true
+rustix = { version = "1.0.5", features = ["fs"] }
 base64 = "0.22.1"
 pnet = "0.35.0"
 

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -1,0 +1,46 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dragonfly_client_core::{Error, Result};
+use tokio::{fs, io};
+
+/// fallocate allocates the space for the file and fills it with zero, only on Linux.
+pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        use rustix::fs::{fallocate, FallocateFlags};
+        use std::os::unix::io::AsFd;
+
+        // Set length (potential truncation).
+        f.set_len(length).await?;
+        let fd = f.as_fd();
+        let offset = 0;
+        let flags = FallocateFlags::KEEP_SIZE;
+
+        loop {
+            match fallocate(fd, flags, offset, length) {
+                Ok(_) => return Ok(()),
+                Err(rustix::io::Errno::INTR) => continue,
+                Err(err) => {
+                    return Err(Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    Ok(())
+}

--- a/dragonfly-client-util/src/lib.rs
+++ b/dragonfly-client-util/src/lib.rs
@@ -15,6 +15,7 @@
  */
 
 pub mod digest;
+pub mod fs;
 pub mod http;
 pub mod id_generator;
 pub mod net;

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -329,14 +329,14 @@ impl ImportCommand {
         let absolute_path = Path::new(&self.path).absolutize()?;
         info!("import file: {}", absolute_path.to_string_lossy());
 
-        let pb = ProgressBar::new_spinner();
-        pb.enable_steady_tick(DEFAULT_PROGRESS_BAR_STEADY_TICK_INTERVAL);
-        pb.set_style(
+        let progress_bar = ProgressBar::new_spinner();
+        progress_bar.enable_steady_tick(DEFAULT_PROGRESS_BAR_STEADY_TICK_INTERVAL);
+        progress_bar.set_style(
             ProgressStyle::with_template("{spinner:.blue} {msg}")
                 .unwrap()
                 .tick_strings(&["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]),
         );
-        pb.set_message("Importing...");
+        progress_bar.set_message("Importing...");
 
         let persistent_cache_task = dfdaemon_download_client
             .upload_persistent_cache_task(UploadPersistentCacheTaskRequest {
@@ -356,7 +356,7 @@ impl ImportCommand {
             })
             .await?;
 
-        pb.finish_with_message(format!("Done: {}", persistent_cache_task.id));
+        progress_bar.finish_with_message(format!("Done: {}", persistent_cache_task.id));
         Ok(())
     }
 

--- a/dragonfly-client/src/dynconfig/mod.rs
+++ b/dragonfly-client/src/dynconfig/mod.rs
@@ -25,7 +25,7 @@ use dragonfly_client_core::{Error, Result};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tonic_health::pb::health_check_response::ServingStatus;
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 use url::Url;
 
 /// Data is the dynamic configuration of the dfdaemon.
@@ -98,9 +98,10 @@ impl Dynconfig {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    if let Err(err) = self.refresh().await {
-                        error!("refresh dynconfig failed: {}", err);
-                    };
+                    match self.refresh().await {
+                        Err(err) => error!("refresh dynconfig failed: {}", err),
+                        Ok(_) => debug!("refresh dynconfig success"),
+                    }
                 }
                 _ = shutdown.recv() => {
                     // Dynconfig server shutting down with signals.

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -128,10 +128,7 @@ impl Task {
         id: &str,
         request: Download,
     ) -> ClientResult<metadata::Task> {
-        let task = self
-            .storage
-            .download_task_started(id, None, None, None, request.load_to_cache)
-            .await?;
+        let task = self.storage.prepare_download_task_started(id).await?;
 
         // Attempt to create a hard link from the task file to the output path.
         //
@@ -250,8 +247,8 @@ impl Task {
         self.storage
             .download_task_started(
                 id,
-                Some(piece_length),
-                Some(content_length),
+                piece_length,
+                content_length,
                 response.http_header,
                 request.load_to_cache,
             )
@@ -1891,7 +1888,7 @@ mod tests {
         // Create a task and save it to storage.
         let task_id = "test-task-id";
         storage
-            .download_task_started(task_id, Some(1024), Some(4096), None, false)
+            .download_task_started(task_id, 1024, 4096, None, false)
             .await
             .unwrap();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces enhancements to task creation and storage management in the Dragonfly client, with a focus on preallocating file space using the `fallocate` function for improved performance and reliability. It also includes updates to function signatures, test cases, and a new utility module for file system operations.

### Task Creation Enhancements:
* Updated `create_task` and `create_persistent_cache_task` methods in `Content` to include a `length` parameter for preallocating file space using the newly introduced `fallocate` function. (`dragonfly-client-storage/src/content.rs`, [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL154-R155) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL401-R410)
* Modified `download_task_started` in `Storage` to pass `content_length` directly to `create_task` and `create_persistent_cache_task`. (`dragonfly-client-storage/src/lib.rs`, [[1]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR109-L134) [[2]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL251-R258) [[3]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL293-R302)

### Utility Module Addition:
* Added a new `fallocate` function in `dragonfly-client-util` for preallocating file space on Linux, leveraging the `rustix` crate. This ensures files are properly sized and zero-filled before use. (`dragonfly-client-util/src/fs/mod.rs`, [dragonfly-client-util/src/fs/mod.rsR1-R50](diffhunk://#diff-a9f7b7691aaa2aae157e921fe3c47897445b7f56aa102d1c3b54279960b7eb20R1-R50))
* Introduced a new `fs` module in `dragonfly-client-util` and updated `Cargo.toml` to include the `tokio` and `rustix` dependencies. (`dragonfly-client-util/src/lib.rs`, [[1]](diffhunk://#diff-c6f703d73adfc69d9b9a521a4c475d6e26e92f07a10e2bee0d0c53fdac80b8ccR18); `dragonfly-client-util/Cargo.toml`, [[2]](diffhunk://#diff-1c96c45400d8ecf785eb0acb8bced3fbd8838ce5882e449bb66aceaf5497021dR33-R34)

### Test Updates:
* Adjusted test cases in `Content` to include the `length` parameter when invoking `create_task` and `create_persistent_cache_task`. (`dragonfly-client-storage/src/content.rs`, [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL633-R650) [[2]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL747-R770) [[3]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL860-R894)
* Updated tests in `Task` to reflect the new `download_task_started` signature. (`dragonfly-client/src/resource/task.rs`, [dragonfly-client/src/resource/task.rsL1894-R1891](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1894-R1891))

### Refactoring and Minor Changes:
* Introduced a `prepare_download_task_started` method in `Storage` to initialize task metadata without creating the task content. (`dragonfly-client-storage/src/lib.rs`, [dragonfly-client-storage/src/lib.rsR109-L134](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR109-L134))
* Refactored `Task` to use `prepare_download_task_started` for metadata setup and updated `download_task_started` calls to match the new method signature. (`dragonfly-client/src/resource/task.rs`, [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L131-R131) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L253-R251)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
