### PR TITLE
feat(dragonfly-client): change MAX_PIECE_LENGTH to 64MiB

### DIFF
--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -46,7 +46,7 @@ pub const MAX_PIECE_COUNT: u64 = 500;
 pub const MIN_PIECE_LENGTH: u64 = 4 * 1024 * 1024;
 
 /// MAX_PIECE_LENGTH is the maximum piece length.
-pub const MAX_PIECE_LENGTH: u64 = 16 * 1024 * 1024;
+pub const MAX_PIECE_LENGTH: u64 = 64 * 1024 * 1024;
 
 /// PieceLengthStrategy sets the optimization strategy of piece length.
 pub enum PieceLengthStrategy {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a change to the `MAX_PIECE_LENGTH` constant in the `dragonfly-client` codebase, increasing its value to allow larger pieces of data to be processed.

Resource configuration update:

* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L49-R49): Increased `MAX_PIECE_LENGTH` from `16 * 1024 * 1024` to `64 * 1024 * 1024`, likely to support larger data pieces in the resource handling logic.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
