### PR TITLE
feat(dragonfly-client-backend): change retry times for backend

### DIFF
--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -47,7 +47,7 @@ const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(300);
 const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// MAX_RETRY_TIMES is the max retry times for the request.
-const MAX_RETRY_TIMES: u32 = 3;
+const MAX_RETRY_TIMES: u32 = 1;
 
 /// NAME is the name of the package.
 pub const NAME: &str = "backend";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small but significant change to the retry behavior of HTTP requests in the `dragonfly-client-backend` library. The maximum number of retry attempts has been reduced from 3 to 1.

* [`dragonfly-client-backend/src/lib.rs`](diffhunk://#diff-6acac939bcda338ef32b3d844b2a6dad132f231935dd23bb8eead046b3effe94L50-R50): Changed `MAX_RETRY_TIMES` from `3` to `1`, reducing the number of retry attempts for HTTP requests.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
