### PR TITLE
feat(dragonfly-client-config): change the default value oft the schedule_timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bincode",
  "bytes",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.26"
+version = "0.2.27"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.26" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.26" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.26" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.26" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.26" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.26" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.26" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.27" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.27" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.27" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.27" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.27" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.27" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.27" }
 dragonfly-api = "=2.1.39"
 thiserror = "1.0"
 futures = "0.3.31"


### PR DESCRIPTION
…
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the version of the Dragonfly client and makes several important changes to the configuration defaults and documentation in the `dfdaemon` module. The key changes include increasing default timeout values and enhancing the documentation for the scheduler's timeout behavior.

### Version Updates:
* Updated the Dragonfly client version from `0.2.26` to `0.2.27` in `Cargo.toml` and all workspace dependencies. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Configuration Changes:
* Increased the default timeout for downloading a piece from 15 seconds to 60 seconds in the `default_download_piece_timeout` function.
* Increased the default scheduler scheduling timeout from 180 seconds to 3 hours in the `default_scheduler_schedule_timeout` function.

### Documentation Enhancements:
* Expanded the documentation for the `schedule_timeout` field in the `Scheduler` struct to provide detailed explanations of its behavior, timeout triggers, and configuration recommendations.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
