### PR TITLE
fix: scheduling and piece collection logic for task abortion

### DIFF
--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -749,7 +749,7 @@ impl PersistentCacheTask {
         })? {
             // Check if the schedule count is exceeded.
             schedule_count += 1;
-            if schedule_count >= self.config.scheduler.max_schedule_count {
+            if schedule_count > self.config.scheduler.max_schedule_count {
                 in_stream_tx
                     .send_timeout(
                         AnnouncePersistentCachePeerRequest {

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -263,7 +263,7 @@ impl PieceCollector {
                     let is_empty = collected_pieces_guard.is_empty();
                     drop(collected_pieces_guard);
 
-                    if !is_empty {
+                    if is_empty {
                         info!("all pieces are collected, abort all tasks");
                         join_set.abort_all();
                     }
@@ -499,7 +499,7 @@ impl PersistentCachePieceCollector {
                     let is_empty = collected_pieces_guard.is_empty();
                     drop(collected_pieces_guard);
 
-                    if !is_empty {
+                    if is_empty {
                         info!("all persistent cache pieces are collected, abort all tasks");
                         join_set.abort_all();
                     }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -578,7 +578,7 @@ impl Task {
         })? {
             // Check if the schedule count is exceeded.
             schedule_count += 1;
-            if schedule_count >= self.config.scheduler.max_schedule_count {
+            if schedule_count > self.config.scheduler.max_schedule_count {
                 in_stream_tx
                     .send_timeout(
                         AnnouncePeerRequest {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify scheduling logic in persistent_cache_task.rs and task.rs to use strict inequality (>) for max_schedule_count comparison, ensuring tasks abort only after exceeding the configured limit. Correct piece collection logic in piece_collector.rs to abort tasks when collected_pieces is empty, fixing the condition for both PieceCollector and PersistentCachePieceCollector to align with intended behavior.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
