### PR TITLE
feat(dragonfly-client): add logs for finished piece from local

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -149,7 +149,7 @@ fn default_download_piece_timeout() -> Duration {
 /// default_download_concurrent_piece_count is the default number of concurrent pieces to download.
 #[inline]
 fn default_download_concurrent_piece_count() -> u32 {
-    16
+    8
 }
 
 /// default_download_max_schedule_count is the default max count of schedule.

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -422,6 +422,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
+            info!("finished piece {} from local", piece_id);
             return Ok(piece);
         }
 
@@ -525,6 +526,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
+            info!("finished piece {} from local", piece_id);
             return Ok(piece);
         }
 
@@ -789,6 +791,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
+            info!("finished persistent cache piece {} from local", piece_id);
             return Ok(piece);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to optimize download behavior and improve logging in the `dragonfly-client` project. The most important changes involve reducing the default concurrent piece download count and adding logging for completed pieces.

### Download behavior optimization:
* [`dragonfly-client-config/src/dfdaemon.rs`](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL152-R152): Reduced the default number of concurrent pieces to download from `16` to `8` to optimize resource usage and potentially improve stability.

### Logging improvements:
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R425): Added `info` log statements to indicate when a piece or a persistent cache piece is finished and retrieved locally. This change appears in three locations within the `impl Piece` block. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R425) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R529) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R794)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
