### PR TITLE
feat: add task type to ID generation for Standard and PersistentCache tasks

### DIFF
--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -152,6 +152,8 @@ impl IDGenerator {
                     hasher.update(piece_length.to_string());
                 }
 
+                hasher.update(TaskType::Standard.as_str_name().as_bytes());
+
                 // Generate the task id.
                 Ok(hex::encode(hasher.finalize()))
             }
@@ -205,6 +207,8 @@ impl IDGenerator {
                 if let Some(piece_length) = piece_length {
                     hasher.update(piece_length.to_string().as_bytes());
                 }
+
+                hasher.update(TaskType::PersistentCache.as_str_name().as_bytes());
 
                 // Generate the task id by crc32.
                 Ok(hasher.finalize().to_string())
@@ -277,7 +281,7 @@ mod tests {
                     application: Some("bar".to_string()),
                     filtered_query_params: vec![],
                 },
-                "99a47b38e9d3321aebebd715bea0483c1400cef2f767f84d97458f9dcedff221",
+                "27554d06dfc788c2c2c60e01960152ffbd4b145fc103fcb80b432b4dc238a6fe",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -288,7 +292,7 @@ mod tests {
                     application: Some("bar".to_string()),
                     filtered_query_params: vec![],
                 },
-                "160fa7f001d9d2e893130894fbb60a5fb006e1d61bff82955f2946582bc9de1d",
+                "06408fbf247ddaca478f8cb9565fe5591c28efd0994b8fea80a6a87d3203c5ca",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -299,7 +303,7 @@ mod tests {
                     application: None,
                     filtered_query_params: vec![],
                 },
-                "2773851c628744fb7933003195db436ce397c1722920696c4274ff804d86920b",
+                "3c3f230ef9f191dd2821510346a7bc138e4894bee9aee184ba250a3040701d2a",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -310,7 +314,7 @@ mod tests {
                     application: Some("bar".to_string()),
                     filtered_query_params: vec![],
                 },
-                "63dee2822037636b0109876b58e95692233840753a882afa69b9b5ee82a6c57d",
+                "c9f9261b7305c24371244f9f149f5d4589ed601348fdf22d7f6f4b10658fdba2",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -321,7 +325,7 @@ mod tests {
                     application: None,
                     filtered_query_params: vec![],
                 },
-                "40c21de3ad2f1470ca1a19a2ad2577803a1829851f6cf862ffa2d4577ae51d38",
+                "9f7c9aafbc6f30f8f41a96ca77eeae80c5b60964b3034b0ee43ccf7b2f9e52b8",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -332,7 +336,7 @@ mod tests {
                     application: None,
                     filtered_query_params: vec!["foo".to_string(), "bar".to_string()],
                 },
-                "100680ad546ce6a577f42f52df33b4cfdca756859e664b8d7de329b150d09ce9",
+                "457b4328cde278e422c9e243f7bfd1e97f511fec43a80f535cf6b0ef6b086776",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -363,7 +367,7 @@ mod tests {
                     tag: Some("tag1".to_string()),
                     application: Some("app1".to_string()),
                 },
-                "223755482",
+                "3490958009",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -373,7 +377,7 @@ mod tests {
                     tag: None,
                     application: Some("app1".to_string()),
                 },
-                "1152081721",
+                "735741469",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -383,7 +387,7 @@ mod tests {
                     tag: Some("tag1".to_string()),
                     application: None,
                 },
-                "990623045",
+                "3954905097",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
@@ -393,7 +397,7 @@ mod tests {
                     tag: None,
                     application: None,
                 },
-                "1293485139",
+                "4162557545",
             ),
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `IDGenerator` in `dragonfly-client-util` to include the `TaskType` in its hashing logic and modifies the associated test cases to reflect the new behavior. These changes ensure that task IDs are now uniquely influenced by their task type, improving the specificity of the generated IDs.

### Core functionality updates:
* Added `TaskType::Standard` and `TaskType::PersistentCache` to the hashing logic in the `IDGenerator` implementation, ensuring task IDs are differentiated by their task type. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R155-R156) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1R211-R212)

### Test updates:
* Updated expected hash values in `mod tests` to align with the new hashing logic that incorporates `TaskType`. This affects multiple test cases, ensuring they reflect the updated ID generation behavior:
  - Updated hash values for various configurations of `application` and `filtered_query_params`. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L280-R284) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L291-R295) [[3]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L302-R306) [[4]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L313-R317) [[5]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L324-R328) [[6]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L335-R339)
  - Updated hash values for configurations involving `tag` and `application`. [[1]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L366-R370) [[2]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L376-R380) [[3]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L386-R390) [[4]](diffhunk://#diff-0facc381d7000044e4fade29b772456b0234ce8f1fa844d8f487bafa375bb6f1L396-R400)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
