### PR TITLE
feat: increase GRPC REQUEST_TIMEOUT to 15 seconds and add comment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "clap",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bincode",
  "bytes",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.28"
+version = "0.2.29"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.28" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.28" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.28" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.28" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.28" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.28" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.28" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.29" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.29" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.29" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.29" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.29" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.29" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.29" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -34,8 +34,12 @@ pub mod scheduler;
 /// CONNECT_TIMEOUT is the timeout for GRPC connection.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// REQUEST_TIMEOUT is the timeout for GRPC requests.
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// REQUEST_TIMEOUT is the timeout for GRPC requests, default is 10 second.
+/// Note: This timeout is used for the whole request, including wait for scheduler
+/// scheduling, refer to https://d7y.io/docs/next/reference/configuration/scheduler/.
+/// Scheduler'configure `scheduler.retryInterval`, `scheduler.retryBackToSourceLimit` and `scheduler.retryLimit`
+/// is used for the scheduler to schedule the task.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// TCP_KEEPALIVE is the keepalive duration for TCP connection.
 pub const TCP_KEEPALIVE: Duration = Duration::from_secs(3600);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `Cargo.toml` file to bump the version of multiple dependencies and the package itself, as well as a change to the `REQUEST_TIMEOUT` constant in the `grpc` module to extend the timeout duration and provide additional documentation.

### Dependency and version updates:
* Updated the package version in `Cargo.toml` from `0.2.28` to `0.2.29`.
* Updated the versions of several workspace dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, etc.) in `Cargo.toml` from `0.2.28` to `0.2.29`.

### Timeout configuration changes:
* Increased the `REQUEST_TIMEOUT` constant in `dragonfly-client/src/grpc/mod.rs` from 5 seconds to 15 seconds and added detailed documentation explaining its purpose and relation to scheduler configuration.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
