### PR TITLE
feat: add hardlink when task is downloaded

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+          toolchain: 1.85.0
 
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "bincode",
  "bytes",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.29"
+version = "0.2.30"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.29" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.29" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.29" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.29" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.29" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.29" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.29" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.30" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.30" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.30" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.30" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.30" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.30" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.30" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `Cargo.toml` file and introduces new functionality in the `dragonfly-client` project. The changes primarily involve version updates for dependencies and a new feature for handling hard links during task processing.

### Dependency Updates:

* Updated the workspace version from `0.2.29` to `0.2.30` in `Cargo.toml`. This includes all related dependencies such as `dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, and others. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### New Feature:

* Added logic in `dragonfly-client/src/resource/task.rs` to handle hard link creation for task files. The behavior depends on the `force_hard_link` setting:
  - If `force_hard_link` is `true`, an error is returned immediately if hard link creation fails.
  - If `force_hard_link` is `false`, it falls back to copying the file if hard link creation fails.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
