### PR TITLE
chore(README.md): add maintainer google groups for communication channels and remove discussion group

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ You can find the full documentation on the [d7y.io](https://d7y.io).
 Join the conversation and help the community.
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Discussion Group**: <dragonfly-discuss@googlegroups.com>
+- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
+- **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
 - **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the community contact information in the `README.md` file to reflect current communication channels and improve clarity.

Updates to community contact information:

* Replaced the outdated "Discussion Group" email with a link to GitHub Discussions using a reference-style link `[discussion]`.
* Updated the "Github Discussions" entry to "Maintainer Group" with the corresponding email address `<dragonfly-maintainers@googlegroups.com>`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
