### PR TITLE
feat: remove span in get piece

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.31"
+version = "0.2.32"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.31" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.31" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.31" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.31" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.31" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.31" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.31" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.32" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.32" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.32" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.32" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.32" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.32" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.32" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -140,7 +140,6 @@ impl Piece {
     }
 
     /// get gets a piece from the local storage.
-    #[instrument(skip_all)]
     pub fn get(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_piece(piece_id)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `Cargo.toml` file to increment the version of the package and its dependencies, as well as a minor change in the `dragonfly-client/src/resource/piece.rs` file to remove the `#[instrument(skip_all)]` attribute from the `get` method.

### Version updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Incremented the package version from `0.2.31` to `0.2.32` and updated all related dependencies to match the new version. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Code cleanup:
* [`dragonfly-client/src/resource/piece.rs`](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L143): Removed the `#[instrument(skip_all)]` attribute from the `get` method, simplifying the function's implementation.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
