### PR TITLE
feat: collects pieces from multiple parents with load balancing strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,12 +961,14 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "dashmap",
  "dragonfly-api",
  "dragonfly-client-backend",
  "dragonfly-client-config",
  "dragonfly-client-core",
  "dragonfly-client-storage",
  "dragonfly-client-util",
+ "fastrand",
  "fs2",
  "fslock",
  "futures",
@@ -1230,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "findshlibs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "headers 0.4.0",
  "hyper 1.6.0",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bincode",
  "bytes",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.33"
+version = "0.2.34"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.33" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.33" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.33" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.33" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.33" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.33" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.33" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.34" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.34" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.34" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.34" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.34" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.34" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.34" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -84,6 +84,8 @@ http-body-util = "0.1.3"
 termion = "4.0.5"
 tabled = "0.19.0"
 path-absolutize = "3.1.1"
+dashmap = "6.1.0"
+fastrand = "2.3.0"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -246,11 +246,24 @@ impl PieceCollector {
                         tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS).await;
                     };
 
-                    let parents = collected_pieces
-                        .get(&message.number)
-                        .map(|v| v.clone())
-                        .unwrap();
-                    let parent = parents.get(fastrand::usize(..parents.len())).unwrap();
+                    let parents = match collected_pieces.get(&message.number) {
+                        Some(v) => v.clone(),
+                        None => {
+                            error!("collected_pieces does not contain piece {}", message.number);
+                            continue;
+                        }
+                    };
+
+                    let parent = match parents.get(fastrand::usize(..parents.len())) {
+                        Some(parent) => parent,
+                        None => {
+                            error!(
+                                "collected_pieces does not contain parent for piece {}",
+                                message.number
+                            );
+                            continue;
+                        }
+                    };
 
                     info!(
                         "picked up piece {}-{} metadata from parent {}",
@@ -514,11 +527,24 @@ impl PersistentCachePieceCollector {
                         tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS).await;
                     };
 
-                    let parents = collected_pieces
-                        .get(&message.number)
-                        .map(|v| v.clone())
-                        .unwrap();
-                    let parent = parents.get(fastrand::usize(..parents.len())).unwrap();
+                    let parents = match collected_pieces.get(&message.number) {
+                        Some(v) => v.clone(),
+                        None => {
+                            error!("collected_pieces does not contain piece {}", message.number);
+                            continue;
+                        }
+                    };
+
+                    let parent = match parents.get(fastrand::usize(..parents.len())) {
+                        Some(parent) => parent,
+                        None => {
+                            error!(
+                                "collected_pieces does not contain parent for piece {}",
+                                message.number
+                            );
+                            continue;
+                        }
+                    };
 
                     info!(
                         "picked up piece {}-{} metadata from parent {}",

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::grpc::dfdaemon_upload::DfdaemonUploadClient;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use dragonfly_api::common::v2::Host;
 use dragonfly_api::dfdaemon::v2::{SyncPersistentCachePiecesRequest, SyncPiecesRequest};
 use dragonfly_client_config::dfdaemon::Config;
@@ -232,10 +232,7 @@ impl PieceCollector {
                     tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS).await;
                     let parents = match collected_pieces.remove(&message.number) {
                         Some((_, parents)) => parents,
-                        None => {
-                            error!("collected_pieces does not contain piece {}", message.number);
-                            continue;
-                        }
+                        None => continue,
                     };
 
                     let parent = match parents.get(fastrand::usize(..parents.len())) {
@@ -495,10 +492,7 @@ impl PersistentCachePieceCollector {
                     tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS).await;
                     let parents = match collected_pieces.remove(&message.number) {
                         Some((_, parents)) => parents,
-                        None => {
-                            error!("collected_pieces does not contain piece {}", message.number);
-                            continue;
-                        }
+                        None => continue,
                     };
 
                     let parent = match parents.get(fastrand::usize(..parents.len())) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the early stage, the pieces are downloaded from a non-dispersed set of parents, resulting in most pieces being downloaded from a single parent. This uneven bandwidth allocation impacts the overall download speed.

![image](https://github.com/user-attachments/assets/7783ae51-49e5-4676-9ab2-3c8b82b58859)
![image](https://github.com/user-attachments/assets/a6470d84-9faf-48eb-a44e-99a4feb192e6)

This strategy is particularly effective when downloading multiple pieces simultaneously, as it naturally spreads the workload across the available parent pool.

The collection process works in two phases:
1. **Synchronization Phase**: Waits for a configured duration (DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS) to collect the same piece information from different parents. This allows the collector to gather multiple sources for each piece.
2. **Selection Phase**: After the wait period, randomly selects one parent from the available candidates for each piece and forwards it to the piece downloader.

**Load Balancing Strategy**:
The random parent selection is designed to distribute download load across multiple parents during concurrent piece downloads. This approach ensures:
- Optimal utilization of bandwidth from multiple parent nodes
- Prevention of overwhelming any single parent with too many requests
- Better overall download performance through parallel connections

![image](https://github.com/user-attachments/assets/227813a4-7330-44b0-b979-6fa10249a359)