### PR TITLE
feat(dragonfly-client-storage): add dist_threshold for disk usage calculation in GC policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "bincode",
  "bytes",
@@ -1143,15 +1143,16 @@ dependencies = [
  "rocksdb",
  "serde",
  "sha2",
- "tempdir",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1341,12 +1342,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1566,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
@@ -3625,19 +3620,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -3676,21 +3658,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3741,15 +3708,6 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3828,15 +3786,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqsign"
@@ -4663,16 +4612,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.34"
+version = "0.2.35"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.34" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.34" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.34" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.34" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.34" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.34" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.34" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.35" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.35" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.35" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.35" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.35" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.35" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.35" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -30,9 +30,10 @@ bytes.workspace = true
 bytesize.workspace = true
 num_cpus = "1.0"
 bincode = "1.3.3"
+walkdir = "2.5.0"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile.workspace = true
 criterion = "0.5"
 
 [[bench]]

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -938,7 +938,7 @@ impl Metadata<RocksdbStorageEngine> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[test]
     fn test_calculate_digest() {
@@ -956,7 +956,7 @@ mod tests {
 
     #[test]
     fn should_create_metadata() {
-        let dir = TempDir::new("metadata").unwrap();
+        let dir = tempdir().unwrap();
         let log_dir = dir.path().join("log");
         let metadata = Metadata::new(Arc::new(Config::default()), dir.path(), &log_dir).unwrap();
         assert!(metadata.get_tasks().unwrap().is_empty());
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn test_task_lifecycle() {
-        let dir = TempDir::new("metadata").unwrap();
+        let dir = tempdir().unwrap();
         let log_dir = dir.path().join("log");
         let metadata = Metadata::new(Arc::new(Config::default()), dir.path(), &log_dir).unwrap();
         let task_id = "d3c4e940ad06c47fc36ac67801e6f8e36cb400e2391708620bc7e865b102062c";
@@ -1028,7 +1028,7 @@ mod tests {
 
     #[test]
     fn test_piece_lifecycle() {
-        let dir = TempDir::new("metadata").unwrap();
+        let dir = tempdir().unwrap();
         let log_dir = dir.path().join("log");
         let metadata = Metadata::new(Arc::new(Config::default()), dir.path(), &log_dir).unwrap();
         let task_id = "d3c4e940ad06c47fc36ac67801e6f8e36cb400e2391708620bc7e865b102062c";

--- a/dragonfly-client-storage/src/storage_engine/rocksdb.rs
+++ b/dragonfly-client-storage/src/storage_engine/rocksdb.rs
@@ -252,7 +252,7 @@ where
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
     struct Object {
@@ -265,7 +265,7 @@ mod tests {
     }
 
     fn create_test_engine() -> RocksdbStorageEngine {
-        let temp_dir = TempDir::new("rocksdb_test").unwrap();
+        let temp_dir = tempdir().unwrap();
         let log_dir = temp_dir.path().to_path_buf();
         RocksdbStorageEngine::open(temp_dir.path(), &log_dir, &[Object::NAMESPACE], false).unwrap()
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces updates to the Dragonfly client codebase, focusing on version upgrades, disk space management enhancements, and testing improvements. The most significant changes involve adding a new `dist_threshold` configuration for disk space management, replacing the `tempdir` dependency with `tempfile`, and upgrading the version of dependencies across multiple components.

### Version Upgrades:
* Updated the version of all Dragonfly client dependencies from `0.2.34` to `0.2.35` in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Disk Space Management Enhancements:
* Added a new `dist_threshold` field to the `Policy` struct in `dragonfly-client-config/src/dfdaemon.rs`, allowing disk space management to be based on a logical portion of the disk rather than the entire disk volume. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1058-R1070) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1088)
* Enhanced the `available_space` and `total_space` methods in `dragonfly-client-storage/src/content.rs` to account for the `dist_threshold` configuration.

### Dependency Updates:
* Replaced the deprecated `tempdir` dependency with `tempfile` across multiple test files, including `dragonfly-client-storage/src/content.rs`, `dragonfly-client-storage/src/metadata.rs`, and `dragonfly-client-storage/src/storage_engine/rocksdb.rs`. [[1]](diffhunk://#diff-2c03376b0ad153d44b0f6af6709c05dc4d1ff5e1f00dc9bccc34611868d2f6cdL628-R661) [[2]](diffhunk://#diff-58e1a6463adbab70df687ead673404e28a954e0a3e955683356e63eda00dcfe9L941-R941) [[3]](diffhunk://#diff-9851d5766f56f7df703ccd575db532d2a1fc71c4031750e5f1e644af33065592L255-R255)
* Added `walkdir` as a new dependency in `dragonfly-client-storage/Cargo.toml` for directory traversal in disk space calculations.

### Testing Improvements:
* Updated tests in `dragonfly-client-storage/src/content.rs` to validate the new `dist_threshold` logic and ensure proper disk space calculations.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/client/issues/1184
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
