### PR TITLE
feat: if the task has started downloading, wait for the first piece to begin downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "bincode",
  "bytes",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.37"
+version = "0.2.38"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.37" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.37" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.37" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.37" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.37" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.37" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.37" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.38" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.38" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.38" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.38" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.38" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.38" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.38" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the first sync, if the task has started downloading, wait for the first piece to begin downloading. This prevents the child from receiving an empty piece, which would cause disconnection from the parent and rescheduling. Waiting ensures the child avoids unnecessary rescheduling and maximizes the chance to download pieces from the parent.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
