### PR TITLE
chore(ci/Dockerfile): add tools for base image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -55,8 +55,9 @@ RUN go install github.com/google/pprof@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl bash-completion procps infiniband-diags ibverbs-utils \
-    apache2-utils ca-certificates binutils dnsutils iputils-ping llvm dstat sysstat net-tools \
+RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio wget curl \
+    iotop sysstat bash-completion procps apache2-utils ca-certificates binutils \
+    dnsutils iputils-ping vim llvm graphviz lsof socat strace dstat net-tools \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/client/target/release/dfget /usr/local/bin/dfget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the dependencies in the `ci/Dockerfile` to streamline the development environment and enhance utility tools. The most significant changes involve replacing and adding packages to better suit the project's requirements.

Dependency updates:

* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL58-R60): Replaced `infiniband-diags` and `ibverbs-utils` with `iperf3` and `fio` to focus on network performance and I/O benchmarking tools.
* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL58-R60): Added new packages such as `iotop`, `vim`, `graphviz`, `lsof`, `socat`, and `strace` to enhance debugging, visualization, and monitoring capabilities.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
