### PR TITLE
feat: support HTTPS protocol for otel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "bincode",
  "bytes",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.39"
+version = "0.2.40"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.39" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.39" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.39" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.39" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.39" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.39" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.39" }
+dragonfly-client = { path = "dragonfly-client", version = "0.2.40" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.40" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.40" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.40" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.40" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.40" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.40" }
 dragonfly-api = "=2.1.39"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-init/src/bin/main.rs
+++ b/dragonfly-client-init/src/bin/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<(), anyhow::Error> {
         None,
         None,
         None,
+        None,
         false,
         args.console,
     );

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -136,6 +136,7 @@ impl ExportCommand {
             None,
             None,
             None,
+            None,
             false,
             self.console,
         );

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -142,6 +142,7 @@ impl ImportCommand {
             None,
             None,
             None,
+            None,
             false,
             self.console,
         );

--- a/dragonfly-client/src/bin/dfcache/stat.rs
+++ b/dragonfly-client/src/bin/dfcache/stat.rs
@@ -88,6 +88,7 @@ impl StatCommand {
             None,
             None,
             None,
+            None,
             false,
             self.console,
         );

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -147,6 +147,7 @@ async fn main() -> Result<(), anyhow::Error> {
         args.log_max_files,
         config.tracing.protocol.clone(),
         config.tracing.endpoint.clone(),
+        config.tracing.path.clone(),
         Some(config.tracing.headers.clone()),
         Some(config.host.clone()),
         config.seed_peer.enable,

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -307,6 +307,7 @@ async fn main() -> anyhow::Result<()> {
         None,
         None,
         None,
+        None,
         false,
         args.console,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces updates to the versioning in `Cargo.toml` and adds enhancements to tracing functionality in the `dragonfly-client` and `dragonfly-client-config` crates. The most significant changes include the addition of a configurable tracing path, updates to the `Tracing` struct and its default implementation, and adjustments to tracing initialization logic to support dynamic endpoint path construction.

### Version Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated all dependencies from version `0.2.39` to `0.2.40`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### Enhancements to Tracing Functionality:
* [`dragonfly-client-config/src/dfdaemon.rs`](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR167-R172): Added a new `path` field to the `Tracing` struct to specify the tracing log endpoint path, with a default value of `/v1/traces`. Implemented a `Default` trait for the `Tracing` struct to initialize this field. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR167-R172) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL1463-R1469) [[3]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1480-R1500)
* [`dragonfly-client/src/tracing/mod.rs`](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R49): Updated the `init_tracing` function to include the `otel_path` parameter, allowing dynamic construction of the endpoint URL by appending the specified path. Adjusted the logic to handle both HTTP and gRPC protocols. [[1]](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R49) [[2]](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79L125-R150)

### Unit Test Updates:
* [`dragonfly-client-config/src/dfdaemon.rs`](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR2215-R2225): Enhanced the `Tracing` struct's unit tests to validate the `path` field and ensure headers are correctly parsed.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
