### PR TITLE
fix: OTLP endpoint URL parsing to correctly include protocol in tracing module

### DIFF
--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -135,7 +135,7 @@ pub fn init_tracing(
                     .expect("failed to create OTLP exporter")
             }
             "http" | "https" => {
-                let mut endpoint_url = url::Url::parse(&format!("http://{}", endpoint))
+                let mut endpoint_url = url::Url::parse(&format!("{}://{}", protocol, endpoint))
                     .expect("failed to parse OTLP endpoint URL");
 
                 if let Some(path) = otel_path {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a single change to the `init_tracing` function in the `dragonfly-client/src/tracing/mod.rs` file. The change updates the URL construction logic to dynamically use the specified protocol (`http` or `https`) instead of defaulting to `http`.

- [`dragonfly-client/src/tracing/mod.rs`](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79L138-R138): Modified the `init_tracing` function to use the `protocol` variable for constructing the OTLP endpoint URL, ensuring compatibility with both `http` and `https`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
