### PR TITLE
chore: update cargo version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "0.2.42"
+version = "1.0.0"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.42"
+version = "1.0.0"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "0.2.42" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "0.2.42" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "0.2.42" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "0.2.42" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "0.2.42" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "0.2.42" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "0.2.42" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.0" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.0" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.0" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.0" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.0" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.0" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.0" }
 dragonfly-api = "=2.1.40"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the versioning in the `Cargo.toml` file to reflect a major release, moving from version `0.2.42` to `1.0.0`. It also updates the dependencies to align with the new version.

Versioning updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Changed the workspace package version from `0.2.42` to `1.0.0`, indicating a major release.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31): Updated all `dragonfly-client` dependencies to use version `1.0.0`, ensuring consistency across the workspace.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
