### PR TITLE
feat: Update error message in task.rs to remove 'persistent cache' reference

### DIFF
--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -239,7 +239,7 @@ impl Task {
         // store the task.
         if !task.is_finished() && !self.storage.has_enough_space(content_length)? {
             return Err(Error::NoSpace(format!(
-                "not enough space to store the persistent cache task: content_length={}",
+                "not enough space to store the task: content_length={}",
                 content_length
             )));
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a minor change to the error message in the `Task` implementation in `dragonfly-client/src/resource/task.rs`. The updated message removes the term "persistent cache," simplifying the phrasing for clarity.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
