### PR TITLE
chore(Dockerfile): support jemalloc for 64K page size

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -34,7 +34,11 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-RUN cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfcache
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+  "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
+  esac && \
+  cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfcache
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -34,7 +34,11 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-RUN cargo build --verbose --bin dfget --bin dfdaemon --bin dfcache
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+  "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
+  esac && \
+  cargo build --verbose --bin dfget --bin dfdaemon --bin dfcache
 
 RUN cargo install flamegraph --root /usr/local
 RUN cargo install bottom --locked --root /usr/local

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -34,7 +34,11 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-RUN cargo build --release --verbose --bin dfinit
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+  "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
+  esac && \
+  cargo build --release --verbose --bin dfinit
 
 FROM public.ecr.aws/debian/debian:bookworm-slim
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces architecture-specific build configurations for the Dragonfly client in multiple Dockerfiles. The changes ensure compatibility with `linux/arm64` by setting the `JEMALLOC_SYS_WITH_LG_PAGE` environment variable during the build process.

Architecture-specific build configurations:

* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL37-R41): Added `ARG TARGETARCH` and conditional logic to set `JEMALLOC_SYS_WITH_LG_PAGE=16` for `linux/arm64` builds before running `cargo build` for `dfget`, `dfdaemon`, and `dfcache`.
* [`ci/Dockerfile.debug`](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L37-R41): Added `ARG TARGETARCH` and conditional logic to set `JEMALLOC_SYS_WITH_LG_PAGE=16` for `linux/arm64` builds before running `cargo build` for `dfget`, `dfdaemon`, and `dfcache`.
* [`ci/Dockerfile.dfinit`](diffhunk://#diff-4bc49af73ee4c312bbe45791f2bb95c950ecc719ca34b5bf59af0649db904dc5L37-R41): Added `ARG TARGETARCH` and conditional logic to set `JEMALLOC_SYS_WITH_LG_PAGE=16` for `linux/arm64` builds before running `cargo build` for `dfinit`.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/client/issues/1083
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
