### PR TITLE
chore(Dockerfile): Change TARGETARCH to TARGETPLATFORM in Dockerfiles for multi-platform builds

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -34,8 +34,8 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-ARG TARGETARCH
-RUN case "${TARGETARCH}" in \
+ARG TARGETPLATFORM
+RUN case "${TARGETPLATFORM}" in \
   "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
   esac && \
   cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfcache

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -34,8 +34,8 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-ARG TARGETARCH
-RUN case "${TARGETARCH}" in \
+ARG TARGETPLATFORM
+RUN case "${TARGETPLATFORM}" in \
   "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
   esac && \
   cargo build --verbose --bin dfget --bin dfdaemon --bin dfcache

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -34,8 +34,8 @@ COPY dragonfly-client-util/src ./dragonfly-client-util/src
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 
-ARG TARGETARCH
-RUN case "${TARGETARCH}" in \
+ARG TARGETPLATFORM
+RUN case "${TARGETPLATFORM}" in \
   "linux/arm64") export JEMALLOC_SYS_WITH_LG_PAGE=16;; \
   esac && \
   cargo build --release --verbose --bin dfinit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Dockerfiles for various build configurations to use `TARGETPLATFORM` instead of `TARGETARCH`. This change ensures compatibility with platform-specific builds and aligns with Docker's recommended practices.

### Updates to build configuration:

* [`ci/Dockerfile`](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL37-R38): Replaced `TARGETARCH` with `TARGETPLATFORM` in the `ARG` declaration and the conditional logic for setting `JEMALLOC_SYS_WITH_LG_PAGE`. This affects the build process for `dfget`, `dfdaemon`, and `dfcache`.
* [`ci/Dockerfile.debug`](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L37-R38): Made the same replacement as above for the debug Dockerfile, ensuring consistent handling of platform-specific builds for `dfget`, `dfdaemon`, and `dfcache`.
* [`ci/Dockerfile.dfinit`](diffhunk://#diff-4bc49af73ee4c312bbe45791f2bb95c950ecc719ca34b5bf59af0649db904dc5L37-R38): Updated the `ARG` declaration and conditional logic to use `TARGETPLATFORM` for the `dfinit` binary build process.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
