### PR TITLE
chore: update cargo version to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.1" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.1" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.1" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.1" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.1" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.1" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.1" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.2" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.2" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.2" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.2" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.2" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.2" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.2" }
 dragonfly-api = "=2.1.40"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the version of the `dragonfly-client` workspace packages from `1.0.1` to `1.0.2` in the `Cargo.toml` file. These changes ensure that the workspace dependencies align with the latest version.

Version updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Updated the `workspace.package.version` from `1.0.1` to `1.0.2`.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31): Updated the version of all `dragonfly-client` workspace dependencies from `1.0.1` to `1.0.2`. This includes `dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-util`, and `dragonfly-client-init`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
