### PR TITLE
feat: Create a blacklist of backends that do not support directory downloads

### DIFF
--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -241,9 +241,9 @@ impl BackendFactory {
         Ok(backend_factory)
     }
 
-    /// supported_download_directory returns whether the scheme supports directory download.
-    pub fn supported_download_directory(scheme: &str) -> bool {
-        object_storage::Scheme::from_str(scheme).is_ok() || scheme == hdfs::HDFS_SCHEME
+    /// unsupported_download_directory returns whether the scheme does not support directory download.
+    pub fn unsupported_download_directory(scheme: &str) -> bool {
+        scheme == http::HTTP_SCHEME || scheme == http::HTTPS_SCHEME
     }
 
     /// build returns the backend by the scheme of the url.

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -23,7 +23,6 @@ use libloading::Library;
 use reqwest::header::HeaderMap;
 use rustls_pki_types::CertificateDer;
 use std::path::Path;
-use std::str::FromStr;
 use std::{collections::HashMap, pin::Pin, time::Duration};
 use std::{fmt::Debug, fs};
 use tokio::io::{AsyncRead, AsyncReadExt};

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -608,7 +608,7 @@ async fn run(mut args: Args, dfdaemon_download_client: DfdaemonDownloadClient) -
     // then download all files in the directory. Otherwise, download the single file.
     let scheme = args.url.scheme();
     if args.url.path().ends_with('/') {
-        if !BackendFactory::supported_download_directory(scheme) {
+        if BackendFactory::unsupported_download_directory(scheme) {
             return Err(Error::Unsupported(format!("{} download directory", scheme)));
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create a blacklist of backends that do not support directory downloads. Currently only http and https can't download directory. This helps the backend plugin to download the directory

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
