### PR TITLE
feat: add panic log for tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
+ "tracing-panic",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -5178,6 +5179,16 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf1298a179837099f9309243af3b554e840f7f67f65e9f55294913299bd4cc5"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -65,6 +65,7 @@ lazy_static.workspace = true
 futures.workspace = true
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "chrono"] }
+tracing-panic = "0.1.2"
 tracing-opentelemetry = "0.30.0"
 opentelemetry = { version = "0.29.1", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.29.0", default-features = false, features = ["trace", "grpc-tonic", "http-proto", "reqwest-blocking-client"] }

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -203,6 +203,7 @@ pub fn init_tracing(
         subscriber.init();
     }
 
+    std::panic::set_hook(Box::new(tracing_panic::panic_hook));
     info!(
         "tracing initialized directory: {}, level: {}",
         log_dir.as_path().display(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new dependency for panic tracing and integrates it into the tracing initialization process in the `dragonfly-client` project. The most important changes include adding the `tracing-panic` crate and setting up a panic hook using this crate.

### Dependency Updates:
* [`dragonfly-client/Cargo.toml`](diffhunk://#diff-651fbc571d827abadd8e14ed21f83bc11941b8733f2d9704b93ae13b4dbfbb31R68): Added the `tracing-panic` crate (version `0.1.2`) to enhance panic handling during runtime tracing.

### Tracing Initialization Enhancements:
* [`dragonfly-client/src/tracing/mod.rs`](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R206): Integrated the `tracing-panic` crate by setting a custom panic hook using `std::panic::set_hook`. This ensures that panic events are captured and logged via the tracing system.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
