### PR TITLE
feat: move metadata update after content task creation in Storage::download_task_started

### DIFF
--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -119,13 +119,6 @@ impl Storage {
         response_header: Option<HeaderMap>,
         load_to_cache: bool,
     ) -> Result<metadata::Task> {
-        let metadata = self.metadata.download_task_started(
-            id,
-            Some(piece_length),
-            Some(content_length),
-            response_header,
-        )?;
-
         self.content.create_task(id, content_length).await?;
         if load_to_cache {
             let mut cache = self.cache.clone();
@@ -133,7 +126,12 @@ impl Storage {
             debug!("put task to cache: {}", id);
         }
 
-        Ok(metadata)
+        self.metadata.download_task_started(
+            id,
+            Some(piece_length),
+            Some(content_length),
+            response_header,
+        )
     }
 
     /// download_task_finished updates the metadata of the task when the task downloads finished.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request modifies the `Storage` implementation in `dragonfly-client-storage/src/lib.rs` to streamline the `download_task_started` method by rearranging the order of operations and removing unnecessary intermediate variables.

### Changes to method logic:

* Refactored the `download_task_started` method to directly return the result of `self.metadata.download_task_started` instead of storing it in a temporary variable (`metadata`). This simplifies the code and reduces redundancy.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
