### PR TITLE
feat: update default plugin directory to /usr/local/lib/dragonfly/plugins/ on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.2" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.2" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.2" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.2" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.2" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.2" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.2" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.3" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.3" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.3" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.3" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.3" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.3" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.3" }
 dragonfly-api = "=2.1.43"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -104,7 +104,7 @@ pub fn default_lock_dir() -> PathBuf {
 /// default_plugin_dir is the default plugin directory for client.
 pub fn default_plugin_dir() -> PathBuf {
     #[cfg(target_os = "linux")]
-    return PathBuf::from("/var/lib/dragonfly/plugins/");
+    return PathBuf::from("/usr/local/lib/dragonfly/plugins/");
 
     #[cfg(target_os = "macos")]
     return home::home_dir().unwrap().join(".dragonfly").join("plugins");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the versioning of dependencies and workspace packages in `Cargo.toml`, along with a change to the default plugin directory path in `dragonfly-client-config`. These changes ensure compatibility with the new version `1.0.3` and adjust the default directory structure for Linux systems.

### Dependency and version updates:
* Updated the workspace package version from `1.0.2` to `1.0.3` in `Cargo.toml`. This reflects a new release of the package.
* Updated the versions of all `dragonfly-client` dependencies in `Cargo.toml` from `1.0.2` to `1.0.3` to maintain consistency with the new release.

### Configuration changes:
* Changed the default plugin directory for Linux systems in the `default_plugin_dir` function from `/var/lib/dragonfly/plugins/` to `/usr/local/lib/dragonfly/plugins/` in `dragonfly-client-config/src/lib.rs`. This aligns with standard practices for local installations.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
