### PR TITLE
fix: rename scheduler_cluster_id in the host config

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -417,6 +417,7 @@ pub struct Host {
     /// scheduler_cluster_id is the ID of the cluster to which the scheduler belongs.
     /// NOTE: This field is used to identify the cluster to which the scheduler belongs.
     /// If this flag is set, the idc, location, hostname and ip will be ignored when listing schedulers.
+    #[serde(rename = "schedulerClusterID")]
     pub scheduler_cluster_id: Option<u64>,
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `dragonfly-client-config/src/dfdaemon.rs` file. The change adds a `#[serde(rename = "schedulerClusterID")]` attribute to the `scheduler_cluster_id` field to specify a custom serialization name.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
