### PR TITLE
feat: add include-files argrument in the downloaded directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "prometheus",
  "prost-wkt-types",
  "rcgen",
+ "regex",
  "reqwest",
  "rolling-file",
  "rustls 0.22.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "prometheus",
  "prost-wkt-types",
  "rcgen",
- "regex",
  "reqwest",
  "rolling-file",
  "rustls 0.22.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "fs2",
  "fslock",
  "futures",
+ "glob",
  "hashring",
  "http 1.3.1",
  "http-body-util",
@@ -1477,9 +1478,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -166,7 +166,7 @@ where
 }
 
 /// The File Entry of a directory, including some relevant file metadata.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DirEntry {
     /// url is the url of the entry.
     pub url: String,

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -87,6 +87,7 @@ tabled = "0.20.0"
 path-absolutize = "3.1.1"
 dashmap = "6.1.0"
 fastrand = "2.3.0"
+regex = "1.11.0"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -88,6 +88,7 @@ path-absolutize = "3.1.1"
 dashmap = "6.1.0"
 fastrand = "2.3.0"
 regex = "1.11.0"
+glob = "0.3.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -87,7 +87,6 @@ tabled = "0.20.0"
 path-absolutize = "3.1.1"
 dashmap = "6.1.0"
 fastrand = "2.3.0"
-regex = "1.11.0"
 glob = "0.3.2"
 
 [dev-dependencies]

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -996,7 +996,7 @@ fn filter_entries(
                 }
                 for c in file.chars() {
                     match c {
-                        '*' => pat.push_str(".*"),
+                        '*' => pat.push_str("[^/]*"),
                         '?' => pat.push('.'),
                         '.' => pat.push_str("\\."),
                         _ => pat.push(c),
@@ -1367,16 +1367,9 @@ mod tests {
             },
         ];
 
-        let filtered_entries = filter_entries(url, entries, Some(vec!["dir/file*".to_string()]));
-        assert_eq!(filtered_entries.len(), 2);
-        assert_eq!(
-            filtered_entries[0].url,
-            "http://example.com/root/dir/file.txt"
-        );
-        assert_eq!(
-            filtered_entries[1].url,
-            "http://example.com/root/dir/file2.txt"
-        );
+        let filtered_entries = filter_entries(url, entries, Some(vec!["dir/subdir/*.txt".to_string()]));
+        assert_eq!(filtered_entries.len(), 1);
+        assert_eq!(filtered_entries[0].url, "http://example.com/root/dir/subdir/file3.txt");
     }
 
     #[test]

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -190,7 +190,7 @@ struct Args {
     #[arg(
         long = "include-files",
         required = false,
-        help = "Include files in the downloaded directory, use relative path. e.g. --include-files='*.txt' --include-files='*.txt'"
+        help = "Specify which files to download when retrieving a directory. The file paths listed in include-files should be relative to the current directory. e.g. --include-files='*.txt' --include-files='example.txt'"
     )]
     include_files: Option<Vec<String>>,
 

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1236,29 +1236,6 @@ mod tests {
     }
 
     #[test]
-    fn should_validate_include_files() {
-        let test_cases = vec![
-            (Some(vec!["dir/file.txt".to_string()]), Ok(())),
-            (
-                Some(vec!["dir/*.txt".to_string(), "dir/file2.txt".to_string()]),
-                Ok(()),
-            ),
-            (
-                Some(vec!["dir/ ".to_string(), "dir/file2.txt".to_string()]),
-                Err(Error::InvalidParameter),
-            ),
-            (
-                Some(vec!["/file.txt".to_string(), "dir/file2.txt".to_string()]),
-                Err(Error::InvalidParameter),
-            ),
-        ];
-
-        for (include_files, _) in test_cases {
-            let result = validate_include_files(include_files);
-            assert_eq!(result.is_ok(), result.is_ok());
-        }
-    }
-    #[test]
     fn should_filter_entries() {
         let url = Url::parse("http://example.com/root/").unwrap();
         let entries = vec![

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1367,9 +1367,13 @@ mod tests {
             },
         ];
 
-        let filtered_entries = filter_entries(url, entries, Some(vec!["dir/subdir/*.txt".to_string()]));
+        let filtered_entries =
+            filter_entries(url, entries, Some(vec!["dir/subdir/*.txt".to_string()]));
         assert_eq!(filtered_entries.len(), 1);
-        assert_eq!(filtered_entries[0].url, "http://example.com/root/dir/subdir/file3.txt");
+        assert_eq!(
+            filtered_entries[0].url,
+            "http://example.com/root/dir/subdir/file3.txt"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Include files in the downloaded directory, use relative path. e.g. --include-files='*.txt' --include-files='*.txt'

- Include files in the downloaded directory, use relative path.
- Support regular expression matching, e.g. 'dir/*', '*.txt'.
- Support illegal path checking

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
