### PR TITLE
feat(dragonfly-client): change permissions of download grpc uds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.4"
+version = "1.0.5"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.4" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.4" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.4" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.4" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.4" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.4" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.4" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.5" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.5" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.5" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.5" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.5" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.5" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.5" }
 dragonfly-api = "=2.1.47"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -148,7 +148,7 @@ impl DfdaemonDownloadServer {
 
         // Bind the unix domain socket and set the permissions for the socket.
         let uds = UnixListener::bind(&self.socket_path)?;
-        let perms = std::fs::Permissions::from_mode(0o660);
+        let perms = std::fs::Permissions::from_mode(0o777);
         fs::set_permissions(&self.socket_path, perms).await?;
 
         // TODO(Gaius): RateLimitLayer is not implemented Clone, so we can't use it here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor change to the permissions of a Unix domain socket in the `DfdaemonDownloadServer` implementation. The permissions have been updated from `0o660` to `0o777` to allow broader access.

* [`dragonfly-client/src/grpc/dfdaemon_download.rs`](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL151-R151): Changed the permissions for the Unix domain socket from `0o660` (read/write for owner and group) to `0o777` (read/write/execute for everyone).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
