### PR TITLE
feat: Bump dragonfly-api to 2.1.49 and add local_only support for task stat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.47"
+version = "2.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490d6bcc647f10a00afbf64f9180f5e705aeb939aa4d476463c336ab8590cb76"
+checksum = "71caaf1841c95fdffc19943e413db6f1e8f88068b381f148e0645dba9a722841"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.5
 dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.5" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.5" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.5" }
-dragonfly-api = "=2.1.47"
+dragonfly-api = "=2.1.49"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1171,6 +1171,13 @@ fn make_response_headers(
         );
     };
 
+    if download_task_started_response.is_finished {
+        download_task_started_response.response_header.insert(
+            header::DRAGONFLY_TASK_DOWNLOAD_FINISHED_HEADER.to_string(),
+            "true".to_string(),
+        );
+    }
+
     hashmap_to_headermap(&download_task_started_response.response_header)
 }
 

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -144,6 +144,11 @@ impl Piece {
         self.storage.get_piece(piece_id)
     }
 
+    /// get_all gets all pieces of a task from the local storage.
+    pub fn get_all(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
+        self.storage.get_pieces(task_id)
+    }
+
     /// calculate_interested calculates the interested pieces by content_length and range.
     pub fn calculate_interested(
         &self,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several updates to the Dragonfly client, focusing on enhancing task handling, improving tracing, and standardizing headers. Key changes include adding a `local_only` flag to task status queries, extending task metadata handling for local storage, and renaming constants for clarity. Below is a breakdown of the most important changes:

### Enhancements to Task Handling:
* Added a `local_only` flag to the `stat_task` methods in both `DfdaemonDownloadServerHandler` and `DfdaemonUploadServerHandler`, allowing task status to be queried exclusively from local storage. This includes updates to span recording and method signatures. (`dragonfly-client/src/grpc/dfdaemon_download.rs`: [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL672-R672) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR691-R701) [[3]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL706-R710); `dragonfly-client/src/grpc/dfdaemon_upload.rs`: [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L640-R640) [[5]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R656-R666) [[6]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L671-R675)
* Enhanced the `stat` method in the `Task` struct to support retrieving task metadata and pieces from local storage when `local_only` is true. This includes filtering unfinished pieces and constructing a detailed `CommonTask` response. (`dragonfly-client/src/resource/task.rs`: [dragonfly-client/src/resource/task.rsL1838-R1908](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1838-R1908))

### Improvements to Tracing and Metrics:
* Updated tracing spans to include the `local_only` flag in both download and upload server handlers for better observability. (`dragonfly-client/src/grpc/dfdaemon_download.rs`: [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL672-R672) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR691-R701); `dragonfly-client/src/grpc/dfdaemon_upload.rs`: [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L640-R640) [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R656-R666)

### Header Standardization:
* Renamed several header constants for consistency by appending `_HEADER` to their names (e.g., `DRAGONFLY_PIECE_LENGTH` to `DRAGONFLY_PIECE_LENGTH_HEADER`). Updated all references accordingly, including tests and utility functions. (`dragonfly-client/src/proxy/header.rs`: [[1]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL69-R86) [[2]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL196-R201) [[3]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL217-R222) [[4]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL362-R390)
* Introduced a new header constant, `DRAGONFLY_TASK_DOWNLOAD_FINISHED_HEADER`, to indicate when a task download is complete. Added logic to include this header in responses. (`dragonfly-client/src/proxy/header.rs`: [[1]](diffhunk://#diff-1b7f22df92aaf0d22154da5c70908b559ad89e77f9d2e806bf1aa26281c84bccL69-R86); `dragonfly-client/src/proxy/mod.rs`: [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR1174-R1180)

### Codebase Enhancements:
* Added a `get_all` method to the `Piece` struct for retrieving all pieces of a task from local storage. (`dragonfly-client/src/resource/piece.rs`: [dragonfly-client/src/resource/piece.rsR147-R151](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R147-R151))
* Included additional imports (e.g., `HashMap`) and minor refactoring in the `Task` struct to support new functionality. (`dragonfly-client/src/resource/task.rs`: [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L23-R24) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R52) [[3]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R397)

### Dependency Update:
* Updated the `dragonfly-api` dependency version from `2.1.47` to `2.1.49` in `Cargo.toml`. (`Cargo.toml`: [Cargo.tomlL32-R32](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L32-R32))
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
