### PR TITLE
feat: update gRPC server to use non-cloned reflection service and fix task piece filtering logic

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -165,7 +165,7 @@ impl DfdaemonDownloadServer {
             .http2_keepalive_interval(Some(super::HTTP2_KEEP_ALIVE_INTERVAL))
             .http2_keepalive_timeout(Some(super::HTTP2_KEEP_ALIVE_TIMEOUT))
             .layer(rate_limit_layer)
-            .add_service(reflection.clone())
+            .add_service(reflection)
             .add_service(health_service)
             .add_service(service)
             .serve_with_incoming_shutdown(uds_stream, async move {

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -165,7 +165,7 @@ impl DfdaemonUploadServer {
             .http2_keepalive_interval(Some(super::HTTP2_KEEP_ALIVE_INTERVAL))
             .http2_keepalive_timeout(Some(super::HTTP2_KEEP_ALIVE_TIMEOUT))
             .layer(rate_limit_layer)
-            .add_service(reflection.clone())
+            .add_service(reflection)
             .add_service(health_service)
             .add_service(service)
             .serve_with_shutdown(self.addr, async move {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1861,7 +1861,7 @@ impl Task {
 
             let pieces = piece_metadatas
                 .into_iter()
-                .filter(|piece| !piece.is_finished())
+                .filter(|piece| piece.is_finished())
                 .map(|piece| {
                     // The traffic_type indicates whether the first download was from the source or hit the remote peer cache.
                     // If the parent_id exists, the piece was downloaded from a remote peer. Otherwise, it was


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes changes to improve code clarity and fix a filtering logic issue in the `dragonfly-client` project. The most important updates involve removing unnecessary cloning of the `reflection` service and correcting the filtering condition for task pieces.

### Code clarity improvements:
* [`dragonfly-client/src/grpc/dfdaemon_download.rs`](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL168-R168): Removed the unnecessary `.clone()` call on the `reflection` service in the `DfdaemonDownloadServer` implementation.
* [`dragonfly-client/src/grpc/dfdaemon_upload.rs`](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L168-R168): Removed the unnecessary `.clone()` call on the `reflection` service in the `DfdaemonUploadServer` implementation.

### Bug fix:
* [`dragonfly-client/src/resource/task.rs`](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1864-R1864): Fixed the filtering logic in the `Task` implementation by changing the condition to include only finished pieces instead of excluding them.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
