### PR TITLE
feat: use piece_timeout for list task entries

### DIFF
--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -894,9 +894,7 @@ async fn get_entries(
             task_id: Uuid::new_v4().to_string(),
             url: args.url.to_string(),
             request_header: header_vec_to_hashmap(args.header.unwrap_or_default())?,
-            timeout: Some(
-                prost_wkt_types::Duration::try_from(args.timeout).or_err(ErrorType::ParseError)?,
-            ),
+            timeout: None,
             certificate_chain: Vec::new(),
             object_storage,
             hdfs,

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -767,17 +767,6 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 Status::internal(err.to_string())
             })?;
 
-        let timeout = match request.timeout {
-            Some(timeout) => Duration::try_from(timeout).map_err(|err| {
-                // Collect the list tasks failure metrics.
-                collect_list_task_entries_failure_metrics(TaskType::Standard as i32);
-
-                error!("parse timeout: {}", err);
-                Status::invalid_argument(err.to_string())
-            })?,
-            None => self.config.download.piece_timeout,
-        };
-
         // Head the task entries.
         let response = backend
             .head(HeadRequest {
@@ -789,7 +778,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                         Status::internal(err.to_string())
                     },
                 )?),
-                timeout,
+                timeout: self.config.download.piece_timeout,
                 client_cert: None,
                 object_storage: request.object_storage.clone(),
                 hdfs: request.hdfs.clone(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request simplifies the timeout handling logic in the `DfdaemonDownloadServerHandler` implementation by removing the conditional timeout parsing and directly using the default configuration value. 

### Simplification of timeout handling:

* Removed the logic for parsing and validating a custom timeout from the `request` object. The implementation now directly uses `self.config.download.piece_timeout` as the timeout value. (`dragonfly-client/src/grpc/dfdaemon_download.rs`, [dragonfly-client/src/grpc/dfdaemon_download.rsL770-L780](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL770-L780))
* Updated the `timeout` field in the backend request to always use `self.config.download.piece_timeout`, ensuring consistency in timeout configuration. (`dragonfly-client/src/grpc/dfdaemon_download.rs`, [dragonfly-client/src/grpc/dfdaemon_download.rsL792-R781](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL792-R781))
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
