### PR TITLE
feat: Add QUIC Client and Server Implementation for Piece Download in dragonfly-client-storage 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.5
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.5" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.5" }
 dragonfly-api = "=2.1.49"
+vortex-protocol = "0.1.0"
+quinn = "0.10"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+vortex-protocol.workspace = true
+quinn.workspace = true
 dragonfly-client-core.workspace = true
 dragonfly-client-config.workspace = true
 dragonfly-client-util.workspace = true
@@ -28,9 +30,17 @@ fs2.workspace = true
 lru.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
+tonic.workspace = true
+url.workspace = true
+lazy_static.workspace = true
+warp.workspace = true
+sysinfo = { version = "0.32.1", default-features = false, features = ["component", "disk", "network", "system", "user"] }
+prometheus = { version = "0.13", features = ["process"] }
 num_cpus = "1.17"
 bincode = "1.3.3"
 walkdir = "2.5.0"
+prost = "0.13.5"
+leaky-bucket = "1.1.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -1,0 +1,17 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod quic;

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -40,9 +40,9 @@ use std::net::SocketAddr;
 
 const HEADER_SIZE: usize = 6;
 
-/// QuicClient is a Quic-based client for dfdaemon upload service.
+/// QUICClient is a QUIC-based client for dfdaemon upload service.
 #[derive(Clone, Validate)]
-pub struct QuicClient {
+pub struct QUICClient {
     /// server_addr is the address of the QUIC server.
     #[validate(custom = "validate_ip_port")]
     addr: String,
@@ -59,8 +59,8 @@ fn validate_ip_port(address: &str) -> Result<(), ValidationError> {
     }
 }
 
-impl QuicClient {
-    /// Creates a new QuicClient.
+impl QUICClient {
+    /// Creates a new QUICClient.
     #[instrument(skip_all)]
     pub async fn new(
         config: Arc<Config>,
@@ -154,7 +154,7 @@ impl QuicClient {
             error!("Failed to read response header: {}", err);
             ClientError::UnexpectedResponse
         })?;
-        info!("QuicClient can receive data");
+        info!("QUICClient can receive data");
         let length = u32::from_be_bytes(header_buf[2..HEADER_SIZE].try_into().expect("Failed to read value length")) as usize;
 
         // Read response data
@@ -190,3 +190,4 @@ impl QuicClient {
     }
 
 }
+

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -1,0 +1,192 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dragonfly_api::dfdaemon::v2::{ 
+    DownloadPieceResponse,
+    DownloadPersistentCachePieceResponse,
+};
+use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_core::{
+    Error as ClientError, Result as ClientResult,
+};
+use prost::Message;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use quinn::{ClientConfig, Endpoint, NewConnection, RecvStream, SendStream};
+use tokio::time::timeout;
+use tracing::{error, info, instrument};
+use vortex_protocol::{
+    Vortex,
+    tlv::Tag,
+    tlv::download_piece::DownloadPiece,
+};
+use bytes::Bytes;
+use validator::{Validate, ValidationError};
+use std::net::SocketAddr;
+
+const HEADER_SIZE: usize = 6;
+
+/// QuicClient is a Quic-based client for dfdaemon upload service.
+#[derive(Clone, Validate)]
+pub struct QuicClient {
+    /// server_addr is the address of the QUIC server.
+    #[validate(custom = "validate_ip_port")]
+    addr: String,
+    /// timeout is the request timeout.
+    timeout: Duration,
+    endpoint: Endpoint,
+}
+
+/// Validate the address.
+fn validate_ip_port(address: &str) -> Result<(), ValidationError> {
+    match address.parse::<SocketAddr>() {
+        Ok(_) => Ok(()),
+        Err(_) => Err(ValidationError::new("invalid_ip_port")),
+    }
+}
+
+impl QuicClient {
+    /// Creates a new QuicClient.
+    #[instrument(skip_all)]
+    pub async fn new(
+        config: Arc<Config>,
+        addr: String,
+    ) -> ClientResult<Self> {
+        // If it is download piece, use the download piece timeout, otherwise use the
+        // default request timeout.
+        let mut timeout = config.download.piece_timeout;
+        if timeout.is_zero() {
+            timeout = Duration::from_secs(30);
+        }
+
+        // Setup QUIC endpoint (client)
+        let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())
+            .map_err(|e| ClientError::ValidationError(e.to_string()))?;
+        endpoint.set_default_client_config(ClientConfig::with_native_roots());
+
+        let client = Self {
+            addr,
+            timeout,
+            endpoint,
+        };
+
+        // Validate the address
+        match client.validate() {
+            Ok(_) => println!("Valid IP:Port"),
+            Err(e) => println!("Validation error: {:?}", e),
+        }
+        Ok(client)
+    }
+
+    /// Downloads piece content from parent.
+    #[instrument(skip_all)]
+    pub async fn download_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<DownloadPieceResponse> {
+        let value: Bytes = DownloadPiece::new(task_id.to_string(), number).into();
+        let packet = Vortex::new(Tag::DownloadPiece, value).expect("Failed to create Vortex packet");        
+        self.send_and_receive(&packet).await
+    }
+
+    /// Downloads piece content from parent.
+    #[instrument(skip_all)]
+    pub async fn download_persistent_cache_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<DownloadPersistentCachePieceResponse> {
+        let value: Bytes = DownloadPiece::new(task_id.to_string(), number).into();
+        let packet = Vortex::new(Tag::DownloadPiece, value).expect("Failed to create Vortex packet");        
+        self.send_and_receive(&packet).await
+    }
+
+    /// Establishes a QUIC connection to the server.
+    async fn connect(&self) -> Result<NewConnection, ClientError> {
+        let conn = timeout(self.timeout, self.endpoint.connect(self.addr.parse().unwrap(), "dragonfly")).await
+            .map_err(|_| ClientError::HostNotFound(self.addr.clone()))?
+            .map_err(|err| {
+                error!("Failed to connect to {}: {}", self.addr, err);
+                ClientError::HostNotFound(self.addr.clone())
+            })?;
+        Ok(conn)
+    }
+
+    /// Sends a request and receives a response over QUIC.
+    async fn send_and_receive<R: Message + Default>(
+        &self,
+        request: &Vortex,
+    ) -> ClientResult<R> {
+        let conn = self.connect().await?;
+        let (mut send, mut recv) = conn.connection.open_bi().await.map_err(|err| {
+            error!("Failed to open QUIC stream: {}", err);
+            ClientError::MpscSend(err.to_string())
+        })?;
+
+        // Send request data
+        send.write_all(&request.to_bytes()).await.map_err(|err| {
+            error!("Failed to send request: {}", err);
+            ClientError::MpscSend(err.to_string())
+        })?;
+        send.finish().await.map_err(|err| {
+            error!("Failed to finish sending: {}", err);
+            ClientError::MpscSend(err.to_string())
+        })?;
+
+        // Read response header
+        let mut header_buf = [0u8; HEADER_SIZE];
+        recv.read_exact(&mut header_buf).await.map_err(|err| {
+            error!("Failed to read response header: {}", err);
+            ClientError::UnexpectedResponse
+        })?;
+        info!("QuicClient can receive data");
+        let length = u32::from_be_bytes(header_buf[2..HEADER_SIZE].try_into().expect("Failed to read value length")) as usize;
+
+        // Read response data
+        let mut response_data = vec![0u8; length];
+        recv.read_exact(&mut response_data).await.map_err(|err| {
+            error!("Failed to read response data: {}", err);
+            ClientError::UnexpectedResponse
+        })?;
+
+        response_data.splice(0..0, header_buf.iter().copied());
+
+        let deserialized = Vortex::from_bytes(response_data.into()).expect("Failed to deserialize packet");
+
+        match deserialized {
+            Vortex::DownloadPiece(_, _) => {
+                return Err(ClientError::UnexpectedResponse);
+            }
+            Vortex::PieceContent(_, piece_content) => {
+                let bytes_back: Bytes = piece_content.into();
+                return R::decode(&*bytes_back).map_err(|err| {
+                    error!("Failed to decode response: {}", err);
+                    ClientError::ValidationError(err.to_string())
+                })
+            }
+            Vortex::Reserved(_) => {return Err(ClientError::UnexpectedResponse);}
+            Vortex::Close(_) => {return Err(ClientError::UnexpectedResponse);}
+            Vortex::Error(_, error) => {
+                error!("Invalid error response: {}", error.message());
+                let code: u8 = error.code().into();
+                return Err(ClientError::InvalidState(code.to_string()));
+            }
+        }
+    }
+
+}

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -1,0 +1,17 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod quic;

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -53,8 +53,8 @@ use std::os::windows::io::{AsRawSocket, RawSocket};
 
 const HEADER_SIZE: usize = 6;
 
-/// QuicServer is a Quic-based server for dfdaemon upload service.
-pub struct QuicServer {
+/// QUICServer is a QUIC-based server for dfdaemon upload service.
+pub struct QUICServer {
     /// config is the configuration of the dfdaemon.
     config: Arc<Config>,
 
@@ -62,7 +62,7 @@ pub struct QuicServer {
     addr: SocketAddr,
 
     /// handler is the request handler.
-    handler: QuicServerHandler,
+    handler: QUICServerHandler,
 
     /// shutdown is used to shutdown the TCP server.
     shutdown: shutdown::Shutdown,
@@ -71,7 +71,7 @@ pub struct QuicServer {
     _shutdown_complete: mpsc::UnboundedSender<()>,
 }
 
-impl QuicServer {
+impl QUICServer {
     /// Creates a new TCPServer.
     #[instrument(skip_all)]
     pub fn new(
@@ -86,7 +86,7 @@ impl QuicServer {
         let interface =
             get_interface_info(config.host.ip.unwrap(), config.upload.rate_limit).unwrap();
 
-        let handler = QuicServerHandler {
+        let handler = QUICServerHandler {
             interface,
             socket_path: config.download.server.socket_path.clone(),
             id_generator,
@@ -182,9 +182,9 @@ impl QuicServer {
 
 }
 
-/// QuicServerHandler handles QUIC connections and requests.
+/// QUICServerHandler handles QUIC connections and requests.
 #[derive(Clone)]
-pub struct QuicServerHandler {
+pub struct QUICServerHandler {
     /// interface is the network interface.
     interface: Interface,
 
@@ -198,7 +198,7 @@ pub struct QuicServerHandler {
     config: Arc<Config>,
 }
 
-impl QuicServerHandler {
+impl QUICServerHandler {
     /// Handles a single QUIC bi-directional stream.
     async fn handle_connection(&self, mut send: SendStream, mut recv: RecvStream) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         loop {
@@ -211,7 +211,7 @@ impl QuicServerHandler {
                     return Err(err.into());
                 }
             }
-            info!("QuicServer can receive data");
+            info!("QUICServer can receive data");
             let length = u32::from_be_bytes(header_buf[2..HEADER_SIZE].try_into().expect("Failed to read value length")) as usize;
 
             // Read request data
@@ -415,3 +415,4 @@ impl QuicServerHandler {
         Ok(response.encode_to_vec())
     }
 }
+

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -1,0 +1,417 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dragonfly_client_util::shutdown;
+use dragonfly_api::common::v2::Piece;
+use dragonfly_api::dfdaemon::v2::{
+    DownloadPieceResponse,
+    DownloadPersistentCachePieceResponse,
+};
+use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_core::{
+    Error as ClientError, Result as ClientResult,
+};
+use dragonfly_client_util::{
+    net::{get_interface_info, Interface},
+    id_generator::IDGenerator,
+};
+use prost::Message;
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use quinn::{Endpoint, ServerConfig, Incoming, RecvStream, SendStream};
+use tokio::sync::mpsc;
+use tokio::sync::Barrier;
+use tracing::{error, info, instrument, Span};
+use vortex_protocol::{
+    Vortex,
+    tlv::{Tag, download_piece::DownloadPiece},
+};
+use crate::Storage;
+use leaky_bucket::RateLimiter;
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, RawSocket};
+
+const HEADER_SIZE: usize = 6;
+
+/// QuicServer is a Quic-based server for dfdaemon upload service.
+pub struct QuicServer {
+    /// config is the configuration of the dfdaemon.
+    config: Arc<Config>,
+
+    /// addr is the address of the TCP server.
+    addr: SocketAddr,
+
+    /// handler is the request handler.
+    handler: QuicServerHandler,
+
+    /// shutdown is used to shutdown the TCP server.
+    shutdown: shutdown::Shutdown,
+
+    /// _shutdown_complete is used to notify the TCP server is shutdown.
+    _shutdown_complete: mpsc::UnboundedSender<()>,
+}
+
+impl QuicServer {
+    /// Creates a new TCPServer.
+    #[instrument(skip_all)]
+    pub fn new(
+        config: Arc<Config>,
+        id_generator: Arc<IDGenerator>,
+        storage: Arc<Storage>,
+        addr: SocketAddr,
+        shutdown: shutdown::Shutdown,
+        shutdown_complete_tx: mpsc::UnboundedSender<()>,
+    ) -> Self {
+        // Initialize the interface info.
+        let interface =
+            get_interface_info(config.host.ip.unwrap(), config.upload.rate_limit).unwrap();
+
+        let handler = QuicServerHandler {
+            interface,
+            socket_path: config.download.server.socket_path.clone(),
+            id_generator,
+            storage,
+            config: config.clone(),
+        };
+
+        Self {
+            config,
+            addr,
+            handler,
+            shutdown,
+            _shutdown_complete: shutdown_complete_tx,
+        }
+    }
+
+    /// Starts the QUIC upload server.
+    #[instrument(skip_all)]
+    pub async fn run(&mut self, quic_server_started_barrier: Arc<Barrier>) -> ClientResult<()> {
+        // Build QUIC server config (for demo, use insecure config, production use real certs!)
+        let mut server_config = ServerConfig::with_single_cert(
+            quinn::CertificateChain::from_certs(vec![quinn::Certificate::from_der(&[0u8; 1]).unwrap()]),
+            quinn::PrivateKey::from_der(&[0u8; 1]).unwrap(),
+        ).unwrap();
+        server_config.transport = Arc::new(quinn::TransportConfig::default());
+
+        let (endpoint, mut incoming) = Endpoint::server(server_config, self.addr).map_err(|err| {
+            error!("Failed to bind QUIC endpoint to {}: {}", self.addr, err);
+            ClientError::HostNotFound(self.addr.to_string())
+        })?;
+
+        info!("QUIC upload server listening on {}", self.addr);
+
+        // Clone the shutdown channel.
+        let mut shutdown = self.shutdown.clone();
+
+        // Notify that the server is ready
+        quic_server_started_barrier.wait().await;
+        info!("QUIC upload server is ready");
+
+        loop {
+            tokio::select! {
+                // Accept new connections
+                Some(connecting) = incoming.next() => {
+                    match connecting.await {
+                        Ok(new_conn) => {
+                            let handler = self.handler.clone();
+                            tokio::spawn(async move {
+                                let mut bi_streams = new_conn.bi_streams;
+                                while let Some(Ok((send, recv))) = bi_streams.next().await {
+                                    if let Err(err) = handler.handle_connection(send, recv).await {
+                                        error!("Error handling QUIC stream: {}", err);
+                                    }
+                                }
+                            });
+                        }
+                        Err(err) => {
+                            error!("Failed to accept QUIC connection: {}", err);
+                        }
+                    }
+                }
+                // Handle shutdown signal
+                _ = shutdown.recv() => {
+                    info!("QUIC upload server shutting down");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Gets the socket file descriptor from a TcpStream
+    #[cfg(unix)]
+    fn get_socket_fd(stream: &quinn::RecvStream) -> Option<RawFd> {
+        // For other platforms, we can use the peer address as identifier
+        stream.peer_addr().ok().map(|addr| addr.to_string().into_bytes().into_iter().collect())
+    }
+
+    /// Gets the socket handle from a TcpStream (Windows)
+    #[cfg(windows)]
+    fn get_socket_fd(stream: &quinn::RecvStream) -> Option<RawSocket> {
+        // For other platforms, we can use the peer address as identifier
+        stream.peer_addr().ok().map(|addr| addr.to_string().into_bytes().into_iter().collect())
+    }
+
+    /// Gets socket information as a generic identifier
+    #[cfg(not(any(unix, windows)))]
+    fn get_socket_fd(stream: &quinn::RecvStream) -> Option<String> {
+        // For other platforms, we can use the peer address as identifier
+        stream.peer_addr().ok().map(|addr| addr.to_string())
+    }
+
+}
+
+/// QuicServerHandler handles QUIC connections and requests.
+#[derive(Clone)]
+pub struct QuicServerHandler {
+    /// interface is the network interface.
+    interface: Interface,
+
+    /// socket_path is the path of the unix domain socket.
+    socket_path: PathBuf,
+
+    id_generator: Arc<IDGenerator>,
+
+    storage: Arc<Storage>,
+
+    config: Arc<Config>,
+}
+
+impl QuicServerHandler {
+    /// Handles a single QUIC bi-directional stream.
+    async fn handle_connection(&self, mut send: SendStream, mut recv: RecvStream) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        loop {
+            // Read header
+            let mut header_buf = [0u8; HEADER_SIZE];
+            match recv.read_exact(&mut header_buf).await {
+                Ok(_) => {}
+                Err(err) => {
+                    error!("Failed to read header: {}", err);
+                    return Err(err.into());
+                }
+            }
+            info!("QuicServer can receive data");
+            let length = u32::from_be_bytes(header_buf[2..HEADER_SIZE].try_into().expect("Failed to read value length")) as usize;
+
+            // Read request data
+            let mut request_data = vec![0u8; length];
+            recv.read_exact(&mut request_data).await?;
+
+            request_data.splice(0..0, header_buf.iter().copied());
+
+            let deserialized = Vortex::from_bytes(request_data.into()).expect("Failed to deserialize packet");
+
+            // Process request based on message type
+            let response_result = match deserialized {
+                Vortex::DownloadPiece(_, download_piece) => {
+                    self.send_piece(&download_piece).await
+                }
+                _ => {
+                    error!("Unsupported message type: {:?}", deserialized.tag());
+                    Err("Unsupported message type".to_string())
+                }
+            };
+
+            // Send response
+            match response_result {
+                Ok(response_data) => {
+                    let rsp = Vortex::new(Tag::PieceContent, response_data.into()).expect("Failed to create Vortex packet");
+                    send.write_all(&rsp.to_bytes()).await?;
+                }
+                Err(error_message) => {
+                    let ersp = Vortex::new(Tag::Error, error_message.into()).expect("Failed to create Vortex packet");
+                    send.write_all(&ersp.to_bytes()).await?;
+                }
+            }
+        }
+
+        // Ok(())
+    }
+
+    /// Handles download piece request.
+    #[instrument(skip_all, fields(host_id, task_id, piece_id))]
+    async fn send_piece(
+        &self,
+        request: &DownloadPiece,
+    ) -> Result<Vec<u8>, String> {
+
+        // Generate the host id.
+        let host_id = self.id_generator.host_id();
+
+        // Get the task id from the request.
+        let task_id = request.task_id();
+
+        // Get the interested piece number from the request.
+        let piece_number = request.piece_number();
+
+        // Generate the piece id.
+        let piece_id = self.storage.piece_id(task_id, piece_number);
+
+        // Span record the host id, task id and piece number.
+        Span::current().record("host_id", host_id.as_str());
+        Span::current().record("task_id", task_id);
+        Span::current().record("piece_id", piece_id.as_str());
+        info!("download piece content in TCP upload server");
+
+        // Get the piece metadata from the local storage.
+        let piece = self
+            .storage
+            .get_piece(piece_id.as_str())
+            .map_err(|err| format!("Failed to get piece metadata: {}", err))?
+            .ok_or_else(|| "Piece metadata not found".to_string())?;
+
+        info!("start upload piece content");
+
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id.as_str());
+        Span::current().record("piece_length", piece.length);
+
+        // Acquire the upload rate limiter.
+        Arc::new(
+        RateLimiter::builder()
+            .initial(self.config.upload.rate_limit.as_u64() as usize)
+            .refill(self.config.upload.rate_limit.as_u64() as usize)
+            .max(self.config.upload.rate_limit.as_u64() as usize)
+            .interval(Duration::from_secs(1))
+            .fair(false)
+            .build(),
+        ).acquire(piece.length as usize).await;
+
+        // Upload the piece content.
+        let mut reader = self.storage
+            .upload_piece(piece_id.as_str(), task_id, None)
+            .await
+            .map_err(|err| {
+                format!("Failed to get piece content: {}", err)
+            })?;
+        // Read the content of the piece.
+        let mut content = vec![0; piece.length as usize];
+        reader.read_exact(&mut content).await.map_err(|err| {
+            format!("Failed to read piece content: {}", err)
+        })?;
+
+        info!("finished upload piece content");
+
+        // Create response
+        let response = DownloadPieceResponse {
+            piece: Some(Piece {
+                number: piece.number,
+                parent_id: piece.parent_id.clone(),
+                offset: piece.offset,
+                length: piece.length,
+                digest: piece.digest.clone(),
+                content: Some(content),
+                traffic_type: None,
+                cost: None,
+                created_at: None,
+            }),
+            digest: Some(piece.calculate_digest()),
+        };
+
+        Ok(response.encode_to_vec())
+    }
+
+    /// Handles download piece request.
+    #[instrument(skip_all, fields(host_id, task_id, piece_id))]
+    async fn send_persistent_cache_piece(
+        &self,
+        request: &DownloadPiece,
+    ) -> Result<Vec<u8>, String> {
+
+        // Generate the host id.
+        let host_id = self.id_generator.host_id();
+
+        // Get the task id from the request.
+        let task_id = request.task_id();
+
+        // Get the interested piece number from the request.
+        let piece_number = request.piece_number();
+
+        // Generate the piece id.
+        let piece_id = self.storage.piece_id(task_id, piece_number);
+
+        // Span record the host id, task id and piece number.
+        Span::current().record("host_id", host_id.as_str());
+        Span::current().record("task_id", task_id);
+        Span::current().record("piece_id", piece_id.as_str());
+        info!("download piece content in TCP upload server");
+
+        // Get the piece metadata from the local storage.
+        let piece = self
+            .storage
+            .get_persistent_cache_piece(piece_id.as_str())
+            .map_err(|err| format!("Failed to get persistent cache piece metadata: {}", err))?
+            .ok_or_else(|| "Persistent cache piece metadata not found".to_string())?;
+
+        info!("start upload persistent cache piece content");
+
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id.as_str());
+        Span::current().record("piece_length", piece.length);
+
+        // Acquire the upload rate limiter.
+        Arc::new(
+        RateLimiter::builder()
+            .initial(self.config.upload.rate_limit.as_u64() as usize)
+            .refill(self.config.upload.rate_limit.as_u64() as usize)
+            .max(self.config.upload.rate_limit.as_u64() as usize)
+            .interval(Duration::from_secs(1))
+            .fair(false)
+            .build(),
+        ).acquire(piece.length as usize).await;
+
+        // Upload the piece content.
+        let mut reader = self.storage
+            .upload_persistent_cache_piece(piece_id.as_str(), task_id, None)
+            .await
+            .map_err(|err| {
+                format!("Failed to get persistent cache piece content: {}", err)
+            })?;
+        // Read the content of the piece.
+        let mut content = vec![0; piece.length as usize];
+        reader.read_exact(&mut content).await.map_err(|err| {
+            format!("Failed to read persistent cache piece content: {}", err)
+        })?;
+
+        info!("finished persistent cache upload piece content");
+
+        // Create response
+        let response = DownloadPersistentCachePieceResponse {
+            piece: Some(Piece {
+                number: piece.number,
+                parent_id: piece.parent_id.clone(),
+                offset: piece.offset,
+                length: piece.length,
+                digest: piece.digest.clone(),
+                content: Some(content),
+                traffic_type: None,
+                cost: None,
+                created_at: None,
+            }),
+            digest: Some(piece.calculate_digest()),
+        };
+
+        Ok(response.encode_to_vec())
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This implementation adds QUIC-based client and server components to the dragonfly-client-storage directory to enable efficient piece downloading functionality. The solution provides a reliable, high-performance QUIC communication layer for distributing file pieces across the Dragonfly P2P network.

## Related Issue

https://github.com/dragonflyoss/design/pull/8

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)

Signed-off-by: LXDgit2018 <1289504283@qq.com>