### PR TITLE
refactor(dfget): Improve logic and error handling in `filter_entries`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.6"
+version = "1.0.7"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.6" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.6" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.6" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.6" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.6" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.6" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.6" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.7" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.7" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.7" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.7" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.7" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.7" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.7" }
 dragonfly-api = "=2.1.49"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -166,7 +166,7 @@ where
 }
 
 /// The File Entry of a directory, including some relevant file metadata.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct DirEntry {
     /// url is the url of the entry.
     pub url: String,

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -129,7 +129,13 @@ pub struct ExportCommand {
 
 /// Implement the execute for ExportCommand.
 impl ExportCommand {
-    /// execute executes the export command.
+    /// Executes the export command with comprehensive validation and advanced error handling.
+    ///
+    /// This function serves as the main entry point for the dfcache export command execution.
+    /// It handles the complete workflow including argument parsing, validation, logging setup,
+    /// dfdaemon client connection, and export operation execution. The function provides
+    /// sophisticated error reporting with colored terminal output, including specialized
+    /// handling for backend errors with HTTP status codes and headers.
     pub async fn execute(&self) -> Result<()> {
         // Parse command line arguments.
         Args::parse();
@@ -436,7 +442,13 @@ impl ExportCommand {
         Ok(())
     }
 
-    /// run runs the export command.
+    /// Executes the export operation to retrieve cached files from the persistent cache system.
+    ///
+    /// This function handles the core export functionality by downloading a cached file from the
+    /// dfdaemon persistent cache system. It supports two transfer modes: direct file transfer
+    /// by dfdaemon (hardlink/copy) or streaming piece content through the client for manual
+    /// file assembly. The operation provides real-time progress feedback and handles file
+    /// creation, directory setup, and efficient piece-by-piece writing with sparse file allocation.
     async fn run(&self, dfdaemon_download_client: DfdaemonDownloadClient) -> Result<()> {
         // Dfcache needs to notify dfdaemon to transfer the piece content of downloading file via unix domain socket
         // when the `transfer_from_dfdaemon` is true. Otherwise, dfdaemon will download the file and hardlink or
@@ -565,7 +577,12 @@ impl ExportCommand {
         Ok(())
     }
 
-    /// validate_args validates the command line arguments.
+    /// Validates command line arguments for the export operation to ensure safe file output.
+    ///
+    /// This function performs essential validation of the output path to prevent file conflicts
+    /// and ensure the target location is suitable for export operations. It checks parent
+    /// directory existence, prevents accidental file overwrites, and validates path accessibility
+    /// before allowing the export operation to proceed.
     fn validate_args(&self) -> Result<()> {
         let absolute_path = Path::new(&self.output).absolutize()?;
         match absolute_path.parent() {

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -128,7 +128,13 @@ pub struct ImportCommand {
 
 /// Implement the execute for ImportCommand.
 impl ImportCommand {
-    /// execute executes the import sub command.
+    /// Executes the import sub command with comprehensive validation and error handling.
+    ///
+    /// This function serves as the main entry point for the dfcache import command execution.
+    /// It handles the complete workflow including argument parsing, validation, logging setup,
+    /// dfdaemon client connection, and import operation execution. The function provides
+    /// detailed error reporting with colored terminal output and follows a fail-fast approach
+    /// with immediate process termination on any critical failures.
     pub async fn execute(&self) -> Result<()> {
         // Parse command line arguments.
         Args::parse();
@@ -326,7 +332,13 @@ impl ImportCommand {
         Ok(())
     }
 
-    /// run runs the import sub command.
+    /// Executes the cache import operation by uploading a file to the persistent cache system.
+    ///
+    /// This function handles the core import functionality by uploading a local file to the
+    /// dfdaemon persistent cache system. It provides visual feedback through a progress spinner,
+    /// converts the file path to absolute format, and configures the cache task with specified
+    /// parameters including TTL, replica count, and piece length. The operation is asynchronous
+    /// and provides completion feedback with the generated task ID.
     async fn run(&self, dfdaemon_download_client: DfdaemonDownloadClient) -> Result<()> {
         let absolute_path = Path::new(&self.path).absolutize()?;
         info!("import file: {}", absolute_path.to_string_lossy());
@@ -363,7 +375,12 @@ impl ImportCommand {
         Ok(())
     }
 
-    /// validate_args validates the command line arguments.
+    /// Validates command line arguments for the import operation to ensure safe and correct execution.
+    ///
+    /// This function performs comprehensive validation of import-specific parameters to prevent
+    /// invalid operations and ensure the import request meets all system requirements. It validates
+    /// TTL boundaries, file existence and type, and piece length constraints before allowing the
+    /// import operation to proceed.
     fn validate_args(&self) -> Result<()> {
         if self.ttl < Duration::from_secs(5 * 60)
             || self.ttl > Duration::from_secs(7 * 24 * 60 * 60)

--- a/dragonfly-client/src/bin/dfcache/main.rs
+++ b/dragonfly-client/src/bin/dfcache/main.rs
@@ -106,7 +106,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// get_and_check_dfdaemon_download_client gets a dfdaemon download client and checks its health.
+/// Creates and validates a dfdaemon download client with health checking.
+///
+/// This function establishes a connection to the dfdaemon service via Unix domain socket
+/// and performs a health check to ensure the service is running and ready to handle
+/// download requests. Only after successful health verification does it return the
+/// download client for actual use.
 pub async fn get_dfdaemon_download_client(endpoint: PathBuf) -> Result<DfdaemonDownloadClient> {
     // Check dfdaemon's health.
     let health_client = HealthClient::new_unix(endpoint.clone()).await?;

--- a/dragonfly-client/src/bin/dfcache/stat.rs
+++ b/dragonfly-client/src/bin/dfcache/stat.rs
@@ -74,7 +74,13 @@ pub struct StatCommand {
 
 /// Implement the execute for StatCommand.
 impl StatCommand {
-    /// execute executes the stat command.
+    /// Executes the stat command with comprehensive error handling and user feedback.
+    ///
+    /// This function serves as the main entry point for the dfcache stat command execution.
+    /// It handles the complete lifecycle including argument parsing, logging initialization,
+    /// dfdaemon client setup, and command execution with detailed error reporting. The
+    /// function provides colored terminal output for better user experience and exits
+    /// with appropriate status codes on failure.
     pub async fn execute(&self) -> Result<()> {
         // Parse command line arguments.
         Args::parse();
@@ -234,7 +240,12 @@ impl StatCommand {
         Ok(())
     }
 
-    /// run runs the stat command.
+    /// Executes the stat command to retrieve and display persistent cache task information.
+    ///
+    /// This function queries the dfdaemon service for detailed information about a specific
+    /// persistent cache task and presents it in a formatted table for user consumption.
+    /// It handles data conversion from raw protocol buffer values to human-readable formats
+    /// including byte sizes, durations, and timestamps with proper timezone conversion.
     async fn run(&self, dfdaemon_download_client: DfdaemonDownloadClient) -> Result<()> {
         let task = dfdaemon_download_client
             .stat_persistent_cache_task(StatPersistentCacheTaskRequest {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated function signature to use references (`&Url`, `&[String]`) for efficiency.
- Improved error handling with detailed `ValidationError` messages instead of generic `UnexpectedResponse`.
- Renamed `rel_path_to_entry` to `entries_by_relative_path` for better clarity.
- Replaced `Vec` with `HashSet` for filtered entries to avoid duplicates.
- Simplified parent directory path construction using `join("")`.
- Enhanced doc comments to clearly describe functionality and behavior.
- Streamlined pattern compilation and iteration using `iter()`.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
