### PR TITLE
feat: rename tracing field from `uri` to `url` in proxy handler functions

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -231,7 +231,7 @@ impl Proxy {
 }
 
 /// handler handles the request from the client.
-#[instrument(skip_all, fields(uri, method, remote_ip))]
+#[instrument(skip_all, fields(url, method, remote_ip))]
 pub async fn handler(
     config: Arc<Config>,
     task: Arc<Task>,
@@ -241,8 +241,8 @@ pub async fn handler(
     server_ca_cert: Arc<Option<Certificate>>,
     remote_ip: std::net::IpAddr,
 ) -> ClientResult<Response> {
-    // Span record the uri and method.
-    Span::current().record("uri", request.uri().to_string().as_str());
+    // Span record the url and method.
+    Span::current().record("url", request.uri().to_string().as_str());
     Span::current().record("method", request.method().as_str());
     Span::current().record("remote_ip", remote_ip.to_string().as_str());
 
@@ -556,7 +556,7 @@ async fn upgraded_tunnel(
 
 /// upgraded_handler handles the upgraded https request from the client.
 #[allow(clippy::too_many_arguments)]
-#[instrument(skip_all, fields(uri, method))]
+#[instrument(skip_all, fields(url, method))]
 pub async fn upgraded_handler(
     config: Arc<Config>,
     task: Arc<Task>,
@@ -567,8 +567,8 @@ pub async fn upgraded_handler(
     dfdaemon_download_client: DfdaemonDownloadClient,
     registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
 ) -> ClientResult<Response> {
-    // Span record the uri and method.
-    Span::current().record("uri", request.uri().to_string().as_str());
+    // Span record the url and method.
+    Span::current().record("url", request.uri().to_string().as_str());
     Span::current().record("method", request.method().as_str());
 
     // Authenticate the request with the basic auth.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the logging instrumentation in the `dragonfly-client` proxy module to use the term "url" instead of "uri" for consistency and clarity. The changes affect both the `handler` and `upgraded_handler` functions.

### Updates to logging fields:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL234-R234): Updated the `#[instrument]` macro in both `handler` and `upgraded_handler` functions to replace the `uri` field with `url`. [[1]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL234-R234) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL559-R559)

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL244-R245): Modified the `Span::current().record` calls in both `handler` and `upgraded_handler` to record the `url` field instead of `uri`. [[1]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL244-R245) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cL570-R571)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
