### PR TITLE
feat: add Range header to ensure Content-Length is returned in response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.7"
+version = "1.0.8"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.7" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.7" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.7" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.7" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.7" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.7" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.7" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.8" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.8" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.8" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.8" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.8" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.8" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.8" }
 dragonfly-api = "=2.1.49"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -138,6 +138,13 @@ impl super::Backend for HTTP {
             .client(request.client_cert)?
             .get(&request.url)
             .headers(header)
+            // Add Range header to ensure Content-Length is returned in response headers.
+            // Some servers (especially when using Transfer-Encoding: chunked,
+            // refer to https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding.) may not
+            // include Content-Length in HEAD requests. Using "bytes=0-" requests the
+            // entire file starting from byte 0, forcing the server to include file size
+            // information in the response headers.
+            .header(reqwest::header::RANGE, "bytes=0-")
             .timeout(request.timeout)
             .send()
             .await


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the versioning in `Cargo.toml` and an enhancement to the HTTP backend implementation to improve response handling. The most important changes are outlined below:

### Version Updates in `Cargo.toml`:
* Updated the workspace package version from `1.0.7` to `1.0.8` to reflect the new release. (`Cargo.toml`, [Cargo.tomlL15-R15](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15))
* Updated dependencies (`dragonfly-client` and related crates) to version `1.0.8` for consistency with the new release. (`Cargo.toml`, [Cargo.tomlL25-R31](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31))

### HTTP Backend Enhancement:
* Added a `Range` header (`bytes=0-`) to HTTP requests in the `dragonfly-client-backend` to ensure the `Content-Length` is included in the response headers. This addresses scenarios where servers using `Transfer-Encoding: chunked` may omit `Content-Length` in `HEAD` requests. (`dragonfly-client-backend/src/http.rs`, [dragonfly-client-backend/src/http.rsR141-R147](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR141-R147))
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
