### PR TITLE
feat:removes the load_to_cache field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.49"
+version = "2.1.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71caaf1841c95fdffc19943e413db6f1e8f88068b381f148e0645dba9a722841"
+checksum = "bfca467dd19bb026b667a89fc3631213957899766dfc95ad62ac0539ce68939b"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.9
 dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.9" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.9" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.9" }
-dragonfly-api = "=2.1.49"
+dragonfly-api = "2.1.55"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -27,7 +27,6 @@ use std::time::Duration;
 use tokio::io::AsyncRead;
 use tokio::time::sleep;
 use tokio_util::either::Either;
-use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
 
 pub mod cache;
@@ -117,14 +116,8 @@ impl Storage {
         piece_length: u64,
         content_length: u64,
         response_header: Option<HeaderMap>,
-        load_to_cache: bool,
     ) -> Result<metadata::Task> {
         self.content.create_task(id, content_length).await?;
-        if load_to_cache {
-            let mut cache = self.cache.clone();
-            cache.put_task(id, content_length).await;
-            debug!("put task to cache: {}", id);
-        }
 
         self.metadata.download_task_started(
             id,
@@ -422,11 +415,10 @@ impl Storage {
         offset: u64,
         length: u64,
         reader: &mut R,
-        load_to_cache: bool,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
         tokio::select! {
-            piece = self.handle_downloaded_from_source_finished(piece_id, task_id, offset, length, reader, load_to_cache) => {
+            piece = self.handle_downloaded_from_source_finished(piece_id, task_id, offset, length, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
@@ -444,30 +436,11 @@ impl Storage {
         offset: u64,
         length: u64,
         reader: &mut R,
-        load_to_cache: bool,
     ) -> Result<metadata::Piece> {
-        let response = if load_to_cache {
-            let mut buffer = Vec::with_capacity(length as usize);
-            let mut tee = InspectReader::new(reader, |bytes| {
-                buffer.extend_from_slice(bytes);
-            });
-
-            let response = self
-                .content
-                .write_piece(task_id, offset, length, &mut tee)
-                .await?;
-
-            self.cache
-                .write_piece(task_id, piece_id, bytes::Bytes::from(buffer))
-                .await?;
-            debug!("put piece to cache: {}", piece_id);
-
-            response
-        } else {
-            self.content
-                .write_piece(task_id, offset, length, reader)
-                .await?
-        };
+        let response = self
+            .content
+            .write_piece(task_id, offset, length, reader)
+            .await?;
 
         let digest = Digest::new(Algorithm::Crc32, response.hash);
         self.metadata.download_piece_finished(
@@ -491,11 +464,10 @@ impl Storage {
         expected_digest: &str,
         parent_id: &str,
         reader: &mut R,
-        load_to_cache: bool,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
         tokio::select! {
-            piece = self.handle_downloaded_piece_from_parent_finished(piece_id, task_id, offset, length, expected_digest, parent_id, reader, load_to_cache) => {
+            piece = self.handle_downloaded_piece_from_parent_finished(piece_id, task_id, offset, length, expected_digest, parent_id, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
@@ -516,30 +488,11 @@ impl Storage {
         expected_digest: &str,
         parent_id: &str,
         reader: &mut R,
-        load_to_cache: bool,
     ) -> Result<metadata::Piece> {
-        let response = if load_to_cache {
-            let mut buffer = Vec::with_capacity(length as usize);
-            let mut tee = InspectReader::new(reader, |bytes| {
-                buffer.extend_from_slice(bytes);
-            });
-
-            let response = self
-                .content
-                .write_piece(task_id, offset, length, &mut tee)
-                .await?;
-
-            self.cache
-                .write_piece(task_id, piece_id, bytes::Bytes::from(buffer))
-                .await?;
-            debug!("put piece to cache: {}", piece_id);
-
-            response
-        } else {
-            self.content
-                .write_piece(task_id, offset, length, reader)
-                .await?
-        };
+        let response = self
+            .content
+            .write_piece(task_id, offset, length, reader)
+            .await?;
 
         let length = response.length;
         let digest = Digest::new(Algorithm::Crc32, response.hash);

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -808,7 +808,6 @@ async fn download(
                 need_piece_content,
                 object_storage,
                 hdfs,
-                load_to_cache: false,
                 force_hard_link: args.force_hard_link,
                 content_for_calculating_task_id: args.content_for_calculating_task_id,
                 remote_ip: Some(local_ip().unwrap().to_string()),

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -25,15 +25,16 @@ use crate::metrics::{
 };
 use crate::resource::{persistent_cache_task, task};
 use crate::shutdown;
-use dragonfly_api::common::v2::{PersistentCacheTask, Priority, Task, TaskType};
+use dragonfly_api::common::v2::{CacheTask, PersistentCacheTask, Priority, Task, TaskType};
 use dragonfly_api::dfdaemon::v2::{
     dfdaemon_download_client::DfdaemonDownloadClient as DfdaemonDownloadGRPCClient,
     dfdaemon_download_server::{
         DfdaemonDownload, DfdaemonDownloadServer as DfdaemonDownloadGRPCServer,
     },
-    DeleteTaskRequest, DownloadPersistentCacheTaskRequest, DownloadPersistentCacheTaskResponse,
-    DownloadTaskRequest, DownloadTaskResponse, Entry, ListTaskEntriesRequest,
-    ListTaskEntriesResponse, StatPersistentCacheTaskRequest,
+    DeleteCacheTaskRequest, DeleteTaskRequest, DownloadCacheTaskRequest, DownloadCacheTaskResponse,
+    DownloadPersistentCacheTaskRequest, DownloadPersistentCacheTaskResponse, DownloadTaskRequest,
+    DownloadTaskResponse, Entry, ListTaskEntriesRequest, ListTaskEntriesResponse,
+    StatCacheTaskRequest as DfdaemonStatCacheTaskRequest, StatPersistentCacheTaskRequest,
     StatTaskRequest as DfdaemonStatTaskRequest, UploadPersistentCacheTaskRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
@@ -1296,6 +1297,39 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             })?;
 
         Ok(Response::new(task))
+    }
+
+    /// DownloadCacheTaskStream is the stream of the download cache task response.
+    type DownloadCacheTaskStream = ReceiverStream<Result<DownloadCacheTaskResponse, Status>>;
+
+    /// download_cache_task tells the dfdaemon to download the cache task.
+    #[instrument(
+        skip_all,
+        fields(host_id, task_id, peer_id, url, remote_ip, content_length)
+    )]
+    async fn download_cache_task(
+        &self,
+        _request: Request<DownloadCacheTaskRequest>,
+    ) -> Result<Response<Self::DownloadCacheTaskStream>, Status> {
+        todo!();
+    }
+
+    /// stat_cache_task gets the status of the cache task.
+    #[instrument(skip_all, fields(host_id, task_id, remote_pi, local_only))]
+    async fn stat_cache_task(
+        &self,
+        _request: Request<DfdaemonStatCacheTaskRequest>,
+    ) -> Result<Response<CacheTask>, Status> {
+        todo!();
+    }
+
+    /// delete_cache_task calls the dfdaemon to delete the cache task.
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
+    async fn delete_cache_task(
+        &self,
+        _request: Request<DeleteCacheTaskRequest>,
+    ) -> Result<Response<()>, Status> {
+        todo!();
     }
 }
 

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -26,18 +26,21 @@ use crate::resource::{persistent_cache_task, task};
 use crate::shutdown;
 use bytesize::MB;
 use dragonfly_api::common::v2::{
-    Host, Network, PersistentCacheTask, Piece, Priority, Task, TaskType,
+    CacheTask, Host, Network, PersistentCacheTask, Piece, Priority, Task, TaskType,
 };
 use dragonfly_api::dfdaemon::v2::{
     dfdaemon_upload_client::DfdaemonUploadClient as DfdaemonUploadGRPCClient,
     dfdaemon_upload_server::{DfdaemonUpload, DfdaemonUploadServer as DfdaemonUploadGRPCServer},
-    DeletePersistentCacheTaskRequest, DeleteTaskRequest, DownloadPersistentCachePieceRequest,
+    DeleteCacheTaskRequest, DeletePersistentCacheTaskRequest, DeleteTaskRequest,
+    DownloadCachePieceRequest, DownloadCachePieceResponse, DownloadCacheTaskRequest,
+    DownloadCacheTaskResponse, DownloadPersistentCachePieceRequest,
     DownloadPersistentCachePieceResponse, DownloadPersistentCacheTaskRequest,
     DownloadPersistentCacheTaskResponse, DownloadPieceRequest, DownloadPieceResponse,
     DownloadTaskRequest, DownloadTaskResponse, ExchangeIbVerbsQueuePairEndpointRequest,
-    ExchangeIbVerbsQueuePairEndpointResponse, StatPersistentCacheTaskRequest, StatTaskRequest,
-    SyncHostRequest, SyncPersistentCachePiecesRequest, SyncPersistentCachePiecesResponse,
-    SyncPiecesRequest, SyncPiecesResponse, UpdatePersistentCacheTaskRequest,
+    ExchangeIbVerbsQueuePairEndpointResponse, StatCacheTaskRequest, StatPersistentCacheTaskRequest,
+    StatTaskRequest, SyncCachePiecesRequest, SyncCachePiecesResponse, SyncHostRequest,
+    SyncPersistentCachePiecesRequest, SyncPersistentCachePiecesResponse, SyncPiecesRequest,
+    SyncPiecesResponse, UpdatePersistentCacheTaskRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client_config::dfdaemon::Config;
@@ -1691,6 +1694,63 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         _request: Request<ExchangeIbVerbsQueuePairEndpointRequest>,
     ) -> Result<Response<ExchangeIbVerbsQueuePairEndpointResponse>, Status> {
         unimplemented!()
+    }
+
+    /// DownloadCacheTaskStream is the stream of the download cache task response.
+    type DownloadCacheTaskStream = ReceiverStream<Result<DownloadCacheTaskResponse, Status>>;
+
+    /// download_cache_task downloads the cache task.
+    #[instrument(
+        skip_all,
+        fields(host_id, task_id, peer_id, url, remote_ip, content_length)
+    )]
+    async fn download_cache_task(
+        &self,
+        _request: Request<DownloadCacheTaskRequest>,
+    ) -> Result<Response<Self::DownloadCacheTaskStream>, Status> {
+        todo!();
+    }
+
+    /// stat_cache_task stats the cache task.
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip, local_only))]
+    async fn stat_cache_task(
+        &self,
+        _request: Request<StatCacheTaskRequest>,
+    ) -> Result<Response<CacheTask>, Status> {
+        todo!();
+    }
+
+    /// delete_cache_task deletes the cache task.
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
+    async fn delete_cache_task(
+        &self,
+        _request: Request<DeleteCacheTaskRequest>,
+    ) -> Result<Response<()>, Status> {
+        todo!();
+    }
+
+    /// SyncCachePiecesStream is the stream of the sync cache pieces response.
+    type SyncCachePiecesStream = ReceiverStream<Result<SyncCachePiecesResponse, Status>>;
+
+    /// sync_cache_pieces provides the cache piece metadata for parent.
+    #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
+    async fn sync_cache_pieces(
+        &self,
+        _request: Request<SyncCachePiecesRequest>,
+    ) -> Result<Response<Self::SyncCachePiecesStream>, Status> {
+        todo!();
+    }
+
+    /// download_cache_piece provides the cache piece content for parent.
+    #[instrument(
+        skip_all,
+        fields(host_id, remote_host_id, task_id, piece_id, piece_length)
+    )]
+    async fn download_cache_piece(
+        &self,
+        _request: Request<DownloadCachePieceRequest>,
+    ) -> Result<Response<DownloadCachePieceResponse>, Status> {
+        todo!();
     }
 }
 

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1102,7 +1102,6 @@ fn make_download_task_request(
             hdfs: None,
             is_prefetch: false,
             need_piece_content: false,
-            load_to_cache: false,
             force_hard_link: header::get_force_hard_link(&header),
             content_for_calculating_task_id: header::get_content_for_calculating_task_id(&header),
             remote_ip: Some(remote_ip.to_string()),

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -412,7 +412,6 @@ impl Piece {
         length: u64,
         parent: piece_collector::CollectedParent,
         is_prefetch: bool,
-        load_to_cache: bool,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
@@ -477,7 +476,6 @@ impl Piece {
                 digest.as_str(),
                 parent.id.as_str(),
                 &mut reader,
-                load_to_cache,
                 self.config.storage.write_piece_timeout,
             )
             .await
@@ -515,7 +513,6 @@ impl Piece {
         length: u64,
         request_header: HeaderMap,
         is_prefetch: bool,
-        load_to_cache: bool,
         object_storage: Option<ObjectStorage>,
         hdfs: Option<Hdfs>,
     ) -> Result<metadata::Piece> {
@@ -641,7 +638,6 @@ impl Piece {
                 offset,
                 length,
                 &mut response.reader,
-                load_to_cache,
                 self.config.storage.write_piece_timeout,
             )
             .await

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -248,13 +248,7 @@ impl Task {
 
         let task = self
             .storage
-            .download_task_started(
-                id,
-                piece_length,
-                content_length,
-                response.http_header,
-                request.load_to_cache,
-            )
+            .download_task_started(id, piece_length, content_length, response.http_header)
             .await;
 
         // Attempt to create a hard link from the task file to the output path.
@@ -740,7 +734,6 @@ impl Task {
                             remaining_interested_pieces.clone(),
                             request.is_prefetch,
                             request.need_piece_content,
-                            request.load_to_cache,
                             download_progress_tx.clone(),
                             in_stream_tx.clone(),
                         )
@@ -984,7 +977,6 @@ impl Task {
         interested_pieces: Vec<metadata::Piece>,
         is_prefetch: bool,
         need_piece_content: bool,
-        load_to_cache: bool,
         download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
         in_stream_tx: Sender<AnnouncePeerRequest>,
     ) -> ClientResult<Vec<metadata::Piece>> {
@@ -1045,7 +1037,6 @@ impl Task {
                 finished_pieces: Arc<Mutex<Vec<metadata::Piece>>>,
                 is_prefetch: bool,
                 need_piece_content: bool,
-                load_to_cache: bool,
             ) -> ClientResult<metadata::Piece> {
                 // Limit the concurrent piece count.
                 let _permit = semaphore.acquire().await.unwrap();
@@ -1066,7 +1057,6 @@ impl Task {
                         length,
                         parent.clone(),
                         is_prefetch,
-                        load_to_cache,
                     )
                     .await
                     .map_err(|err| {
@@ -1200,7 +1190,6 @@ impl Task {
                     finished_pieces.clone(),
                     is_prefetch,
                     need_piece_content,
-                    load_to_cache,
                 )
                 .in_current_span(),
             );
@@ -1314,7 +1303,6 @@ impl Task {
                 request_header: HeaderMap,
                 is_prefetch: bool,
                 need_piece_content: bool,
-                load_to_cache: bool,
                 piece_manager: Arc<piece::Piece>,
                 semaphore: Arc<Semaphore>,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
@@ -1338,7 +1326,6 @@ impl Task {
                         length,
                         request_header,
                         is_prefetch,
-                        load_to_cache,
                         object_storage,
                         hdfs,
                     )
@@ -1443,7 +1430,6 @@ impl Task {
                     request_header.clone(),
                     request.is_prefetch,
                     request.need_piece_content,
-                    request.load_to_cache,
                     self.piece.clone(),
                     semaphore.clone(),
                     download_progress_tx.clone(),
@@ -1710,7 +1696,6 @@ impl Task {
                 length: u64,
                 request_header: HeaderMap,
                 is_prefetch: bool,
-                load_to_cache: bool,
                 piece_manager: Arc<piece::Piece>,
                 semaphore: Arc<Semaphore>,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
@@ -1733,7 +1718,6 @@ impl Task {
                         length,
                         request_header,
                         is_prefetch,
-                        load_to_cache,
                         object_storage,
                         hdfs,
                     )
@@ -1792,7 +1776,6 @@ impl Task {
                     interested_piece.length,
                     request_header.clone(),
                     request.is_prefetch,
-                    request.load_to_cache,
                     self.piece.clone(),
                     semaphore.clone(),
                     download_progress_tx.clone(),
@@ -1986,7 +1969,7 @@ mod tests {
         // Create a task and save it to storage.
         let task_id = "test-task-id";
         storage
-            .download_task_started(task_id, 1024, 4096, None, false)
+            .download_task_started(task_id, 1024, 4096, None)
             .await
             .unwrap();
 


### PR DESCRIPTION
## Description
This pull request removes the `load_to_cache` field and adds trait method definitions to `dfdaemon_download.rs` and `dfdaemon_upload.rs`.

## Related Issue

### Changes
- Removed cache-related processing from Task handling.
- Added trait method definitions such as `download_cache_task` to `dfdaemon_download.rs` and `dfdaemon_upload.rs` to comply with the API format of version 2.1.55.

## Motivation and Context
- Aim to allow Task to focus on disk interactions while delegating memory cache operations to CacheTask.

## Screenshots (if appropriate)
