### PR TITLE
feat: Disable compression in HTTP client configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "bincode",
  "bytes",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.8"
+version = "1.0.9"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.8" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.8" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.8" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.8" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.8" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.8" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.8" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.9" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.9" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.9" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.9" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.9" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.9" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.9" }
 dragonfly-api = "=2.1.49"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -51,10 +51,10 @@ impl HTTP {
             .with_no_client_auth();
 
         let client = reqwest::Client::builder()
-            .gzip(true)
-            .brotli(true)
-            .zstd(true)
-            .deflate(true)
+            .no_gzip()
+            .no_brotli()
+            .no_zstd()
+            .no_deflate()
             .use_preconfigured_tls(client_config_builder)
             .pool_max_idle_per_host(super::POOL_MAX_IDLE_PER_HOST)
             .tcp_keepalive(super::KEEP_ALIVE_INTERVAL)
@@ -89,10 +89,10 @@ impl HTTP {
                     .with_no_client_auth();
 
                 let client = reqwest::Client::builder()
-                    .gzip(true)
-                    .brotli(true)
-                    .zstd(true)
-                    .deflate(true)
+                    .no_gzip()
+                    .no_brotli()
+                    .no_zstd()
+                    .no_deflate()
                     .use_preconfigured_tls(client_config_builder)
                     .build()?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the HTTP client configuration in the `dragonfly-client-backend/src/http.rs` file to disable support for several content-encoding compression algorithms. The main change is switching from enabling compression formats to explicitly disabling them in the client builder.

HTTP client compression configuration:

* Changed the `reqwest::Client::builder()` calls to use `.no_gzip()`, `.no_brotli()`, `.no_zstd()`, and `.no_deflate()` instead of enabling these compression algorithms, effectively disabling support for gzip, brotli, zstd, and deflate encodings. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL54-R57) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL92-R95)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
