### PR TITLE
feat: enable console subscriber layer for tracing spawn tasks on `127.0.0.1:6669` when log level is TRACE

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,13 +993,14 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "bytes",
  "bytesize",
  "chrono",
  "clap",
+ "console-subscriber",
  "dashmap",
  "dragonfly-api",
  "dragonfly-client-backend",
@@ -1025,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1056,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1086,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1104,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1121,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "bincode",
  "bytes",
@@ -1148,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1545,11 +1585,24 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
  "tonic",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -1861,7 +1914,7 @@ dependencies = [
  "hyper 1.6.0",
  "libc",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -4858,6 +4911,7 @@ dependencies = [
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.9"
+version = "1.0.10"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.9" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.9" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.9" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.9" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.9" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.9" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.9" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.10" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.10" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.10" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.10" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.10" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.10" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.10" }
 dragonfly-api = "=2.1.49"
 thiserror = "2.0"
 futures = "0.3.31"
@@ -71,7 +71,7 @@ serde_yaml = "0.9"
 http = "1"
 tonic = { version = "0.12.2", features = ["tls"] }
 tonic-reflection = "0.12.3"
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.16", features = ["full"] }
 tokio-stream = "0.1.17"
 validator = { version = "0.16", features = ["derive"] }

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo ./cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src
@@ -40,6 +41,8 @@ RUN case "${TARGETPLATFORM}" in \
   esac && \
   cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfcache
 
+RUN cargo install tokio-console --locked --root /usr/local
+
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
 ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
@@ -67,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio curl
 COPY --from=builder /app/client/target/release/dfget /usr/local/bin/dfget
 COPY --from=builder /app/client/target/release/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/release/dfcache /usr/local/bin/dfcache
+COPY --from=builder /usr/local/bin/tokio-console /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo ./cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src
@@ -42,6 +43,7 @@ RUN case "${TARGETPLATFORM}" in \
 
 RUN cargo install flamegraph --root /usr/local
 RUN cargo install bottom --locked --root /usr/local
+RUN cargo install tokio-console --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
@@ -72,6 +74,7 @@ COPY --from=builder /app/client/target/debug/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/debug/dfcache /usr/local/bin/dfcache
 COPY --from=builder /usr/local/bin/flamegraph /usr/local/bin/
 COPY --from=builder /usr/local/bin/btm /usr/local/bin/
+COPY --from=builder /usr/local/bin/tokio-console /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app/client
 
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo ./cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -50,6 +50,17 @@ impl HTTP {
             .with_custom_certificate_verifier(NoVerifier::new())
             .with_no_client_auth();
 
+        // Disable automatic compression to prevent double-decompression issues.
+        //
+        // Problem scenario:
+        // 1. Origin server supports gzip and returns "content-encoding: gzip" header.
+        // 2. Backend decompresses the response and stores uncompressed content to disk.
+        // 3. When user's client downloads via dfdaemon proxy, the original "content-encoding: gzip".
+        //    header is forwarded to it.
+        // 4. User's client attempts to decompress the already-decompressed content, causing errors.
+        //
+        // Solution: Disable all compression formats (gzip, brotli, zstd, deflate) to ensure
+        // we receive and store uncompressed content, eliminating the double-decompression issue.
         let client = reqwest::Client::builder()
             .no_gzip()
             .no_brotli()
@@ -88,6 +99,17 @@ impl HTTP {
                     .with_root_certificates(root_cert_store)
                     .with_no_client_auth();
 
+                // Disable automatic compression to prevent double-decompression issues.
+                //
+                // Problem scenario:
+                // 1. Origin server supports gzip and returns "content-encoding: gzip" header.
+                // 2. Backend decompresses the response and stores uncompressed content to disk.
+                // 3. When user's client downloads via dfdaemon proxy, the original "content-encoding: gzip".
+                //    header is forwarded to it.
+                // 4. User's client attempts to decompress the already-decompressed content, causing errors.
+                //
+                // Solution: Disable all compression formats (gzip, brotli, zstd, deflate) to ensure
+                // we receive and store uncompressed content, eliminating the double-decompression issue.
                 let client = reqwest::Client::builder()
                     .no_gzip()
                     .no_brotli()

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -85,6 +85,7 @@ path-absolutize = "3.1.1"
 dashmap = "6.1.0"
 fastrand = "2.3.0"
 glob = "0.3.2"
+console-subscriber = "0.4.1"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -102,8 +102,16 @@ pub fn init_tracing(
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::default().add_directive(log_level.into()));
 
+    // Enable console subscriber layer for tracing spawn tasks on `127.0.0.1:6669` when log level is TRACE.
+    let console_subscriber_layer = if log_level == Level::TRACE {
+        Some(console_subscriber::spawn())
+    } else {
+        None
+    };
+
     let subscriber = Registry::default()
         .with(env_filter)
+        .with(console_subscriber_layer)
         .with(file_logging_layer)
         .with(stdout_logging_layer);
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces improvements to tracing and debugging capabilities, updates dependency versions, and addresses a double-decompression issue in HTTP downloads. The most significant changes are grouped below:

### Tracing and Debugging Enhancements

* Added the `console-subscriber` dependency to `dragonfly-client` and enabled the console tracing layer when log level is set to TRACE, allowing for better visibility into spawned tasks during debugging. (`dragonfly-client/Cargo.toml`, `dragonfly-client/src/tracing/mod.rs`) [[1]](diffhunk://#diff-651fbc571d827abadd8e14ed21f83bc11941b8733f2d9704b93ae13b4dbfbb31R88) [[2]](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R105-R114)
* Updated `tokio` dependency to include the `tracing` feature, and added configuration to enable `tokio_unstable` for advanced runtime features. (`Cargo.toml`, `.cargo/config.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L74-R74) [[2]](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R1-R2)
* Updated Dockerfiles to install and include the `tokio-console` binary in both release and debug images, improving runtime introspection for deployed containers. (`ci/Dockerfile`, `ci/Dockerfile.debug`, `ci/Dockerfile.dfinit`) [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR44-R45) [[2]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR73) [[3]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R46) [[4]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R77) [[5]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR10) [[6]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R10) [[7]](diffhunk://#diff-4bc49af73ee4c312bbe45791f2bb95c950ecc719ca34b5bf59af0649db904dc5R10)

### Dependency and Version Updates

* Bumped the workspace and all internal package versions from `1.0.9` to `1.0.10` for consistency and release tracking. (`Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

### HTTP Download Reliability

* Disabled automatic compression (gzip, brotli, zstd, deflate) in HTTP client code to prevent double-decompression errors when proxying downloads, ensuring uncompressed content is stored and served correctly. (`dragonfly-client-backend/src/http.rs`) [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR53-R63) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR102-R112)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
