### PR TITLE
chore(ci/Dockerfile): add grpcurl for dfdaemon container

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -59,6 +59,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 FROM public.ecr.aws/docker/library/golang:1.23.0-alpine3.20 AS pprof
 
 RUN go install github.com/google/pprof@latest
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim
 
@@ -72,6 +73,7 @@ COPY --from=builder /app/client/target/release/dfdaemon /usr/local/bin/dfdaemon
 COPY --from=builder /app/client/target/release/dfcache /usr/local/bin/dfcache
 COPY --from=builder /usr/local/bin/tokio-console /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
+COPY --from=pprof /go/bin/grpcurl /bin/grpcurl
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 
 ENTRYPOINT ["/usr/local/bin/dfdaemon"]

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -61,6 +61,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 FROM public.ecr.aws/docker/library/golang:1.23.0-alpine3.20 AS pprof
 
 RUN go install github.com/google/pprof@latest
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim
 
@@ -76,6 +77,7 @@ COPY --from=builder /usr/local/bin/flamegraph /usr/local/bin/
 COPY --from=builder /usr/local/bin/btm /usr/local/bin/
 COPY --from=builder /usr/local/bin/tokio-console /usr/local/bin/
 COPY --from=pprof /go/bin/pprof /bin/pprof
+COPY --from=pprof /go/bin/grpcurl /bin/grpcurl
 COPY --from=health /bin/grpc_health_probe /bin/grpc_health_probe
 
 ENTRYPOINT ["/usr/local/bin/dfdaemon"]

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -25,6 +25,7 @@ sha2.workspace = true
 uuid.workspace = true
 hex.workspace = true
 crc32fast.workspace = true
+openssl.workspace = true
 lazy_static.workspace = true
 bytesize.workspace = true
 lru.workspace = true

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -48,6 +48,7 @@ tokio-stream.workspace = true
 reqwest.workspace = true
 url.workspace = true
 http.workspace = true
+openssl.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds support for the `openssl` crate in both `dragonfly-client-util` and `dragonfly-client` and enhances the Docker images by including the `grpcurl` tool. The main changes improve debugging and testing capabilities for gRPC services in CI environments and prepare the Rust projects for potential future use of OpenSSL.

**Docker image enhancements:**

* Added installation of `grpcurl` in the `pprof` build stage of both `ci/Dockerfile` and `ci/Dockerfile.debug`, enabling gRPC endpoint testing and debugging. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR62) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R64)
* Included `grpcurl` binary in the final Docker images by copying it from the `pprof` build stage. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR76) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944R80)

**Rust workspace dependency updates:**

* Added `openssl` as a workspace dependency in `dragonfly-client-util/Cargo.toml` and `dragonfly-client/Cargo.toml`, preparing both crates for cryptographic operations or secure communication. [[1]](diffhunk://#diff-1c96c45400d8ecf785eb0acb8bced3fbd8838ce5882e449bb66aceaf5497021dR28) [[2]](diffhunk://#diff-651fbc571d827abadd8e14ed21f83bc11941b8733f2d9704b93ae13b4dbfbb31R51)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
