### PR TITLE
feat: Add support for CacheTask in the storage layer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "lazy_static",
  "leaky-bucket",
  "local-ip-address",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -1200,6 +1201,7 @@ dependencies = [
  "http-range-header",
  "lazy_static",
  "lru",
+ "openssl",
  "pnet",
  "rcgen",
  "reqwest",
@@ -2864,6 +2866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.1+3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +2882,7 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -22,6 +22,7 @@ use lru_cache::LruCache;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::io::Cursor;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncRead, BufReader};
 use tokio::sync::RwLock;
@@ -110,7 +111,7 @@ pub struct Cache {
     config: Arc<Config>,
 
     /// size is the size of the cache in bytes.
-    size: u64,
+    size: Arc<AtomicU64>,
 
     /// capacity is the maximum capacity of the cache in bytes.
     capacity: u64,
@@ -119,13 +120,22 @@ pub struct Cache {
     tasks: Arc<RwLock<LruCache<String, Task>>>,
 }
 
+/// WriteCachePieceResponse is the response of writing a cache piece.
+pub struct WriteCachePieceResponse {
+    /// length is the length of the cache piece.
+    pub length: u64,
+
+    /// hash is the hash of the cache piece.
+    pub hash: String,
+}
+
 /// Cache implements the cache for storing piece content by LRU algorithm.
 impl Cache {
     /// new creates a new cache with the specified capacity.
     pub fn new(config: Arc<Config>) -> Self {
         Cache {
             config: config.clone(),
-            size: 0,
+            size: Arc::new(AtomicU64::new(0)),
             capacity: config.storage.cache_capacity.as_u64(),
             // LRU cache capacity is set to usize::MAX to avoid evicting tasks. LRU cache will evict tasks
             // by cache capacity(cache size) itself, and used pop_lru to evict the least recently
@@ -180,18 +190,28 @@ impl Cache {
     }
 
     /// write_piece writes the piece content to the cache.
-    pub async fn write_piece(&self, task_id: &str, piece_id: &str, content: Bytes) -> Result<()> {
+    pub async fn write_piece(
+        &self,
+        task_id: &str,
+        piece_id: &str,
+        content: Bytes,
+    ) -> Result<WriteCachePieceResponse> {
         let mut tasks = self.tasks.write().await;
         let Some(task) = tasks.get(task_id) else {
             return Err(Error::TaskNotFound(task_id.to_string()));
         };
 
+        let mut hasher = crc32fast::Hasher::new();
+        let length = content.len() as u64;
+        hasher.update(&content);
+        let hash = hasher.finalize().to_string();
+
         if task.contains(piece_id).await {
-            return Ok(());
+            return Ok(WriteCachePieceResponse { length, hash });
         }
 
         task.write_piece(piece_id, content).await;
-        Ok(())
+        Ok(WriteCachePieceResponse { length, hash })
     }
 
     /// put_task puts a new task into the cache, constrained by the capacity of the cache.
@@ -212,10 +232,11 @@ impl Cache {
         }
 
         let mut tasks = self.tasks.write().await;
-        while self.size + content_length > self.capacity {
+        while self.size.load(Ordering::Relaxed) + content_length > self.capacity {
             match tasks.pop_lru() {
                 Some((_, task)) => {
-                    self.size -= task.content_length();
+                    self.size
+                        .fetch_sub(task.content_length(), Ordering::Relaxed);
                 }
                 None => {
                     break;
@@ -225,7 +246,7 @@ impl Cache {
 
         let task = Task::new(content_length);
         tasks.put(task_id.to_string(), task);
-        self.size += content_length;
+        self.size.fetch_add(content_length, Ordering::Relaxed);
     }
 
     pub async fn delete_task(&mut self, task_id: &str) -> Result<()> {
@@ -234,7 +255,8 @@ impl Cache {
             return Err(Error::TaskNotFound(task_id.to_string()));
         };
 
-        self.size -= task.content_length();
+        self.size
+            .fetch_sub(task.content_length(), Ordering::Relaxed);
         Ok(())
     }
 
@@ -297,7 +319,7 @@ mod tests {
 
         for (config, expected_size, expected_capacity) in test_cases {
             let cache = Cache::new(Arc::new(config));
-            assert_eq!(cache.size, expected_size);
+            assert_eq!(cache.size.load(Ordering::Relaxed), expected_size);
             assert_eq!(cache.capacity, expected_capacity);
         }
     }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::AsyncRead;
+use tokio::io::{self, AsyncRead};
 use tokio::time::sleep;
 use tokio_util::either::Either;
 use tracing::{debug, error, info, instrument, warn};
@@ -361,6 +361,102 @@ impl Storage {
             .unwrap_or_else(|err| {
                 error!("delete persistent cache task content failed: {}", err);
             });
+    }
+
+    /// prepare_download_cache_task_started prepares the metadata of the cache task when the cache task downloads
+    /// started.
+    pub async fn prepare_download_cache_task_started(
+        &self,
+        id: &str,
+    ) -> Result<metadata::CacheTask> {
+        self.metadata
+            .download_cache_task_started(id, None, None, None)
+    }
+
+    /// download_cache_task_started updates the metadata of the cache task and create cache task content
+    /// when the cache task downloads started.
+    #[instrument(skip_all)]
+    pub async fn download_cache_task_started(
+        &self,
+        id: &str,
+        piece_length: u64,
+        content_length: u64,
+        response_header: Option<HeaderMap>,
+    ) -> Result<metadata::CacheTask> {
+        let mut cache = self.cache.clone();
+        cache.put_task(id, content_length).await;
+
+        self.metadata.download_cache_task_started(
+            id,
+            Some(piece_length),
+            Some(content_length),
+            response_header,
+        )
+    }
+
+    /// download_cache_task_finished updates the metadata of the cache task when the cache task downloads finished.
+    #[instrument(skip_all)]
+    pub fn download_cache_task_finished(&self, id: &str) -> Result<metadata::CacheTask> {
+        self.metadata.download_cache_task_finished(id)
+    }
+
+    /// download_cache_task_failed updates the metadata of the cache task when the cache task downloads failed.
+    #[instrument(skip_all)]
+    pub async fn download_cache_task_failed(&self, id: &str) -> Result<metadata::CacheTask> {
+        self.metadata.download_cache_task_failed(id)
+    }
+
+    /// prefetch_cache_task_started updates the metadata of the cache task when the cache task prefetches started.
+    #[instrument(skip_all)]
+    pub async fn prefetch_cache_task_started(&self, id: &str) -> Result<metadata::CacheTask> {
+        self.metadata.prefetch_cache_task_started(id)
+    }
+
+    /// prefetch_cache_task_failed updates the metadata of the cache task when the cache task prefetches failed.
+    #[instrument(skip_all)]
+    pub async fn prefetch_cache_task_failed(&self, id: &str) -> Result<metadata::CacheTask> {
+        self.metadata.prefetch_cache_task_failed(id)
+    }
+
+    /// upload_cache_task_finished updates the metadata of the cache task when the cache task uploads finished.
+    #[instrument(skip_all)]
+    pub fn upload_cache_task_finished(&self, id: &str) -> Result<metadata::CacheTask> {
+        self.metadata.upload_cache_task_finished(id)
+    }
+
+    /// get_cache_task returns the cache task metadata.
+    #[instrument(skip_all)]
+    pub fn get_cache_task(&self, id: &str) -> Result<Option<metadata::CacheTask>> {
+        self.metadata.get_cache_task(id)
+    }
+
+    /// is_cache_task_exists returns whether the cache task exists.
+    #[instrument(skip_all)]
+    pub fn is_cache_task_exists(&self, id: &str) -> Result<bool> {
+        self.metadata.is_cache_task_exists(id)
+    }
+
+    /// get_cache_tasks returns the cache task metadatas.
+    #[instrument(skip_all)]
+    pub fn get_cache_tasks(&self) -> Result<Vec<metadata::CacheTask>> {
+        self.metadata.get_cache_tasks()
+    }
+
+    /// delete_cache_task deletes the cache task metadatas, cache task content and piece metadatas.
+    #[instrument(skip_all)]
+    pub async fn delete_cache_task(&self, id: &str) {
+        self.metadata
+            .delete_cache_task(id)
+            .unwrap_or_else(|err| error!("delete cache task metadata failed: {}", err));
+
+        self.metadata.delete_pieces(id).unwrap_or_else(|err| {
+            error!("delete cache piece metadatas failed: {}", err);
+        });
+
+        let mut cache = self.cache.clone();
+        cache.delete_task(id).await.unwrap_or_else(|err| {
+            info!("delete cache task from cache failed: {}", err);
+        });
     }
 
     /// create_persistent_cache_piece creates a new persistent cache piece.
@@ -797,6 +893,264 @@ impl Storage {
                 _ = interval.tick() => {
                     let piece = self
                         .get_persistent_cache_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    // If the piece is finished, return.
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+                }
+                _ = &mut wait_timeout => {
+                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                }
+            }
+        }
+    }
+
+    /// download_cache_piece_started updates the metadata of the cache piece and writes
+    /// the data of cache piece to file when the cache piece downloads started.
+    #[instrument(skip_all)]
+    pub async fn download_cache_piece_started(
+        &self,
+        piece_id: &str,
+        number: u32,
+    ) -> Result<metadata::Piece> {
+        // Wait for the piece to be finished.
+        match self.wait_for_cache_piece_finished(piece_id).await {
+            Ok(piece) => Ok(piece),
+            // If piece is not found or wait timeout, create piece metadata.
+            Err(_) => self.metadata.download_piece_started(piece_id, number),
+        }
+    }
+
+    /// download_cache_piece_from_source_finished is used for downloading cache piece from source.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn download_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        reader: &mut R,
+        timeout: Duration,
+    ) -> Result<metadata::Piece> {
+        tokio::select! {
+            piece = self.handle_downloaded_cache_piece_from_source_finished(piece_id, task_id, offset, length, reader) => {
+                piece
+            }
+            _ = sleep(timeout) => {
+                Err(Error::DownloadPieceFinished(piece_id.to_string()))
+            }
+        }
+    }
+
+    // handle_downloaded_cache_piece_from_source_finished handles the downloaded cache piece from source.
+    #[instrument(skip_all)]
+    async fn handle_downloaded_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        reader: &mut R,
+    ) -> Result<metadata::Piece> {
+        let response = {
+            let mut buffer = Vec::with_capacity(length as usize);
+            let mut reader_cursor = std::io::Cursor::new(&mut buffer);
+            io::copy(reader, &mut reader_cursor).await?;
+
+            let response = self
+                .cache
+                .write_piece(task_id, piece_id, bytes::Bytes::from(buffer))
+                .await?;
+            debug!("put piece to cache: {}", piece_id);
+
+            response
+        };
+
+        let digest = Digest::new(Algorithm::Crc32, response.hash);
+
+        self.metadata.download_piece_finished(
+            piece_id,
+            offset,
+            length,
+            digest.to_string().as_str(),
+            None,
+        )
+    }
+
+    /// download_cache_piece_from_parent_finished is used for downloading cache piece from parent.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn download_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        expected_digest: &str,
+        parent_id: &str,
+        reader: &mut R,
+        timeout: Duration,
+    ) -> Result<metadata::Piece> {
+        tokio::select! {
+            piece = self.handle_downloaded_cache_piece_from_parent_finished(piece_id, task_id, offset, length, expected_digest, parent_id, reader) => {
+                piece
+            }
+            _ = sleep(timeout) => {
+                Err(Error::DownloadPieceFinished(piece_id.to_string()))
+            }
+        }
+    }
+
+    // handle_downloaded_cache_piece_from_parent_finished handles the downloaded cache piece from parent.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn handle_downloaded_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        expected_digest: &str,
+        parent_id: &str,
+        reader: &mut R,
+    ) -> Result<metadata::Piece> {
+        let response = {
+            let mut buffer = Vec::with_capacity(length as usize);
+            let mut reader_cursor = std::io::Cursor::new(&mut buffer);
+            io::copy(reader, &mut reader_cursor).await?;
+
+            let response = self
+                .cache
+                .write_piece(task_id, piece_id, bytes::Bytes::from(buffer))
+                .await?;
+            debug!("put piece to cache: {}", piece_id);
+
+            response
+        };
+
+        let length = response.length;
+        let digest = Digest::new(Algorithm::Crc32, response.hash);
+
+        // Check the digest of the piece.
+        if expected_digest != digest.to_string() {
+            return Err(Error::DigestMismatch(
+                expected_digest.to_string(),
+                digest.to_string(),
+            ));
+        }
+
+        self.metadata.download_piece_finished(
+            piece_id,
+            offset,
+            length,
+            digest.to_string().as_str(),
+            Some(parent_id.to_string()),
+        )
+    }
+    /// download_cache_piece_failed updates the metadata of the cache piece when the cache piece downloads failed.
+    #[instrument(skip_all)]
+    pub fn download_cache_piece_failed(&self, piece_id: &str) -> Result<()> {
+        self.metadata.download_piece_failed(piece_id)
+    }
+
+    /// upload_cache_piece updates the metadata of the piece and
+    /// returns the data of the piece.
+    #[instrument(skip_all)]
+    pub async fn upload_cache_piece(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        range: Option<Range>,
+    ) -> Result<impl AsyncRead> {
+        // Wait for the cache piece to be finished.
+        self.wait_for_cache_piece_finished(piece_id).await?;
+
+        // Start uploading the task.
+        self.metadata.upload_cache_task_started(task_id)?;
+
+        // Get the piece metadata and return the content of the piece.
+        match self.metadata.get_piece(piece_id) {
+            Ok(Some(piece)) => {
+                if self.cache.contains_piece(task_id, piece_id).await {
+                    match self
+                        .cache
+                        .read_piece(task_id, piece_id, piece.clone(), range)
+                        .await
+                    {
+                        Ok(reader) => {
+                            // Finish uploading the task.
+                            self.metadata.upload_cache_task_finished(task_id)?;
+                            debug!("get piece from cache: {}", piece_id);
+                            Ok(reader)
+                        }
+                        Err(err) => {
+                            // Failed uploading the cache task.
+                            self.metadata.upload_cache_task_failed(task_id)?;
+                            Err(err)
+                        }
+                    }
+                } else {
+                    // Failed uploading the cache task.
+                    self.metadata.upload_cache_task_failed(task_id)?;
+                    Err(Error::PieceNotFound(piece_id.to_string()))
+                }
+            }
+            Ok(None) => {
+                // Failed uploading the cache task.
+                self.metadata.upload_cache_task_failed(task_id)?;
+                Err(Error::PieceNotFound(piece_id.to_string()))
+            }
+            Err(err) => {
+                // Failed uploading the cache task.
+                self.metadata.upload_cache_task_failed(task_id)?;
+                Err(err)
+            }
+        }
+    }
+
+    /// get_cache_piece returns the cache piece metadata.
+    pub fn get_cache_piece(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
+        self.metadata.get_piece(piece_id)
+    }
+
+    /// is_cache_piece_exists returns whether the cache piece exists.
+    #[instrument(skip_all)]
+    pub fn is_cache_piece_exists(&self, piece_id: &str) -> Result<bool> {
+        self.metadata.is_piece_exists(piece_id)
+    }
+
+    /// get_cache_pieces returns the cache piece metadatas.
+    #[instrument(skip_all)]
+    pub fn get_cache_pieces(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
+        self.metadata.get_pieces(task_id)
+    }
+
+    /// cache_piece_id returns the cache piece id.
+    #[inline]
+    pub fn cache_piece_id(&self, task_id: &str, number: u32) -> String {
+        self.metadata.piece_id(task_id, number)
+    }
+
+    /// wait_for_cache_piece_finished waits for the cache piece to be finished.
+    #[instrument(skip_all)]
+    async fn wait_for_cache_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
+        // Total timeout for downloading a piece, combining the download time and the time to write to storage.
+        let wait_timeout = tokio::time::sleep(
+            self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
+        );
+        tokio::pin!(wait_timeout);
+
+        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let piece = self
+                        .get_cache_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
                     // If the piece is finished, return.


### PR DESCRIPTION
## Description
This pull request modifies the Cache's `size` field type, adds storage layer support for CacheTask, and implements related processing for CacheTask metadata.

## Related Issue
### Changes
- Reconstruct the `Cache` structure, changing the `size` field to `Arc<AtomicU64>` to achieve internal mutability and state sharing.
- Created a new CacheTask metadata structure and implemented its associated processing functions.
- Added CacheTask support in the storage layer, implementing all necessary functions for its download functionality.

## Motivation and Context
To provide storage layer support for CacheTask, laying the foundation for future CacheTask integration into the client.