### PR TITLE
feat(ci/Dockerfile): lock bottom version to 0.11.0 in debug Dockerfile

### DIFF
--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -42,7 +42,7 @@ RUN case "${TARGETPLATFORM}" in \
   cargo build --verbose --bin dfget --bin dfdaemon --bin dfcache
 
 RUN cargo install flamegraph --root /usr/local
-RUN cargo install bottom --locked --root /usr/local
+RUN cargo install bottom --version 0.11.0 --locked --root /usr/local
 RUN cargo install tokio-console --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the `ci/Dockerfile.debug` to ensure consistent builds by specifying the version of the `bottom` tool during installation.

* Docker build consistency:
  * Explicitly sets the `bottom` tool version to `0.11.0` in the `cargo install` command in `ci/Dockerfile.debug` to avoid unexpected changes from upstream updates.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
