### PR TITLE
feat: add proxy port to host when announce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.57"
+version = "2.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d07e740a105d6dd2ce968318897beaf37ef8b8f581fbae3d0e227722857786b"
+checksum = "2e535ca2ddc8e44c457c95412717b01325e5c8313b64be355aa443c45f1e723d"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/dragonfly-client/src/announcer/mod.rs
+++ b/dragonfly-client/src/announcer/mod.rs
@@ -234,10 +234,9 @@ impl SchedulerAnnouncer {
             network: Some(network),
             disk: Some(disk),
             build: Some(build),
-
-            // TODO: Get scheduler cluster id from dynconfig.
-            scheduler_cluster_id: 0,
+            scheduler_cluster_id: self.config.host.scheduler_cluster_id.unwrap_or_default(),
             disable_shared: self.config.upload.disable_shared,
+            proxy_port: self.config.proxy.server.port as i32,
         };
 
         Ok(AnnounceHostRequest {


### PR DESCRIPTION
This pull request updates how the `SchedulerAnnouncer` constructs the `AnnounceHostRequest`, ensuring that configuration values are correctly propagated to the request. The most important changes are related to improved usage of configuration parameters.

Configuration propagation improvements:

* The `scheduler_cluster_id` field in `AnnounceHostRequest` now uses the value from `self.config.host.scheduler_cluster_id`, defaulting to zero if not set, instead of a hardcoded zero.
* The new `proxy_port` field is set in `AnnounceHostRequest`, using the value from `self.config.proxy.server.port` cast to an `i32`.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
