### PR TITLE
fix(ci): copy .cargo directory correctly in Docker images

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
-COPY .cargo ./cargo
+COPY .cargo ./.cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
-COPY .cargo ./cargo
+COPY .cargo ./.cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app/client
 
 COPY Cargo.toml Cargo.lock ./
-COPY .cargo ./cargo
+COPY .cargo ./.cargo
 
 COPY dragonfly-client/Cargo.toml ./dragonfly-client/Cargo.toml
 COPY dragonfly-client/src ./dragonfly-client/src


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor but important fix to the Dockerfile setup for the project. The change ensures that the `.cargo` configuration directory is copied with the correct path in all relevant Dockerfiles, which helps with proper Rust build configuration inside the containers.

- Dockerfile path correction:
  * Changed the copy command from `COPY .cargo ./cargo` to `COPY .cargo ./.cargo` in `ci/Dockerfile`, `ci/Dockerfile.debug`, and `ci/Dockerfile.dfinit` to ensure the `.cargo` directory is correctly placed for Rust builds. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL10-R10) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L10-R10) [[3]](diffhunk://#diff-4bc49af73ee4c312bbe45791f2bb95c950ecc719ca34b5bf59af0649db904dc5L10-R10)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
