### PR TITLE
feat: add X-Dragonfly-Server-IP for response proxy ip

### DIFF
--- a/dragonfly-client/src/proxy/header.rs
+++ b/dragonfly-client/src/proxy/header.rs
@@ -88,6 +88,10 @@ pub const DRAGONFLY_TASK_DOWNLOAD_FINISHED_HEADER: &str = "X-Dragonfly-Task-Down
 /// based on `url`, `piece_length`, `tag`, `application`, and `filtered_query_params`.
 pub const DRAGONFLY_TASK_ID_HEADER: &str = "X-Dragonfly-Task-ID";
 
+/// DRAGONFLY_SERVER_IP_HEADER is the response header key of server IP.
+/// It is used to indicate the IP address of the server that handled the request.
+pub const DRAGONFLY_SERVER_IP_HEADER: &str = "X-Dragonfly-Server-IP";
+
 /// get_tag gets the tag from http header.
 pub fn get_tag(header: &HeaderMap) -> Option<String> {
     header

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -770,6 +770,7 @@ async fn proxy_via_dfdaemon(
     let mut response = Response::new(boxed_body);
     *response.headers_mut() = make_response_headers(
         message.task_id.as_str(),
+        config.host.ip.unwrap(),
         download_task_started_response.clone(),
     )?;
     *response.status_mut() = http::StatusCode::OK;
@@ -1154,6 +1155,7 @@ fn make_download_url(
 /// make_response_headers makes the response headers.
 fn make_response_headers(
     task_id: &str,
+    server_ip: std::net::IpAddr,
     mut download_task_started_response: DownloadTaskStartedResponse,
 ) -> ClientResult<hyper::header::HeaderMap> {
     // Insert the content range header to the response header.
@@ -1184,6 +1186,11 @@ fn make_response_headers(
     download_task_started_response.response_header.insert(
         header::DRAGONFLY_TASK_ID_HEADER.to_string(),
         task_id.to_string(),
+    );
+
+    download_task_started_response.response_header.insert(
+        header::DRAGONFLY_SERVER_IP_HEADER.to_string(),
+        server_ip.to_string(),
     );
 
     hashmap_to_headermap(&download_task_started_response.response_header)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds support for including the server's IP address in the response headers for requests handled by the Dragonfly proxy. The main focus is to provide clients with information about which server processed their request by introducing a new response header and updating the relevant code paths to populate it.

**Header support improvements:**

* Introduced a new constant `DRAGONFLY_SERVER_IP_HEADER` in `header.rs` to represent the response header key for the server's IP address.
* Updated the `make_response_headers` function in `mod.rs` to accept a `server_ip` parameter and insert the server IP into the response headers using the new header key. [[1]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR1158) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR1191-R1195)
* Modified the call to `make_response_headers` in `proxy_via_dfdaemon` to pass the server's IP address from the configuration.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
