### PR TITLE
build(ci): add bpftrace to Dockerfile dependencies

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -65,7 +65,7 @@ FROM public.ecr.aws/debian/debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio curl \
     iotop sysstat bash-completion procps apache2-utils ca-certificates binutils \
-    dnsutils iputils-ping llvm graphviz lsof strace dstat net-tools \
+    dnsutils iputils-ping llvm graphviz lsof strace dstat net-tools bpftrace \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/client/target/release/dfget /usr/local/bin/dfget

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -67,7 +67,7 @@ FROM public.ecr.aws/debian/debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio curl infiniband-diags ibverbs-utils \
     iotop sysstat bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools \
-    dnsutils iputils-ping vim linux-perf llvm lsof socat strace dstat net-tools \
+    dnsutils iputils-ping vim linux-perf llvm lsof socat strace dstat net-tools bpftrace \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/client/target/debug/dfget /usr/local/bin/dfget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Docker build configuration to include the `bpftrace` tool in both the standard and debug CI images. This will enable advanced tracing and performance analysis capabilities in the CI environment.

**Docker image enhancements:**

* Added `bpftrace` to the list of installed packages in `ci/Dockerfile` to support eBPF-based tracing in the standard CI image.
* Added `bpftrace` to the list of installed packages in `ci/Dockerfile.debug` for the debug CI image, providing enhanced debugging and tracing tools.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
