### PR TITLE
fix: replace inspect with inspect_err for error logging

### DIFF
--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -155,7 +155,7 @@ impl super::Backend for HTTP {
         let header = request
             .http_header
             .ok_or(Error::InvalidParameter)
-            .inspect(|_err| {
+            .inspect_err(|_err| {
                 error!("request header is missing");
             })?;
 
@@ -217,7 +217,7 @@ impl super::Backend for HTTP {
         let header = request
             .http_header
             .ok_or(Error::InvalidParameter)
-            .inspect(|_err| {
+            .inspect_err(|_err| {
                 error!("request header is missing");
             })?;
 

--- a/dragonfly-client/src/dynconfig/mod.rs
+++ b/dragonfly-client/src/dynconfig/mod.rs
@@ -185,7 +185,7 @@ impl Dynconfig {
             let domain_name = Url::parse(addr.as_str())?
                 .host_str()
                 .ok_or(Error::InvalidParameter)
-                .inspect(|_err| {
+                .inspect_err(|_err| {
                     error!("invalid address: {}", addr);
                 })?
                 .to_string();


### PR DESCRIPTION
This pull request makes minor improvements to error handling in the codebase by updating how errors are logged when certain parameters are missing or invalid. Instead of using `.inspect`, the code now uses `.inspect_err`, which ensures error messages are only logged when an error actually occurs.

Error handling improvements:

* In `dragonfly-client-backend/src/http.rs`, updated two places in the `HTTP` backend implementation to use `.inspect_err` for logging when the request header is missing. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL158-R158) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL220-R220)
* In `dragonfly-client/src/dynconfig/mod.rs`, changed the error logging for invalid addresses in the `Dynconfig` implementation to use `.inspect_err`.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
