### PR TITLE
build(ci): update package versions in Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -41,7 +41,7 @@ RUN case "${TARGETPLATFORM}" in \
   esac && \
   cargo build --release --verbose --bin dfget --bin dfdaemon --bin dfcache
 
-RUN cargo install tokio-console --locked --root /usr/local
+RUN cargo install tokio-console --version 0.1.13 --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
@@ -63,8 +63,8 @@ RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio curl \
-    iotop sysstat bash-completion procps apache2-utils ca-certificates binutils \
+RUN apt-get update && apt-get install -y --no-install-recommends iperf3 linux-libc-dev libc6-dev \
+    iotop sysstat bash-completion procps apache2-utils ca-certificates binutils fio curl \
     dnsutils iputils-ping llvm graphviz lsof strace dstat net-tools bpftrace \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -41,9 +41,9 @@ RUN case "${TARGETPLATFORM}" in \
   esac && \
   cargo build --verbose --bin dfget --bin dfdaemon --bin dfcache
 
-RUN cargo install flamegraph --root /usr/local
+RUN cargo install flamegraph --version 0.6.8 --root /usr/local
 RUN cargo install bottom --version 0.11.0 --locked --root /usr/local
-RUN cargo install tokio-console --locked --root /usr/local
+RUN cargo install tokio-console --version 0.1.13 --locked --root /usr/local
 
 FROM public.ecr.aws/docker/library/alpine:3.20 AS health
 
@@ -66,7 +66,7 @@ RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 FROM public.ecr.aws/debian/debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iperf3 fio curl infiniband-diags ibverbs-utils \
-    iotop sysstat bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools \
+    iotop sysstat bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools linux-libc-dev libc6-dev \
     dnsutils iputils-ping vim linux-perf llvm lsof socat strace dstat net-tools bpftrace \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Docker build files to improve reproducibility and ensure compatibility by pinning specific tool versions and adjusting package dependencies. The most important changes are grouped below:

Dependency version pinning:

* Explicitly sets the version of `tokio-console` to `0.1.13` in both `ci/Dockerfile` and `ci/Dockerfile.debug` to ensure consistent builds. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL44-R44) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L44-R46)
* Pins `flamegraph` to version `0.6.8` in `ci/Dockerfile.debug` for reproducibility.

Build environment improvements:

* Adds `linux-libc-dev` and `libc6-dev` to the list of installed packages in both `ci/Dockerfile` and `ci/Dockerfile.debug` to support building and running binaries that require development headers. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL66-R67) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L69-R69)
* Reorders some package installations for clarity and to ensure dependencies are installed in the correct order.

These changes help make the Docker images more stable and predictable across different environments.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
