### PR TITLE
build(ci): update golang version in Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -56,7 +56,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi && \
     chmod +x /bin/grpc_health_probe
 
-FROM public.ecr.aws/docker/library/golang:1.23.0-alpine3.20 AS pprof
+FROM public.ecr.aws/docker/library/golang:1.24.0-alpine3.20 AS pprof
 
 RUN go install github.com/google/pprof@latest
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -58,7 +58,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi && \
     chmod +x /bin/grpc_health_probe
 
-FROM public.ecr.aws/docker/library/golang:1.23.0-alpine3.20 AS pprof
+FROM public.ecr.aws/docker/library/golang:1.24.0-alpine3.20 AS pprof
 
 RUN go install github.com/google/pprof@latest
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the base Golang image version used in both the `ci/Dockerfile` and `ci/Dockerfile.debug` files. The change upgrades from Go 1.23.0 to Go 1.24.0, ensuring that the Docker images use the latest stable Go release for building and installing profiling and gRPC tools.

Dependency updates:

* Upgraded the base image from `golang:1.23.0-alpine3.20` to `golang:1.24.0-alpine3.20` in both `ci/Dockerfile` [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL59-R59) and `ci/Dockerfile.debug` [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L61-R61).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
