### PR TITLE
refactor(client): replace openssl with reqwest for HTTP/HTTPS requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,6 @@ dependencies = [
  "lazy_static",
  "leaky-bucket",
  "local-ip-address",
- "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -1201,7 +1200,6 @@ dependencies = [
  "http-range-header",
  "lazy_static",
  "lru",
- "openssl",
  "pnet",
  "rcgen",
  "reqwest",
@@ -2951,15 +2949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.2+3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +2956,6 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [
     "stream",
-    "native-tls",
-    "default-tls",
     "rustls-tls",
     "gzip",
     "brotli",
@@ -70,6 +68,7 @@ rocksdb = "0.22.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 http = "1"
+lazy_static = "1.5"
 tonic = { version = "0.12.2", features = ["tls"] }
 tonic-reflection = "0.12.3"
 tokio = { version = "1.47.1", features = ["full", "tracing"] }
@@ -82,7 +81,7 @@ regex = "1.11.2"
 humantime = "2.1.0"
 prost-wkt-types = "0.6"
 chrono = { version = "0.4.41", features = ["serde", "clock"] }
-openssl = { version = "0.10", features = ["vendored"] }
+# openssl = { version = "0.10", features = ["vendored"] }
 opendal = { version = "0.48.0", features = [
     "services-s3",
     "services-azblob",
@@ -104,7 +103,6 @@ tokio-rustls = "0.25.0-alpha.4"
 serde_json = "1.0.143"
 lru = "0.12.5"
 fs2 = "0.4.3"
-lazy_static = "1.5"
 bytes = "1.10"
 local-ip-address = "0.6.5"
 sysinfo = { version = "0.32.1", default-features = false, features = ["component", "disk", "network", "system", "user"] }

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -26,7 +26,6 @@ uuid.workspace = true
 sysinfo.workspace = true
 hex.workspace = true
 crc32fast.workspace = true
-openssl.workspace = true
 lazy_static.workspace = true
 bytesize.workspace = true
 lru.workspace = true

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -48,7 +48,6 @@ tokio-stream.workspace = true
 reqwest.workspace = true
 url.workspace = true
 http.workspace = true
-openssl.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
- Remove openssl dependency from Cargo.toml and Cargo.lock
- Update proxy module to use reqwest for HTTP/HTTPS requests
- Convert hyper requests to reqwest requests for better error handling
- Improve code readability and maintainability by using higher-level abstractions

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
