### PR TITLE
feat(object_storage): add security token to OSS initialization

### DIFF
--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -359,9 +359,15 @@ impl ObjectStorage {
         object_storage: common::v2::ObjectStorage,
         timeout: Duration,
     ) -> ClientResult<Operator> {
-        if let (Some(access_key_id), Some(access_key_secret), Some(endpoint)) = (
+        if let (
+            Some(access_key_id),
+            Some(access_key_secret),
+            Some(security_token),
+            Some(endpoint),
+        ) = (
             &object_storage.access_key_id,
             &object_storage.access_key_secret,
+            &object_storage.security_token,
             &object_storage.endpoint,
         ) {
             // Initialize the OSS operator with the object storage.
@@ -369,6 +375,7 @@ impl ObjectStorage {
             builder = builder
                 .access_key_id(access_key_id)
                 .access_key_secret(access_key_secret)
+                .security_token(security_token)
                 .endpoint(endpoint)
                 .root("/")
                 .bucket(&parsed_url.bucket);
@@ -379,13 +386,16 @@ impl ObjectStorage {
                 .layer(TimeoutLayer::new().with_timeout(timeout)));
         }
 
-        if let (Some(security_token), Some(endpoint)) =
-            (&object_storage.security_token, &object_storage.endpoint)
-        {
+        if let (Some(access_key_id), Some(access_key_secret), Some(endpoint)) = (
+            &object_storage.access_key_id,
+            &object_storage.access_key_secret,
+            &object_storage.endpoint,
+        ) {
             // Initialize the OSS operator with the object storage.
             let mut builder = opendal::services::Oss::default();
             builder = builder
-                .security_token(security_token)
+                .access_key_id(access_key_id)
+                .access_key_secret(access_key_secret)
                 .endpoint(endpoint)
                 .root("/")
                 .bucket(&parsed_url.bucket);
@@ -798,6 +808,8 @@ mod tests {
                 Scheme::OSS,
                 ObjectStorageInfo {
                     endpoint: Some("test-endpoint.local".into()),
+                    access_key_id: Some("access-key-id".into()),
+                    access_key_secret: Some("access-key-secret".into()),
                     security_token: Some("security-token".into()),
                     ..Default::default()
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the OSS object storage initialization logic to ensure that all required credentials are provided together, improving security and correctness. The changes focus on how the `Operator` is initialized with credentials in the `ObjectStorage` implementation.

Credential handling improvements:

* Updated the main OSS operator initialization to require `access_key_id`, `access_key_secret`, `security_token`, and `endpoint` all to be present before proceeding, and added `.security_token(security_token)` to the builder.
* Updated the fallback OSS operator initialization to require `access_key_id`, `access_key_secret`, and `endpoint` (instead of just `security_token` and `endpoint`), and now sets `access_key_id` and `access_key_secret` on the builder instead of just `security_token`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
