### PR TITLE
feat: Add CacheTask processing logic

### DIFF
--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -18,7 +18,8 @@ use bytesize::ByteSize;
 use clap::Parser;
 use dragonfly_api::common::v2::{Download, Hdfs, ObjectStorage, TaskType};
 use dragonfly_api::dfdaemon::v2::{
-    download_task_response, DownloadTaskRequest, ListTaskEntriesRequest,
+    download_cache_task_response, download_task_response, DownloadCacheTaskRequest,
+    DownloadTaskRequest, ListTaskEntriesRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
@@ -308,6 +309,13 @@ struct Args {
         value_parser = VersionValueParser
     )]
     version: bool,
+
+    #[arg(
+        long = "cache",
+        default_value_t = false,
+        help = "Use cache task for download"
+    )]
+    cache: bool,
 }
 
 #[tokio::main]
@@ -799,15 +807,29 @@ async fn download(
         (Some(args.output.to_string_lossy().to_string()), false)
     };
 
+    // Get actual path rather than percentage encoded path as download path.
+    let download_path = percent_decode_str(args.url.path()).decode_utf8_lossy();
+    progress_bar.set_style(
+        ProgressStyle::with_template(
+            "{msg:.bold}\n[{elapsed_precise}] [{bar:60.green/red}] {percent:3}% ({bytes_per_sec:.red}, {eta:.cyan})",
+        )
+        .or_err(ErrorType::ParseError)?
+        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
+            write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+        })
+        .progress_chars("=>-"),
+    );
+    progress_bar.set_message(download_path.to_string());
+
     // Create dfdaemon client.
-    let response = download_client
-        .download_task(DownloadTaskRequest {
-            download: Some(Download {
+    if args.cache {
+        let response = download_client
+            .download_cache_task(DownloadCacheTaskRequest {
                 url: args.url.to_string(),
                 digest: args.digest,
                 // NOTE: Dfget does not support range download.
                 range: None,
-                r#type: TaskType::Standard as i32,
+                r#type: TaskType::Cache as i32,
                 tag: Some(args.tag),
                 application: Some(args.application),
                 priority: args.priority,
@@ -827,113 +849,170 @@ async fn download(
                 need_piece_content,
                 object_storage,
                 hdfs,
-                force_hard_link: args.force_hard_link,
                 content_for_calculating_task_id: args.content_for_calculating_task_id,
                 remote_ip: Some(local_ip().unwrap().to_string()),
-            }),
-        })
-        .await
-        .inspect_err(|err| {
-            error!("download task failed: {}", err);
-        })?;
-
-    // If transfer_from_dfdaemon is true, then dfget needs to create the output file and write the
-    // piece content to the output file.
-    let mut f = if args.transfer_from_dfdaemon {
-        if let Some(parent) = args.output.parent() {
-            if !parent.exists() {
-                fs::create_dir_all(parent).await.inspect_err(|err| {
-                    error!("failed to create directory {:?}: {}", parent, err);
-                })?;
-            }
-        }
-
-        let f = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .mode(dfget::DEFAULT_OUTPUT_FILE_MODE)
-            .open(&args.output)
+            })
             .await
             .inspect_err(|err| {
-                error!("open file {:?} failed: {}", args.output, err);
+                error!("download task failed: {}", err);
             })?;
 
-        Some(f)
-    } else {
-        None
-    };
-
-    // Get actual path rather than percentage encoded path as download path.
-    let download_path = percent_decode_str(args.url.path()).decode_utf8_lossy();
-    progress_bar.set_style(
-        ProgressStyle::with_template(
-            "{msg:.bold}\n[{elapsed_precise}] [{bar:60.green/red}] {percent:3}% ({bytes_per_sec:.red}, {eta:.cyan})",
-        )
-        .or_err(ErrorType::ParseError)?
-        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
-            write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
-        })
-        .progress_chars("=>-"),
-    );
-    progress_bar.set_message(download_path.to_string());
-
-    // Download file.
-    let mut downloaded = 0;
-    let mut out_stream = response.into_inner();
-    while let Some(message) = out_stream.message().await.inspect_err(|err| {
-        error!("get message failed: {}", err);
-    })? {
-        match message.response {
-            Some(download_task_response::Response::DownloadTaskStartedResponse(response)) => {
-                if let Some(f) = &f {
-                    fallocate(f, response.content_length)
-                        .await
-                        .inspect_err(|err| {
-                            error!("fallocate {:?} failed: {}", args.output, err);
-                        })?;
+        // Download file.
+        let mut downloaded = 0;
+        let mut out_stream = response.into_inner();
+        while let Some(message) = out_stream.message().await.inspect_err(|err| {
+            error!("get message failed: {}", err);
+        })? {
+            match message.response {
+                Some(download_cache_task_response::Response::DownloadCacheTaskStartedResponse(
+                    response,
+                )) => {
+                    progress_bar.set_length(response.content_length);
                 }
-
-                progress_bar.set_length(response.content_length);
-            }
-            Some(download_task_response::Response::DownloadPieceFinishedResponse(response)) => {
-                let piece = response
-                    .piece
-                    .ok_or(Error::InvalidParameter)
-                    .inspect_err(|_err| {
-                        error!("response piece is missing");
-                    })?;
-
-                // Dfget needs to write the piece content to the output file.
-                if let Some(f) = &mut f {
-                    f.seek(SeekFrom::Start(piece.offset))
-                        .await
-                        .inspect_err(|err| {
-                            error!("seek {:?} failed: {}", args.output, err);
-                        })?;
-
-                    let content =
-                        piece
-                            .content
+                Some(download_cache_task_response::Response::DownloadPieceFinishedResponse(
+                    response,
+                )) => {
+                    let piece =
+                        response
+                            .piece
                             .ok_or(Error::InvalidParameter)
                             .inspect_err(|_err| {
-                                error!("piece content is missing");
+                                error!("response piece is missing");
                             })?;
 
-                    f.write_all(&content).await.inspect_err(|err| {
-                        error!("write {:?} failed: {}", args.output, err);
-                    })?;
-
-                    debug!("copy piece {} to {:?} success", piece.number, args.output);
+                    downloaded += piece.length;
+                    let position = min(
+                        downloaded + piece.length,
+                        progress_bar.length().unwrap_or(0),
+                    );
+                    progress_bar.set_position(position);
                 }
-
-                downloaded += piece.length;
-                let position = min(
-                    downloaded + piece.length,
-                    progress_bar.length().unwrap_or(0),
-                );
-                progress_bar.set_position(position);
+                None => {}
             }
-            None => {}
+        }
+    } else {
+        let response = download_client
+            .download_task(DownloadTaskRequest {
+                download: Some(Download {
+                    url: args.url.to_string(),
+                    digest: args.digest,
+                    // NOTE: Dfget does not support range download.
+                    range: None,
+                    r#type: TaskType::Standard as i32,
+                    tag: Some(args.tag),
+                    application: Some(args.application),
+                    priority: args.priority,
+                    filtered_query_params,
+                    request_header: header_vec_to_hashmap(args.header.unwrap_or_default())?,
+                    piece_length: args.piece_length.map(|piece_length| piece_length.as_u64()),
+                    output_path,
+                    timeout: Some(
+                        prost_wkt_types::Duration::try_from(args.timeout)
+                            .or_err(ErrorType::ParseError)?,
+                    ),
+                    need_back_to_source: false,
+                    disable_back_to_source: args.disable_back_to_source,
+                    certificate_chain: Vec::new(),
+                    prefetch: false,
+                    is_prefetch: false,
+                    need_piece_content,
+                    object_storage,
+                    hdfs,
+                    force_hard_link: args.force_hard_link,
+                    content_for_calculating_task_id: args.content_for_calculating_task_id,
+                    remote_ip: Some(local_ip().unwrap().to_string()),
+                }),
+            })
+            .await
+            .inspect_err(|err| {
+                error!("download task failed: {}", err);
+            })?;
+
+        // If transfer_from_dfdaemon is true, then dfget needs to create the output file and write the
+        // piece content to the output file.
+        let mut f = if args.transfer_from_dfdaemon {
+            if let Some(parent) = args.output.parent() {
+                if !parent.exists() {
+                    fs::create_dir_all(parent).await.inspect_err(|err| {
+                        error!("failed to create directory {:?}: {}", parent, err);
+                    })?;
+                }
+            }
+
+            let f = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(dfget::DEFAULT_OUTPUT_FILE_MODE)
+                .open(&args.output)
+                .await
+                .inspect_err(|err| {
+                    error!("open file {:?} failed: {}", args.output, err);
+                })?;
+
+            Some(f)
+        } else {
+            None
+        };
+
+        // Download file.
+        let mut downloaded = 0;
+        let mut out_stream = response.into_inner();
+        while let Some(message) = out_stream.message().await.inspect_err(|err| {
+            error!("get message failed: {}", err);
+        })? {
+            match message.response {
+                Some(download_task_response::Response::DownloadTaskStartedResponse(response)) => {
+                    if let Some(f) = &f {
+                        fallocate(f, response.content_length)
+                            .await
+                            .inspect_err(|err| {
+                                error!("fallocate {:?} failed: {}", args.output, err);
+                            })?;
+                    }
+
+                    progress_bar.set_length(response.content_length);
+                }
+                Some(download_task_response::Response::DownloadPieceFinishedResponse(response)) => {
+                    let piece =
+                        response
+                            .piece
+                            .ok_or(Error::InvalidParameter)
+                            .inspect_err(|_err| {
+                                error!("response piece is missing");
+                            })?;
+
+                    // Dfget needs to write the piece content to the output file.
+                    if let Some(f) = &mut f {
+                        f.seek(SeekFrom::Start(piece.offset))
+                            .await
+                            .inspect_err(|err| {
+                                error!("seek {:?} failed: {}", args.output, err);
+                            })?;
+
+                        let content =
+                            piece
+                                .content
+                                .ok_or(Error::InvalidParameter)
+                                .inspect_err(|_err| {
+                                    error!("piece content is missing");
+                                })?;
+
+                        f.write_all(&content).await.inspect_err(|err| {
+                            error!("write {:?} failed: {}", args.output, err);
+                        })?;
+
+                        debug!("copy piece {} to {:?} success", piece.number, args.output);
+                    }
+
+                    downloaded += piece.length;
+                    let position = min(
+                        downloaded + piece.length,
+                        progress_bar.length().unwrap_or(0),
+                    );
+                    progress_bar.set_position(position);
+                }
+                None => {}
+            }
         }
     }
 

--- a/dragonfly-client/src/resource/cache_task.rs
+++ b/dragonfly-client/src/resource/cache_task.rs
@@ -1,0 +1,1950 @@
+/*
+ *     Copyright 2024 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
+use crate::metrics::{
+    collect_backend_request_failure_metrics, collect_backend_request_finished_metrics,
+    collect_backend_request_started_metrics,
+};
+use dragonfly_api::common::v2::{
+    CachePeer, CacheTask as CommonCacheTask, Hdfs, ObjectStorage, Piece, SizeScope, TaskType,
+    TrafficType,
+};
+use dragonfly_api::dfdaemon::{
+    self,
+    v2::{download_cache_task_response, DownloadCacheTaskRequest, DownloadCacheTaskResponse},
+};
+use dragonfly_api::errordetails::v2::{Backend, Unknown};
+use dragonfly_api::scheduler::v2::{
+    announce_cache_peer_request, announce_cache_peer_response,
+    download_piece_back_to_source_failed_request, AnnounceCachePeerRequest, DeleteCacheTaskRequest,
+    DownloadCachePeerBackToSourceFailedRequest, DownloadCachePeerBackToSourceFinishedRequest,
+    DownloadCachePeerBackToSourceStartedRequest, DownloadCachePeerFailedRequest,
+    DownloadCachePeerFinishedRequest, DownloadCachePeerStartedRequest,
+    DownloadPieceBackToSourceFailedRequest, DownloadPieceBackToSourceFinishedRequest,
+    DownloadPieceFailedRequest, DownloadPieceFinishedRequest, RegisterCachePeerRequest,
+    RescheduleCachePeerRequest, StatCacheTaskRequest,
+};
+use dragonfly_client_backend::{BackendFactory, HeadRequest};
+use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_core::{
+    error::{BackendError, DownloadFromParentFailed, ErrorType, OrErr},
+    Error, Result as ClientResult,
+};
+use dragonfly_client_storage::{metadata, Storage};
+use dragonfly_client_util::{
+    http::{hashmap_to_headermap, headermap_to_hashmap},
+    id_generator::IDGenerator,
+};
+use reqwest::header::HeaderMap;
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::time::Instant;
+use tokio::io::AsyncReadExt;
+use tokio::sync::{
+    mpsc::{self, Sender},
+    Semaphore,
+};
+use tokio::task::JoinSet;
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
+use tonic::{Request, Status};
+use tracing::{debug, error, info, instrument, warn, Instrument};
+
+use super::*;
+
+/// CacheTask represents a cache task manager.
+pub struct CacheTask {
+    /// config is the configuration of the dfdaemon.
+    config: Arc<Config>,
+
+    /// id_generator is the id generator.
+    pub id_generator: Arc<IDGenerator>,
+
+    /// storage is the local storage.
+    storage: Arc<Storage>,
+
+    /// scheduler_client is the grpc client of the scheduler.
+    pub scheduler_client: Arc<SchedulerClient>,
+
+    /// backend_factory is the backend factory.
+    pub backend_factory: Arc<BackendFactory>,
+
+    /// piece is the piece manager.
+    pub piece: Arc<piece::Piece>,
+}
+
+/// CacheTask implements the cache task manager.
+impl CacheTask {
+    /// new returns a new CacheTask.
+    pub fn new(
+        config: Arc<Config>,
+        id_generator: Arc<IDGenerator>,
+        storage: Arc<Storage>,
+        scheduler_client: Arc<SchedulerClient>,
+        backend_factory: Arc<BackendFactory>,
+    ) -> ClientResult<Self> {
+        let piece = piece::Piece::new(
+            config.clone(),
+            id_generator.clone(),
+            storage.clone(),
+            backend_factory.clone(),
+        )?;
+        let piece = Arc::new(piece);
+
+        Ok(Self {
+            config,
+            id_generator,
+            storage: storage.clone(),
+            scheduler_client: scheduler_client.clone(),
+            backend_factory: backend_factory.clone(),
+            piece: piece.clone(),
+        })
+    }
+
+    /// get gets the metadata of the cache task.
+    #[instrument(skip_all)]
+    pub fn get(&self, id: &str) -> ClientResult<Option<metadata::CacheTask>> {
+        self.storage.get_cache_task(id)
+    }
+
+    /// download_started updates the metadata of the cache task when the cache task downloads started.
+    #[instrument(skip_all)]
+    pub async fn download_started(
+        &self,
+        id: &str,
+        request: DownloadCacheTaskRequest,
+    ) -> ClientResult<metadata::CacheTask> {
+        self.storage.prepare_download_cache_task_started(id).await?;
+
+        // Handle the request header.
+        let mut request_header =
+            hashmap_to_headermap(&request.request_header).inspect_err(|err| {
+                error!("convert header: {}", err);
+            })?;
+
+        // Remove the range header to prevent the server from
+        // returning a 206 partial content and returning
+        // a 200 full content.
+        request_header.remove(reqwest::header::RANGE);
+
+        // Head the url to get the content length.
+        let backend = self.backend_factory.build(request.url.as_str())?;
+
+        // Record the start time.
+        let start_time = Instant::now();
+
+        // Collect the backend request started metrics.
+        collect_backend_request_started_metrics(
+            backend.scheme().as_str(),
+            http::Method::HEAD.as_str(),
+        );
+        let response = backend
+            .head(HeadRequest {
+                task_id: id.to_string(),
+                url: request.url,
+                http_header: Some(request_header),
+                timeout: self.config.download.piece_timeout,
+                client_cert: None,
+                object_storage: request.object_storage,
+                hdfs: request.hdfs,
+            })
+            .await
+            .inspect_err(|_err| {
+                // Collect the backend request failure metrics.
+                collect_backend_request_failure_metrics(
+                    backend.scheme().as_str(),
+                    http::Method::HEAD.as_str(),
+                );
+            })?;
+
+        // Check if the status code is success.
+        if !response.success {
+            // Collect the backend request failure metrics.
+            collect_backend_request_failure_metrics(
+                backend.scheme().as_str(),
+                http::Method::HEAD.as_str(),
+            );
+
+            return Err(Error::BackendError(Box::new(BackendError {
+                message: response.error_message.unwrap_or_default(),
+                status_code: response.http_status_code,
+                header: response.http_header,
+            })));
+        }
+
+        // Collect the backend request finished metrics.
+        collect_backend_request_finished_metrics(
+            backend.scheme().as_str(),
+            http::Method::HEAD.as_str(),
+            start_time.elapsed(),
+        );
+
+        let content_length = match response.content_length {
+            Some(content_length) => content_length,
+            None => return Err(Error::InvalidContentLength),
+        };
+
+        let piece_length = match request.piece_length {
+            Some(piece_length) => self
+                .piece
+                .calculate_piece_length(piece::PieceLengthStrategy::FixedPieceLength(piece_length)),
+            None => {
+                self.piece
+                    .calculate_piece_length(piece::PieceLengthStrategy::OptimizeByFileLength(
+                        content_length,
+                    ))
+            }
+        };
+
+        self.storage
+            .download_cache_task_started(id, piece_length, content_length, response.http_header)
+            .await
+    }
+
+    /// download_finished updates the metadata of the cache task when the cache task downloads finished.
+    #[instrument(skip_all)]
+    pub fn download_finished(&self, id: &str) -> ClientResult<metadata::CacheTask> {
+        self.storage.download_cache_task_finished(id)
+    }
+
+    /// download_failed updates the metadata of the cache task when the cache task downloads failed.
+    #[instrument(skip_all)]
+    pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
+        self.storage
+            .download_cache_task_failed(id)
+            .await
+            .map(|_| ())
+    }
+
+    /// prefetch_task_started updates the metadata of the cache task when the cache task prefetch started.
+    #[instrument(skip_all)]
+    pub async fn prefetch_task_started(&self, id: &str) -> ClientResult<metadata::CacheTask> {
+        self.storage.prefetch_cache_task_started(id).await
+    }
+
+    /// prefetch_task_failed updates the metadata of the cache task when the cache task prefetch failed.
+    #[instrument(skip_all)]
+    pub async fn prefetch_task_failed(&self, id: &str) -> ClientResult<metadata::CacheTask> {
+        self.storage.prefetch_cache_task_failed(id).await
+    }
+
+    /// download downloads a cache task.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn download(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        request: DownloadCacheTaskRequest,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+    ) -> ClientResult<()> {
+        // Get the id of the cache task.
+        let task_id = task.id.as_str();
+
+        // Get the content length from the cache task.
+        let Some(content_length) = task.content_length() else {
+            error!("content length not found");
+            return Err(Error::InvalidContentLength);
+        };
+
+        // Get the piece length from the task.
+        let Some(piece_length) = task.piece_length() else {
+            error!("piece length not found");
+            return Err(Error::InvalidPieceLength);
+        };
+
+        // Calculate the interested pieces to download.
+        let interested_pieces =
+            match self
+                .piece
+                .calculate_interested(piece_length, content_length, request.range)
+            {
+                Ok(interested_pieces) => interested_pieces,
+                Err(err) => {
+                    error!("calculate interested pieces error: {:?}", err);
+                    return Err(err);
+                }
+            };
+        debug!(
+            "interested pieces: {:?}",
+            interested_pieces
+                .iter()
+                .map(|p| p.number)
+                .collect::<Vec<u32>>()
+        );
+
+        // Construct the pieces for the download task started response.
+        let mut pieces = Vec::new();
+        for interested_piece in interested_pieces.clone() {
+            pieces.push(Piece {
+                number: interested_piece.number,
+                parent_id: interested_piece.parent_id.clone(),
+                offset: interested_piece.offset,
+                length: interested_piece.length,
+                digest: interested_piece.digest.clone(),
+                content: None,
+                traffic_type: None,
+                cost: interested_piece.prost_cost(),
+                created_at: Some(prost_wkt_types::Timestamp::from(
+                    interested_piece.created_at,
+                )),
+            });
+        }
+
+        // Send the download task started request.
+        download_progress_tx
+            .send_timeout(
+                Ok(DownloadCacheTaskResponse {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    response: Some(
+                        download_cache_task_response::Response::DownloadCacheTaskStartedResponse(
+                            dfdaemon::v2::DownloadCacheTaskStartedResponse {
+                                content_length,
+                                range: request.range,
+                                response_header: task.response_header.clone(),
+                                pieces,
+                                is_finished: task.is_finished(),
+                            },
+                        ),
+                    ),
+                }),
+                REQUEST_TIMEOUT,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("send DownloadCacheTaskStartedResponse failed: {:?}", err);
+            })?;
+
+        // Download the pieces from the local.
+        debug!("download the pieces from local");
+        let finished_pieces = match self
+            .download_partial_from_local(
+                task,
+                host_id,
+                peer_id,
+                request.need_piece_content,
+                interested_pieces.clone(),
+                download_progress_tx.clone(),
+            )
+            .await
+        {
+            Ok(finished_pieces) => finished_pieces,
+            Err(err) => {
+                error!("download from local error: {:?}", err);
+                return Err(err);
+            }
+        };
+
+        // Remove the finished pieces from the pieces.
+        let interested_pieces = self
+            .piece
+            .remove_finished_from_interested(finished_pieces, interested_pieces);
+        info!(
+            "interested pieces after removing the finished piece: {:?}",
+            interested_pieces
+                .iter()
+                .map(|p| p.number)
+                .collect::<Vec<u32>>()
+        );
+
+        // Check if all pieces are downloaded.
+        if interested_pieces.is_empty() {
+            info!("all pieces are downloaded from local");
+            return Ok(());
+        };
+        debug!("download the pieces with scheduler");
+
+        // Download the pieces with scheduler.
+        let finished_pieces = match self
+            .download_partial_with_scheduler(
+                task,
+                host_id,
+                peer_id,
+                interested_pieces.clone(),
+                content_length,
+                request.clone(),
+                download_progress_tx.clone(),
+            )
+            .await
+        {
+            Ok(finished_pieces) => finished_pieces,
+            Err(err) => {
+                error!("download with scheduler error: {:?}", err);
+
+                // If disable back-to-source is true, return an error directly.
+                if request.disable_back_to_source {
+                    error!(
+                        "download back-to-source is disabled, download with scheduler error: {:?}",
+                        err
+                    );
+                    return Err(Error::Unknown("download failed".to_string()));
+                };
+
+                // Download the pieces from the source.
+                if let Err(err) = self
+                    .download_partial_from_source(
+                        task,
+                        host_id,
+                        peer_id,
+                        interested_pieces.clone(),
+                        request.clone(),
+                        download_progress_tx.clone(),
+                    )
+                    .await
+                {
+                    error!("download from source error: {:?}", err);
+                    return Err(err);
+                }
+
+                info!("all pieces are downloaded from source");
+                return Ok(());
+            }
+        };
+
+        // Remove the finished pieces from the pieces.
+        let interested_pieces = self
+            .piece
+            .remove_finished_from_interested(finished_pieces, interested_pieces);
+        info!(
+            "interested pieces after removing the finished piece: {:?}",
+            interested_pieces
+                .iter()
+                .map(|p| p.number)
+                .collect::<Vec<u32>>()
+        );
+
+        // Check if all pieces are downloaded.
+        if interested_pieces.is_empty() {
+            info!("all pieces are downloaded with scheduler");
+            return Ok(());
+        };
+
+        // If disable back-to-source is true, return an error directly.
+        if request.disable_back_to_source {
+            error!("download back-to-source is disabled");
+            return Err(Error::Unknown("download failed".to_string()));
+        };
+
+        // Download the pieces from the source.
+        if let Err(err) = self
+            .download_partial_from_source(
+                task,
+                host_id,
+                peer_id,
+                interested_pieces.clone(),
+                request.clone(),
+                download_progress_tx.clone(),
+            )
+            .await
+        {
+            error!("download from source error: {:?}", err);
+            return Err(err);
+        }
+
+        info!("all pieces are downloaded from source");
+        Ok(())
+    }
+
+    /// download_partial_with_scheduler downloads a partial cache task with scheduler.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn download_partial_with_scheduler(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        interested_pieces: Vec<metadata::Piece>,
+        content_length: u64,
+        request: DownloadCacheTaskRequest,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the cache task.
+        let task_id = task.id.as_str();
+
+        // Initialize the schedule count.
+        let mut schedule_count = 0;
+
+        // Initialize the finished pieces.
+        let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
+
+        // Initialize stream channel.
+        let (in_stream_tx, in_stream_rx) = mpsc::channel(10 * 1024);
+
+        // Send the register peer request.
+        in_stream_tx
+            .send_timeout(
+                AnnounceCachePeerRequest {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    request: Some(
+                        announce_cache_peer_request::Request::RegisterCachePeerRequest(
+                            RegisterCachePeerRequest {
+                                url: request.url.clone(),
+                                digest: request.digest.clone(),
+                                range: request.range,
+                                r#type: request.r#type,
+                                tag: request.tag.clone(),
+                                application: request.application.clone(),
+                                priority: request.priority,
+                                filtered_query_params: request.filtered_query_params.clone(),
+                                request_header: request.request_header.clone(),
+                                piece_length: request.piece_length,
+                                output_path: request.output_path.clone(),
+                                timeout: request.timeout,
+                                disable_back_to_source: request.disable_back_to_source,
+                                need_back_to_source: request.need_back_to_source,
+                                certificate_chain: request.certificate_chain.clone(),
+                                prefetch: request.prefetch,
+                                object_storage: request.object_storage.clone(),
+                                hdfs: request.hdfs.clone(),
+                                is_prefetch: request.is_prefetch,
+                                need_piece_content: request.need_piece_content,
+                                content_for_calculating_task_id: request
+                                    .content_for_calculating_task_id
+                                    .clone(),
+                                remote_ip: request.remote_ip.clone(),
+                            },
+                        ),
+                    ),
+                },
+                REQUEST_TIMEOUT,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("send RegisterCachePeerRequest failed: {:?}", err);
+            })?;
+        info!("sent RegisterCachePeerRequest");
+
+        // Initialize the stream.
+        let in_stream = ReceiverStream::new(in_stream_rx);
+        let request_stream = Request::new(in_stream);
+        let response = self
+            .scheduler_client
+            .announce_cache_peer(task_id, peer_id, request_stream)
+            .await
+            .inspect_err(|err| {
+                error!("announce cache peer failed: {:?}", err);
+            })?;
+        info!("announced cache peer has been connected");
+
+        let out_stream = response
+            .into_inner()
+            .timeout(self.config.scheduler.schedule_timeout);
+        tokio::pin!(out_stream);
+
+        while let Some(message) = out_stream.try_next().await.inspect_err(|err| {
+            error!("receive message from scheduler failed: {:?}", err);
+        })? {
+            // Check if the schedule count is exceeded.
+            schedule_count += 1;
+            if schedule_count > self.config.scheduler.max_schedule_count {
+                in_stream_tx
+                    .send_timeout(
+                        AnnounceCachePeerRequest {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            request: Some(
+                                announce_cache_peer_request::Request::DownloadCachePeerFailedRequest(
+                                    DownloadCachePeerFailedRequest {
+                                        description: Some(
+                                            "max schedule count exceeded".to_string(),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                            error!("send DownloadCachePeerFailedRequest failed: {:?}", err)
+                        });
+                info!("sent DownloadCachePeerFailedRequest");
+
+                // Wait for the latest message to be sent.
+                in_stream_tx.closed().await;
+                return Ok(finished_pieces);
+            }
+
+            let response = message?.response.ok_or(Error::UnexpectedResponse)?;
+            match response {
+                announce_cache_peer_response::Response::EmptyCacheTaskResponse(response) => {
+                    // If the cache task is empty, return an empty vector.
+                    info!("empty cache task response: {:?}", response);
+
+                    // Send the download peer started request.
+                    in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::DownloadCachePeerStartedRequest(
+                                        DownloadCachePeerStartedRequest {},
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .inspect_err(|err| {
+                            error!("send DownloadCachePeerStartedRequest failed: {:?}", err);
+                        })?;
+                    info!("sent DownloadCachePeerStartedRequest");
+
+                    // Send the download peer finished request.
+                    in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::DownloadCachePeerFinishedRequest(
+                                        DownloadCachePeerFinishedRequest {
+                                            content_length: 0,
+                                            piece_count: 0,
+                                        },
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .inspect_err(|err| {
+                            error!("send DownloadCachePeerFinishedRequest failed: {:?}", err);
+                        })?;
+                    info!("sent DownloadCachePeerFinishedRequest");
+
+                    // Wait for the latest message to be sent.
+                    in_stream_tx.closed().await;
+                    return Ok(Vec::new());
+                }
+                announce_cache_peer_response::Response::NormalCacheTaskResponse(response) => {
+                    // If the cache task is normal, download the pieces from the parent.
+                    info!(
+                        "normal cache task response: {:?}",
+                        response
+                            .candidate_parents
+                            .iter()
+                            .map(|p| p.id.clone())
+                            .collect::<Vec<String>>()
+                    );
+
+                    // Send the download peer started request.
+                    match in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::DownloadCachePeerStartedRequest(
+                                        DownloadCachePeerStartedRequest {},
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                    {
+                        Ok(_) => info!("sent DownloadCachePeerStartedRequest"),
+                        Err(err) => {
+                            error!("send DownloadCachePeerStartedRequest failed: {:?}", err);
+                            return Ok(finished_pieces);
+                        }
+                    };
+
+                    // Remove the finished pieces from the pieces.
+                    let remaining_interested_pieces = self.piece.remove_finished_from_interested(
+                        finished_pieces.clone(),
+                        interested_pieces.clone(),
+                    );
+
+                    // Download the pieces from the parent.
+                    let partial_finished_pieces = match self
+                        .download_partial_with_scheduler_from_parent(
+                            task,
+                            host_id,
+                            peer_id,
+                            response.candidate_parents.clone(),
+                            remaining_interested_pieces.clone(),
+                            request.is_prefetch,
+                            request.need_piece_content,
+                            download_progress_tx.clone(),
+                            in_stream_tx.clone(),
+                        )
+                        .await
+                    {
+                        Ok(partial_finished_pieces) => {
+                            info!(
+                                "schedule {} finished {} pieces from parent",
+                                schedule_count,
+                                partial_finished_pieces.len()
+                            );
+
+                            partial_finished_pieces
+                        }
+                        Err(err) => {
+                            error!("download from parent error: {:?}", err);
+                            Vec::new()
+                        }
+                    };
+
+                    // Merge the finished pieces.
+                    finished_pieces = self.piece.merge_finished_pieces(
+                        finished_pieces.clone(),
+                        partial_finished_pieces.clone(),
+                    );
+
+                    // Check if all pieces are downloaded.
+                    if finished_pieces.len() == interested_pieces.len() {
+                        // Send the download peer finished request.
+                        match in_stream_tx
+                            .send_timeout(
+                                AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(
+                                        announce_cache_peer_request::Request::DownloadCachePeerFinishedRequest(
+                                            DownloadCachePeerFinishedRequest {
+                                                content_length,
+                                                piece_count: interested_pieces.len() as u32,
+                                            },
+                                        ),
+                                    ),
+                                },
+                                REQUEST_TIMEOUT,
+                            )
+                            .await
+                        {
+                            Ok(_) => info!("sent DownloadCachePeerFinishedRequest"),
+                            Err(err) => {
+                                error!("send DownloadCachePeerFinishedRequest failed: {:?}", err);
+                            }
+                        }
+
+                        // Wait for the latest message to be sent.
+                        in_stream_tx.closed().await;
+                        return Ok(finished_pieces);
+                    }
+
+                    // If not all pieces are downloaded, send the reschedule request.
+                    match in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::RescheduleCachePeerRequest(
+                                        RescheduleCachePeerRequest {
+                                            candidate_parents: response.candidate_parents,
+                                            description: Some(
+                                                "not all pieces are downloaded from parent"
+                                                    .to_string(),
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                    {
+                        Ok(_) => info!("sent RescheduleCachePeerRequest"),
+                        Err(err) => {
+                            error!("send RescheduleCachePeerRequest failed: {:?}", err);
+                            return Ok(finished_pieces);
+                        }
+                    };
+                }
+                announce_cache_peer_response::Response::NeedBackToSourceResponse(response) => {
+                    // If the task need back to source, download the pieces from the source.
+                    info!("need back to source response: {:?}", response);
+
+                    // Send the download peer back-to-source request.
+                    match in_stream_tx
+                        .send_timeout(AnnounceCachePeerRequest {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            request: Some(
+                                announce_cache_peer_request::Request::DownloadCachePeerBackToSourceStartedRequest(
+                                    DownloadCachePeerBackToSourceStartedRequest {
+                                        description: None,
+                                    },
+                                ),
+                            ),
+                        }, REQUEST_TIMEOUT)
+                    .await {
+                        Ok(_) => info!("sent DownloadCachePeerBackToSourceStartedRequest"),
+                        Err(err) => {
+                            error!("send DownloadCachePeerBackToSourceStartedRequest failed: {:?}", err);
+                            return Ok(finished_pieces);
+                        }
+                    };
+
+                    // Remove the finished pieces from the pieces.
+                    let remaining_interested_pieces = self.piece.remove_finished_from_interested(
+                        finished_pieces.clone(),
+                        interested_pieces.clone(),
+                    );
+
+                    // Download the pieces from the source.
+                    let partial_finished_pieces = match self
+                        .download_partial_with_scheduler_from_source(
+                            task,
+                            host_id,
+                            peer_id,
+                            remaining_interested_pieces.clone(),
+                            request.clone(),
+                            download_progress_tx.clone(),
+                            in_stream_tx.clone(),
+                        )
+                        .await
+                    {
+                        Ok(finished_pieces) => finished_pieces,
+                        Err(err) => {
+                            in_stream_tx
+                                .send_timeout(AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(
+                                        announce_cache_peer_request::Request::DownloadCachePeerBackToSourceFailedRequest(
+                                            DownloadCachePeerBackToSourceFailedRequest {
+                                                description: Some(err.to_string()),
+                                            },
+                                        ),
+                                    ),
+                                }, REQUEST_TIMEOUT)
+                                .await
+                                .unwrap_or_else(|err| {
+                                    error!("send DownloadCachePeerBackToSourceFailedRequest failed: {:?}", err)
+                                });
+                            info!("sent DownloadCachePeerBackToSourceFailedRequest");
+
+                            // Wait for the latest message to be sent.
+                            in_stream_tx.closed().await;
+                            return Ok(finished_pieces);
+                        }
+                    };
+
+                    // Merge the finished pieces.
+                    finished_pieces = self.piece.merge_finished_pieces(
+                        finished_pieces.clone(),
+                        partial_finished_pieces.clone(),
+                    );
+
+                    if partial_finished_pieces.len() == remaining_interested_pieces.len() {
+                        // Send the download peer finished request.
+                        match in_stream_tx
+                            .send_timeout(
+                                AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(
+                                        announce_cache_peer_request::Request::DownloadCachePeerBackToSourceFinishedRequest(
+                                            DownloadCachePeerBackToSourceFinishedRequest {
+                                                content_length,
+                                                piece_count: interested_pieces.len() as u32,
+                                            },
+                                        ),
+                                    ),
+                                },
+                                REQUEST_TIMEOUT,
+                            )
+                            .await
+                        {
+                            Ok(_) => info!("sent DownloadCachePeerBackToSourceFinishedRequest"),
+                            Err(err) => {
+                                error!("send DownloadCachePeerBackToSourceFinishedRequest failed: {:?}", err);
+                            }
+                        }
+
+                        // Wait for the latest message to be sent.
+                        in_stream_tx.closed().await;
+                        return Ok(finished_pieces);
+                    }
+
+                    match in_stream_tx
+                        .send_timeout(AnnounceCachePeerRequest {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            request: Some(
+                                announce_cache_peer_request::Request::DownloadCachePeerBackToSourceFailedRequest(
+                                    DownloadCachePeerBackToSourceFailedRequest {
+                                        description: Some("not all pieces are downloaded from source".to_string()),
+                                    },
+                                ),
+                            ),
+                        }, REQUEST_TIMEOUT)
+                    .await {
+                        Ok(_) => info!("sent DownloadCachePeerBackToSourceFailedRequest"),
+                        Err(err) => {
+                            error!("send DownloadCachePeerBackToSourceFailedRequest failed: {:?}", err);
+                        }
+                    }
+
+                    // Wait for the latest message to be sent.
+                    in_stream_tx.closed().await;
+                    return Ok(finished_pieces);
+                }
+            }
+        }
+
+        // If the stream is finished abnormally, return an error.
+        error!("stream is finished abnormally");
+        Ok(finished_pieces)
+    }
+
+    /// download_partial_with_scheduler_from_parent downloads a partial task with scheduler from a parent.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn download_partial_with_scheduler_from_parent(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        parents: Vec<CachePeer>,
+        interested_pieces: Vec<metadata::Piece>,
+        is_prefetch: bool,
+        need_piece_content: bool,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+        in_stream_tx: Sender<AnnounceCachePeerRequest>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the cache task.
+        let task_id = task.id.as_str();
+
+        // Initialize the piece collector.
+        let piece_collector = piece_collector::PieceCollector::new(
+            self.config.clone(),
+            host_id,
+            task_id,
+            interested_pieces.clone(),
+            parents
+                .into_iter()
+                .map(|peer| piece_collector::CollectedParent {
+                    id: peer.id,
+                    host: peer.host,
+                })
+                .collect(),
+        )
+        .await;
+        let mut piece_collector_rx = piece_collector.run().await;
+
+        // Initialize the interrupt. If download from parent failed with scheduler or download
+        // progress, interrupt the collector and return the finished pieces.
+        let interrupt = Arc::new(AtomicBool::new(false));
+
+        // Initialize the finished pieces.
+        let finished_pieces = Arc::new(Mutex::new(Vec::new()));
+
+        // Initialize the join set.
+        let mut join_set = JoinSet::new();
+        let semaphore = Arc::new(Semaphore::new(
+            self.config.download.concurrent_piece_count as usize,
+        ));
+
+        // Download the pieces from the parents.
+        while let Some(collect_piece) = piece_collector_rx.recv().await {
+            if interrupt.load(Ordering::SeqCst) {
+                // If the interrupt is true, break the collector loop.
+                debug!("interrupt the piece collector");
+                drop(piece_collector_rx);
+                break;
+            }
+
+            async fn download_from_parent(
+                task_id: String,
+                host_id: String,
+                peer_id: String,
+                number: u32,
+                length: u64,
+                parent: piece_collector::CollectedParent,
+                piece_manager: Arc<piece::Piece>,
+                semaphore: Arc<Semaphore>,
+                download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+                in_stream_tx: Sender<AnnounceCachePeerRequest>,
+                interrupt: Arc<AtomicBool>,
+                finished_pieces: Arc<Mutex<Vec<metadata::Piece>>>,
+                is_prefetch: bool,
+                need_piece_content: bool,
+            ) -> ClientResult<metadata::Piece> {
+                // Limit the concurrent piece count.
+                let _permit = semaphore.acquire().await.unwrap();
+
+                let piece_id = piece_manager.cache_id(task_id.as_str(), number);
+                info!(
+                    "start to download piece {} from parent {:?}",
+                    piece_id,
+                    parent.id.clone()
+                );
+
+                let metadata = piece_manager
+                    .download_cache_from_parent(
+                        piece_id.as_str(),
+                        host_id.as_str(),
+                        task_id.as_str(),
+                        number,
+                        length,
+                        parent.clone(),
+                        is_prefetch,
+                    )
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "download piece {} from parent {:?} error: {:?}",
+                            piece_id,
+                            parent.id.clone(),
+                            err
+                        );
+                        Error::DownloadFromParentFailed(DownloadFromParentFailed {
+                            piece_number: number,
+                            parent_id: parent.id.clone(),
+                        })
+                    })?;
+
+                // Construct the piece.
+                let mut piece = Piece {
+                    number: metadata.number,
+                    parent_id: metadata.parent_id.clone(),
+                    offset: metadata.offset,
+                    length: metadata.length,
+                    digest: metadata.digest.clone(),
+                    content: None,
+                    traffic_type: Some(TrafficType::RemotePeer as i32),
+                    cost: metadata.prost_cost(),
+                    created_at: Some(prost_wkt_types::Timestamp::from(metadata.created_at)),
+                };
+
+                // If need_piece_content is true, read the piece content from the local.
+                if need_piece_content {
+                    let mut reader = piece_manager
+                        .download_cache_from_local_into_async_read(
+                            piece_id.as_str(),
+                            task_id.as_str(),
+                            metadata.length,
+                            None,
+                            true,
+                            false,
+                        )
+                        .await
+                        .inspect_err(|err| {
+                            error!("read piece {} failed: {:?}", piece_id, err);
+                            interrupt.store(true, Ordering::SeqCst);
+                        })?;
+
+                    let mut content = vec![0; metadata.length as usize];
+                    reader.read_exact(&mut content).await.inspect_err(|err| {
+                        error!("read piece {} failed: {:?}", piece_id, err);
+                        interrupt.store(true, Ordering::SeqCst);
+                    })?;
+
+                    piece.content = Some(content);
+                }
+
+                // Send the download piece finished request.
+                in_stream_tx
+                    .send_timeout(
+                        AnnounceCachePeerRequest {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            request: Some(
+                                announce_cache_peer_request::Request::DownloadPieceFinishedRequest(
+                                    DownloadPieceFinishedRequest {
+                                        piece: Some(piece.clone()),
+                                    },
+                                ),
+                            ),
+                        },
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                        error!(
+                            "send DownloadPieceFinishedRequest for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+                        interrupt.store(true, Ordering::SeqCst);
+                    });
+
+                // Send the download progress.
+                download_progress_tx
+                    .send_timeout(
+                        Ok(DownloadCacheTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece.clone()),
+                                    },
+                                ),
+                            ),
+                        }),
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+                        interrupt.store(true, Ordering::SeqCst);
+                    });
+
+                info!(
+                    "finished piece {} from parent {:?}",
+                    piece_id, metadata.parent_id
+                );
+
+                let mut finished_pieces = finished_pieces.lock().unwrap();
+                finished_pieces.push(metadata.clone());
+
+                Ok(metadata)
+            }
+
+            join_set.spawn(
+                download_from_parent(
+                    task_id.to_string(),
+                    host_id.to_string(),
+                    peer_id.to_string(),
+                    collect_piece.number,
+                    collect_piece.length,
+                    collect_piece.parent.clone(),
+                    self.piece.clone(),
+                    semaphore.clone(),
+                    download_progress_tx.clone(),
+                    in_stream_tx.clone(),
+                    interrupt.clone(),
+                    finished_pieces.clone(),
+                    is_prefetch,
+                    need_piece_content,
+                )
+                .in_current_span(),
+            );
+        }
+
+        // Wait for the pieces to be downloaded.
+        while let Some(message) = join_set
+            .join_next()
+            .await
+            .transpose()
+            .or_err(ErrorType::AsyncRuntimeError)?
+        {
+            match message {
+                Ok(_) => {}
+                Err(Error::DownloadFromParentFailed(err)) => {
+                    let (piece_number, parent_id) = (err.piece_number, err.parent_id);
+
+                    // Send the download piece failed request.
+                    in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::DownloadPieceFailedRequest(
+                                        DownloadPieceFailedRequest {
+                                            piece_number: Some(err.piece_number),
+                                            parent_id,
+                                            temporary: true,
+                                        },
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "send DownloadPieceFailedRequest for piece {} failed: {:?}",
+                                self.piece.cache_id(task_id, piece_number),
+                                err
+                            )
+                        });
+
+                    // If the download failed from the parent, continue to download the next
+                    // piece and ignore the error.
+                    continue;
+                }
+                Err(Error::SendTimeout) => {
+                    join_set.detach_all();
+
+                    // If the send timeout with scheduler or download progress, return the finished pieces.
+                    // It will stop the download from the parent with scheduler
+                    // and download from the source directly from middle.
+                    let finished_pieces = finished_pieces.lock().unwrap().clone();
+                    return Ok(finished_pieces);
+                }
+                Err(err) => {
+                    error!("download from parent error: {:?}", err);
+
+                    // If the unknown error occurred, continue to download the next piece and
+                    // ignore the error.
+                    continue;
+                }
+            }
+        }
+
+        let finished_pieces = finished_pieces.lock().unwrap().clone();
+        Ok(finished_pieces)
+    }
+
+    /// download_partial_with_scheduler_from_source downloads a partial task with scheduler from the source.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn download_partial_with_scheduler_from_source(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        interested_pieces: Vec<metadata::Piece>,
+        request: DownloadCacheTaskRequest,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+        in_stream_tx: Sender<AnnounceCachePeerRequest>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the task.
+        let task_id = task.id.as_str();
+
+        // Convert the header.
+        let request_header: HeaderMap = (&request.request_header)
+            .try_into()
+            .or_err(ErrorType::ParseError)?;
+
+        // Initialize the finished pieces.
+        let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
+
+        // Download the piece from the local.
+        let mut join_set = JoinSet::new();
+        let semaphore = Arc::new(Semaphore::new(
+            self.config.download.concurrent_piece_count as usize,
+        ));
+        for interested_piece in interested_pieces {
+            async fn download_from_source(
+                task_id: String,
+                host_id: String,
+                peer_id: String,
+                number: u32,
+                url: String,
+                offset: u64,
+                length: u64,
+                request_header: HeaderMap,
+                is_prefetch: bool,
+                need_piece_content: bool,
+                piece_manager: Arc<piece::Piece>,
+                semaphore: Arc<Semaphore>,
+                download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+                in_stream_tx: Sender<AnnounceCachePeerRequest>,
+                object_storage: Option<ObjectStorage>,
+                hdfs: Option<Hdfs>,
+            ) -> ClientResult<metadata::Piece> {
+                // Limit the concurrent download count.
+                let _permit = semaphore.acquire().await.unwrap();
+
+                let piece_id = piece_manager.cache_id(task_id.as_str(), number);
+                info!("start to download piece {} from source", piece_id);
+
+                let metadata = piece_manager
+                    .download_cache_from_source(
+                        piece_id.as_str(),
+                        task_id.as_str(),
+                        number,
+                        url.as_str(),
+                        offset,
+                        length,
+                        request_header,
+                        is_prefetch,
+                        object_storage,
+                        hdfs,
+                    )
+                    .await?;
+
+                // Construct the piece.
+                let mut piece = Piece {
+                    number: metadata.number,
+                    parent_id: metadata.parent_id.clone(),
+                    offset: metadata.offset,
+                    length: metadata.length,
+                    digest: metadata.digest.clone(),
+                    content: None,
+                    traffic_type: Some(TrafficType::BackToSource as i32),
+                    cost: metadata.prost_cost(),
+                    created_at: Some(prost_wkt_types::Timestamp::from(metadata.created_at)),
+                };
+
+                // If need_piece_content is true, read the piece content from the local.
+                if need_piece_content {
+                    let mut reader = piece_manager
+                        .download_cache_from_local_into_async_read(
+                            piece_id.as_str(),
+                            task_id.as_str(),
+                            metadata.length,
+                            None,
+                            true,
+                            false,
+                        )
+                        .await
+                        .inspect_err(|err| {
+                            error!("read piece {} failed: {:?}", piece_id, err);
+                        })?;
+
+                    let mut content = vec![0; metadata.length as usize];
+                    reader.read_exact(&mut content).await.inspect_err(|err| {
+                        error!("read piece {} failed: {:?}", piece_id, err);
+                    })?;
+
+                    piece.content = Some(content);
+                }
+
+                // Send the download piece finished request.
+                in_stream_tx
+                        .send_timeout(
+                            AnnounceCachePeerRequest {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                request: Some(
+                                    announce_cache_peer_request::Request::DownloadPieceBackToSourceFinishedRequest(
+                                        DownloadPieceBackToSourceFinishedRequest {
+                                            piece: Some(piece.clone()),
+                                        },
+                                    ),
+                                ),
+                            },
+                            REQUEST_TIMEOUT,
+                        )
+                        .await.unwrap_or_else(|err| {
+                            error!("send DownloadPieceBackToSourceFinishedRequest for piece {} failed: {:?}", piece_id, err);
+                        });
+
+                // Send the download progress.
+                download_progress_tx
+                    .send_timeout(
+                        Ok(DownloadCacheTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece.clone()),
+                                    },
+                                ),
+                            ),
+                        }),
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+                    });
+
+                info!("finished piece {} from source", piece_id);
+                Ok(metadata)
+            }
+
+            join_set.spawn(
+                download_from_source(
+                    task_id.to_string(),
+                    host_id.to_string(),
+                    peer_id.to_string(),
+                    interested_piece.number,
+                    request.url.clone(),
+                    interested_piece.offset,
+                    interested_piece.length,
+                    request_header.clone(),
+                    request.is_prefetch,
+                    request.need_piece_content,
+                    self.piece.clone(),
+                    semaphore.clone(),
+                    download_progress_tx.clone(),
+                    in_stream_tx.clone(),
+                    request.object_storage.clone(),
+                    request.hdfs.clone(),
+                )
+                .in_current_span(),
+            );
+        }
+
+        // Wait for the pieces to be downloaded.
+        while let Some(message) = join_set
+            .join_next()
+            .await
+            .transpose()
+            .or_err(ErrorType::AsyncRuntimeError)?
+        {
+            match message {
+                Ok(metadata) => {
+                    // Store the finished piece.
+                    finished_pieces.push(metadata.clone());
+                }
+                Err(Error::BackendError(err)) => {
+                    join_set.detach_all();
+
+                    // Send the download piece http failed request.
+                    in_stream_tx.send_timeout(AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(announce_cache_peer_request::Request::DownloadPieceBackToSourceFailedRequest(
+                                            DownloadPieceBackToSourceFailedRequest{
+                                                piece_number: None,
+                                                response: Some(download_piece_back_to_source_failed_request::Response::Backend(
+                                                        Backend{
+                                                            message: err.message.clone(),
+                                                            header: headermap_to_hashmap(&err.header.clone().unwrap_or_default()),
+                                                            status_code: err.status_code.map(|code| code.as_u16() as i32),
+                                                        }
+                                                )),
+                                            }
+                                    )),
+                                }, REQUEST_TIMEOUT)
+                                .await
+                                .unwrap_or_else(|err| error!("send DownloadPieceBackToSourceFailedRequest error: {:?}", err));
+
+                    // If the backend error with source, return the error.
+                    // It will stop the download from the source with scheduler
+                    // and download from the source directly from beginning.
+                    return Err(Error::BackendError(err));
+                }
+                Err(Error::SendTimeout) => {
+                    join_set.detach_all();
+
+                    // Send the download piece failed request.
+                    in_stream_tx.send_timeout(AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(announce_cache_peer_request::Request::DownloadPieceBackToSourceFailedRequest(
+                                            DownloadPieceBackToSourceFailedRequest{
+                                                piece_number: None,
+                                                response: Some(download_piece_back_to_source_failed_request::Response::Unknown(
+                                                        Unknown{
+                                                            message: Some("send timeout".to_string()),
+                                                        }
+                                                )),
+                                            }
+                                    )),
+                                }, REQUEST_TIMEOUT)
+                                .await
+                                .unwrap_or_else(|err| error!("send DownloadPieceBackToSourceFailedRequest error: {:?}", err));
+
+                    // If the send timeout with scheduler or download progress, return
+                    // the finished pieces. It will stop the download from the source with
+                    // scheduler and download from the source directly from middle.
+                    return Ok(finished_pieces);
+                }
+                Err(err) => {
+                    join_set.detach_all();
+
+                    // Send the download piece failed request.
+                    in_stream_tx.send_timeout(AnnounceCachePeerRequest {
+                                    host_id: host_id.to_string(),
+                                    task_id: task_id.to_string(),
+                                    peer_id: peer_id.to_string(),
+                                    request: Some(announce_cache_peer_request::Request::DownloadPieceBackToSourceFailedRequest(
+                                            DownloadPieceBackToSourceFailedRequest{
+                                                piece_number: None,
+                                                response: Some(download_piece_back_to_source_failed_request::Response::Unknown(
+                                                        Unknown{
+                                                            message: Some(err.to_string()),
+                                                        }
+                                                )),
+                                            }
+                                    )),
+                                }, REQUEST_TIMEOUT)
+                                .await
+                                .unwrap_or_else(|err| error!("send DownloadPieceBackToSourceFailedRequest error: {:?}", err));
+
+                    // If the unknown error, return the error.
+                    // It will stop the download from the source with scheduler
+                    // and download from the source directly from beginning.
+                    return Err(err);
+                }
+            }
+        }
+
+        Ok(finished_pieces)
+    }
+
+    /// download_partial_from_local downloads a partial cache task from a local.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn download_partial_from_local(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        need_piece_content: bool,
+        interested_pieces: Vec<metadata::Piece>,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the task.
+        let task_id = task.id.as_str();
+
+        // Initialize the finished pieces.
+        let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
+
+        // Download the piece from the local.
+        for interested_piece in interested_pieces {
+            let piece_id = self.piece.cache_id(task_id, interested_piece.number);
+
+            // Get the piece metadata from the local storage.
+            let piece = match self.piece.get_cache(piece_id.as_str()) {
+                Ok(Some(piece)) => piece,
+                Ok(None) => {
+                    debug!("piece {} not found in local storage", piece_id);
+                    continue;
+                }
+                Err(err) => {
+                    error!("get piece {} from local storage error: {:?}", piece_id, err);
+                    continue;
+                }
+            };
+
+            // Fake the download from the local.
+            self.piece.download_cache_from_local(task_id, piece.length);
+            info!("finished piece {} from local", piece_id,);
+
+            // Construct the piece.
+            let mut piece = Piece {
+                number: piece.number,
+                parent_id: None,
+                offset: piece.offset,
+                length: piece.length,
+                digest: piece.digest.clone(),
+                content: None,
+                traffic_type: Some(TrafficType::LocalPeer as i32),
+                cost: piece.prost_cost(),
+                created_at: Some(prost_wkt_types::Timestamp::from(piece.created_at)),
+            };
+
+            // If need_piece_content is true, read the piece content from the local.
+            if need_piece_content {
+                let mut reader = self
+                    .piece
+                    .download_cache_from_local_into_async_read(
+                        piece_id.as_str(),
+                        task_id,
+                        piece.length,
+                        None,
+                        true,
+                        false,
+                    )
+                    .await
+                    .inspect_err(|err| {
+                        error!("read piece {} failed: {:?}", piece_id, err);
+                    })?;
+
+                let mut content = vec![0; piece.length as usize];
+                reader.read_exact(&mut content).await.inspect_err(|err| {
+                    error!("read piece {} failed: {:?}", piece_id, err);
+                })?;
+
+                piece.content = Some(content);
+            }
+
+            // Send the download progress.
+            download_progress_tx
+                .send_timeout(
+                    Ok(DownloadCacheTaskResponse {
+                        host_id: host_id.to_string(),
+                        task_id: task_id.to_string(),
+                        peer_id: peer_id.to_string(),
+                        response: Some(
+                            download_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                dfdaemon::v2::DownloadPieceFinishedResponse {
+                                    piece: Some(piece.clone()),
+                                },
+                            ),
+                        ),
+                    }),
+                    REQUEST_TIMEOUT,
+                )
+                .await
+                .unwrap_or_else(|err| {
+                    error!(
+                        "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                        piece_id, err
+                    );
+                });
+
+            // Store the finished piece.
+            finished_pieces.push(interested_piece.clone());
+        }
+
+        Ok(finished_pieces)
+    }
+
+    /// download_partial_from_source downloads a partial task from the source.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn download_partial_from_source(
+        &self,
+        task: &metadata::CacheTask,
+        host_id: &str,
+        peer_id: &str,
+        interested_pieces: Vec<metadata::Piece>,
+        request: DownloadCacheTaskRequest,
+        download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the task.
+        let task_id = task.id.as_str();
+
+        // Convert the header.
+        let request_header: HeaderMap = (&request.request_header)
+            .try_into()
+            .or_err(ErrorType::ParseError)?;
+
+        // Initialize the finished pieces.
+        let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
+
+        // Download the pieces.
+        let mut join_set = JoinSet::new();
+        let semaphore = Arc::new(Semaphore::new(
+            self.config.download.concurrent_piece_count as usize,
+        ));
+
+        for interested_piece in &interested_pieces {
+            async fn download_from_source(
+                task_id: String,
+                host_id: String,
+                peer_id: String,
+                number: u32,
+                url: String,
+                offset: u64,
+                length: u64,
+                request_header: HeaderMap,
+                is_prefetch: bool,
+                piece_manager: Arc<piece::Piece>,
+                semaphore: Arc<Semaphore>,
+                download_progress_tx: Sender<Result<DownloadCacheTaskResponse, Status>>,
+                object_storage: Option<ObjectStorage>,
+                hdfs: Option<Hdfs>,
+            ) -> ClientResult<metadata::Piece> {
+                // Limit the concurrent download count.
+                let _permit = semaphore.acquire().await.unwrap();
+
+                let piece_id = piece_manager.cache_id(task_id.as_str(), number);
+                info!("start to download piece {} from source", piece_id);
+
+                let metadata = piece_manager
+                    .download_cache_from_source(
+                        piece_id.as_str(),
+                        task_id.as_str(),
+                        number,
+                        url.as_str(),
+                        offset,
+                        length,
+                        request_header,
+                        is_prefetch,
+                        object_storage,
+                        hdfs,
+                    )
+                    .await?;
+
+                // Construct the piece.
+                let piece = Piece {
+                    number: metadata.number,
+                    parent_id: None,
+                    offset: metadata.offset,
+                    length: metadata.length,
+                    digest: metadata.digest.clone(),
+                    content: None,
+                    traffic_type: Some(TrafficType::BackToSource as i32),
+                    cost: metadata.prost_cost(),
+                    created_at: Some(prost_wkt_types::Timestamp::from(metadata.created_at)),
+                };
+
+                // Send the download progress.
+                download_progress_tx
+                    .send_timeout(
+                        Ok(DownloadCacheTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece.clone()),
+                                    },
+                                ),
+                            ),
+                        }),
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+                    });
+
+                info!("finished piece {} from source", piece_id);
+                Ok(metadata)
+            }
+
+            join_set.spawn(
+                download_from_source(
+                    task_id.to_string(),
+                    host_id.to_string(),
+                    peer_id.to_string(),
+                    interested_piece.number,
+                    request.url.clone(),
+                    interested_piece.offset,
+                    interested_piece.length,
+                    request_header.clone(),
+                    request.is_prefetch,
+                    self.piece.clone(),
+                    semaphore.clone(),
+                    download_progress_tx.clone(),
+                    request.object_storage.clone(),
+                    request.hdfs.clone(),
+                )
+                .in_current_span(),
+            );
+        }
+
+        // Wait for the pieces to be downloaded.
+        while let Some(message) = join_set
+            .join_next()
+            .await
+            .transpose()
+            .or_err(ErrorType::AsyncRuntimeError)?
+        {
+            match message {
+                Ok(metadata) => {
+                    // Store the finished piece.
+                    finished_pieces.push(metadata.clone());
+                }
+                Err(err) => {
+                    join_set.detach_all();
+
+                    // If the download failed from the source, return the error.
+                    // It will stop the download from the source.
+                    return Err(err);
+                }
+            }
+        }
+
+        // Check if all pieces are downloaded.
+        if finished_pieces.len() != interested_pieces.len() {
+            // If not all pieces are downloaded, return an error.
+            return Err(Error::Unknown(
+                "not all pieces are downloaded from source".to_string(),
+            ));
+        }
+
+        return Ok(finished_pieces);
+    }
+
+    /// stat_cache_task returns the cache task metadata.
+    #[instrument(skip_all)]
+    pub async fn stat(
+        &self,
+        task_id: &str,
+        host_id: &str,
+        local_only: bool,
+    ) -> ClientResult<CommonCacheTask> {
+        if local_only {
+            let Some(task_metadata) = self.storage.get_cache_task(task_id).inspect_err(|err| {
+                error!(
+                    "get cache task {} from local storage error: {:?}",
+                    task_id, err
+                );
+            })?
+            else {
+                return Err(Error::TaskNotFound(task_id.to_owned()));
+            };
+
+            let piece_metadatas = self.piece.get_all(task_id).inspect_err(|err| {
+                error!(
+                    "get pieces for task {} from local storage error: {:?}",
+                    task_id, err
+                );
+            })?;
+
+            let pieces = piece_metadatas
+                .into_iter()
+                .filter(|piece| piece.is_finished())
+                .map(|piece| {
+                    // The traffic_type indicates whether the first download was from the source or hit the remote peer cache.
+                    // If the parent_id exists, the piece was downloaded from a remote peer. Otherwise, it was
+                    // downloaded from the source.
+                    let traffic_type = match piece.parent_id {
+                        None => TrafficType::BackToSource,
+                        Some(_) => TrafficType::RemotePeer,
+                    };
+
+                    Piece {
+                        number: piece.number,
+                        parent_id: piece.parent_id.clone(),
+                        offset: piece.offset,
+                        length: piece.length,
+                        digest: piece.digest.clone(),
+                        content: None,
+                        traffic_type: Some(traffic_type as i32),
+                        cost: piece.prost_cost(),
+                        created_at: Some(prost_wkt_types::Timestamp::from(piece.created_at)),
+                    }
+                })
+                .collect::<Vec<Piece>>();
+
+            return Ok(CommonCacheTask {
+                id: task_metadata.id,
+                r#type: TaskType::Cache as i32,
+                url: String::new(),
+                digest: None,
+                tag: None,
+                application: None,
+                filtered_query_params: Vec::new(),
+                request_header: HashMap::new(),
+                content_length: task_metadata.content_length.unwrap_or(0),
+                piece_count: pieces.len() as u32,
+                size_scope: SizeScope::Normal as i32,
+                pieces,
+                state: String::new(),
+                peer_count: 0,
+                has_available_peer: false,
+                created_at: Some(prost_wkt_types::Timestamp::from(task_metadata.created_at)),
+                updated_at: Some(prost_wkt_types::Timestamp::from(task_metadata.updated_at)),
+            });
+        }
+
+        let task = self
+            .scheduler_client
+            .stat_cache_task(StatCacheTaskRequest {
+                host_id: host_id.to_string(),
+                task_id: task_id.to_string(),
+            })
+            .await
+            .inspect_err(|err| {
+                error!("stat cache task failed: {}", err);
+            })?;
+
+        Ok(task)
+    }
+
+    /// delete_cache_task deletes a cache task and reclaim local storage.
+    #[instrument(skip_all)]
+    pub async fn delete(&self, task_id: &str, host_id: &str) -> ClientResult<()> {
+        let task = self.storage.get_cache_task(task_id).inspect_err(|err| {
+            error!(
+                "get cache task {} from local storage error: {:?}",
+                task_id, err
+            );
+        })?;
+
+        match task {
+            Some(task) => {
+                self.storage.delete_cache_task(task.id.as_str()).await;
+
+                self.scheduler_client
+                    .delete_cache_task(DeleteCacheTaskRequest {
+                        host_id: host_id.to_string(),
+                        task_id: task_id.to_string(),
+                    })
+                    .await
+                    .inspect_err(|err| {
+                        error!(
+                            "delete cache task {} failed from scheduler: {:?}",
+                            task_id, err
+                        );
+                    })?;
+
+                info!("delete cache task {} from local storage", task.id);
+                Ok(())
+            }
+            None => {
+                error!("delete_cache_task cache task {} not found", task_id);
+                Err(Error::TaskNotFound(task_id.to_owned()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    // test_delete_cache_task_not_found tests the CacheTask.delete method when the cache task does not exist.
+    #[tokio::test]
+    async fn test_delete_cache_task_not_found() {
+        // Create a temporary directory for testing.
+        let temp_dir = tempdir().unwrap();
+        let log_dir = temp_dir.path().join("log");
+        std::fs::create_dir_all(&log_dir).unwrap();
+
+        // Create configuration.
+        let config = Config::default();
+        let config = Arc::new(config);
+
+        // Create storage.
+        let storage = Storage::new(config.clone(), temp_dir.path(), log_dir)
+            .await
+            .unwrap();
+        let storage = Arc::new(storage);
+
+        // Test Storage.get_task and Error::TaskNotFound.
+        let task_id = "non-existent-task-id";
+
+        // Verify that non-existent tasks return None.
+        let task = storage.get_cache_task(task_id).unwrap();
+        assert!(task.is_none(), "non-existent tasks should return None");
+
+        // Create a task and save it to storage.
+        let task_id = "test-task-id";
+        storage
+            .download_cache_task_started(task_id, 1024, 4096, None)
+            .await
+            .unwrap();
+
+        // Verify that the task exists.
+        let task = storage.get_cache_task(task_id).unwrap();
+        assert!(task.is_some(), "task should exist");
+
+        // Delete the task from storage.
+        storage.delete_cache_task(task_id).await;
+
+        // Verify that the task has been deleted.
+        let task = storage.get_cache_task(task_id).unwrap();
+        assert!(task.is_none(), "task should be deleted");
+    }
+}

--- a/dragonfly-client/src/resource/mod.rs
+++ b/dragonfly-client/src/resource/mod.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+pub mod cache_task;
 pub mod persistent_cache_task;
 pub mod piece;
 pub mod piece_collector;

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -393,6 +393,69 @@ impl Piece {
         self.storage.upload_piece(piece_id, task_id, range).await
     }
 
+    /// upload_cache_from_local_into_async_read uploads a single cache piece from local cache.
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn upload_cache_from_local_into_async_read(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        length: u64,
+        range: Option<Range>,
+        disable_rate_limit: bool,
+    ) -> Result<impl AsyncRead> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+        Span::current().record("piece_length", length);
+
+        // Acquire the upload rate limiter.
+        if !disable_rate_limit {
+            self.upload_rate_limiter.acquire(length as usize).await;
+        }
+
+        // Upload the cache piece content.
+        self.storage
+            .upload_cache_piece(piece_id, task_id, range)
+            .await
+            .inspect(|_| {
+                collect_upload_piece_traffic_metrics(
+                    self.id_generator.task_type(task_id) as i32,
+                    length,
+                );
+            })
+    }
+
+    /// download_cache_from_local_into_async_read downloads a single piece from local cache.
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_cache_from_local_into_async_read(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        length: u64,
+        range: Option<Range>,
+        disable_rate_limit: bool,
+        is_prefetch: bool,
+    ) -> Result<impl AsyncRead> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+        Span::current().record("piece_length", length);
+
+        // Acquire the download rate limiter.
+        if !disable_rate_limit {
+            if is_prefetch {
+                // Acquire the prefetch rate limiter.
+                self.prefetch_rate_limiter.acquire(length as usize).await;
+            } else {
+                // Acquire the download rate limiter.
+                self.download_rate_limiter.acquire(length as usize).await;
+            }
+        }
+
+        // Upload the piece content.
+        self.storage
+            .upload_cache_piece(piece_id, task_id, range)
+            .await
+    }
+
     /// download_from_local downloads a single piece from local cache. Fake the download piece
     /// from the local cache, just collect the metrics.
     #[instrument(skip_all)]
@@ -664,6 +727,290 @@ impl Piece {
                 Err(err)
             }
         }
+    }
+
+    /// id generates a new cache piece id.
+    #[inline]
+    pub fn cache_id(&self, task_id: &str, number: u32) -> String {
+        self.storage.cache_piece_id(task_id, number)
+    }
+
+    /// get_cache gets a cache piece from the local storage.
+    pub fn get_cache(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
+        self.storage.get_cache_piece(piece_id)
+    }
+
+    /// download_cache_from_parent downloads a single piece from a parent.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_cache_from_parent(
+        &self,
+        piece_id: &str,
+        host_id: &str,
+        task_id: &str,
+        number: u32,
+        length: u64,
+        parent: piece_collector::CollectedParent,
+        is_prefetch: bool,
+    ) -> Result<metadata::Piece> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+        Span::current().record("piece_length", length);
+
+        // Record the start of downloading piece.
+        let piece = self
+            .storage
+            .download_cache_piece_started(piece_id, number)
+            .await?;
+
+        // If the piece is downloaded by the other thread,
+        // return the piece directly.
+        if piece.is_finished() {
+            info!("finished piece {} from local", piece_id);
+            return Ok(piece);
+        }
+
+        if is_prefetch {
+            // Acquire the prefetch rate limiter.
+            self.prefetch_rate_limiter.acquire(length as usize).await;
+        } else {
+            // Acquire the download rate limiter.
+            self.download_rate_limiter.acquire(length as usize).await;
+        }
+
+        // Create a dfdaemon client.
+        let host = parent.host.clone().ok_or_else(|| {
+            error!("peer host is empty");
+            if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                error!("set piece metadata failed: {}", err)
+            };
+
+            Error::InvalidPeer(parent.id.clone())
+        })?;
+
+        let (content, offset, digest) = self
+            .downloader
+            .download_cache_piece(
+                format!("{}:{}", host.ip, host.port).as_str(),
+                number,
+                host_id,
+                task_id,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("download piece failed: {}", err);
+                if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                    error!("set piece metadata failed: {}", err)
+                };
+            })?;
+        let mut reader = Cursor::new(content);
+
+        // Record the finish of downloading piece.
+        match self
+            .storage
+            .download_cache_piece_from_parent_finished(
+                piece_id,
+                task_id,
+                offset,
+                length,
+                digest.as_str(),
+                parent.id.as_str(),
+                &mut reader,
+                self.config.storage.write_piece_timeout,
+            )
+            .await
+        {
+            Ok(piece) => {
+                collect_download_piece_traffic_metrics(
+                    &TrafficType::RemotePeer,
+                    self.id_generator.task_type(task_id) as i32,
+                    length,
+                );
+
+                Ok(piece)
+            }
+            Err(err) => {
+                error!("download cache piece finished: {}", err);
+                if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                    error!("set cache piece metadata failed: {}", err)
+                };
+
+                Err(err)
+            }
+        }
+    }
+
+    /// download_cache_from_source downloads a single piece from the source.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_cache_from_source(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        number: u32,
+        url: &str,
+        offset: u64,
+        length: u64,
+        request_header: HeaderMap,
+        is_prefetch: bool,
+        object_storage: Option<ObjectStorage>,
+        hdfs: Option<Hdfs>,
+    ) -> Result<metadata::Piece> {
+        // Span record the piece_id.
+        Span::current().record("piece_id", piece_id);
+        Span::current().record("piece_length", length);
+
+        // Record the start of downloading piece.
+        let piece = self
+            .storage
+            .download_cache_piece_started(piece_id, number)
+            .await?;
+
+        // If the piece is downloaded by the other thread,
+        // return the piece directly.
+        if piece.is_finished() {
+            info!("finished piece {} from local", piece_id);
+            return Ok(piece);
+        }
+
+        if is_prefetch {
+            // Acquire the prefetch rate limiter.
+            self.prefetch_rate_limiter.acquire(length as usize).await;
+        } else {
+            // Acquire the download rate limiter.
+            self.download_rate_limiter.acquire(length as usize).await;
+        }
+
+        // Add range header to the request by offset and length.
+        let mut request_header = request_header.clone();
+        request_header.insert(
+            header::RANGE,
+            format!("bytes={}-{}", offset, offset + length - 1)
+                .parse()
+                .unwrap(),
+        );
+
+        // Download the piece from the source.
+        let backend = self.backend_factory.build(url).inspect_err(|err| {
+            error!("build backend failed: {}", err);
+            if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                error!("set piece metadata failed: {}", err)
+            };
+        })?;
+
+        // Record the start time.
+        let start_time = Instant::now();
+
+        // Collect the backend request started metrics.
+        collect_backend_request_started_metrics(
+            backend.scheme().as_str(),
+            http::Method::GET.as_str(),
+        );
+        let mut response = backend
+            .get(GetRequest {
+                task_id: task_id.to_string(),
+                piece_id: piece_id.to_string(),
+                url: url.to_string(),
+                range: Some(Range {
+                    start: offset,
+                    length,
+                }),
+                http_header: Some(request_header),
+                timeout: self.config.download.piece_timeout,
+                client_cert: None,
+                object_storage,
+                hdfs,
+            })
+            .await
+            .inspect_err(|err| {
+                // Collect the backend request failure metrics.
+                collect_backend_request_failure_metrics(
+                    backend.scheme().as_str(),
+                    http::Method::GET.as_str(),
+                );
+
+                // if the request is failed.
+                error!("backend get failed: {}", err);
+                if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                    error!("set cache piece metadata failed: {}", err)
+                };
+            })?;
+
+        if !response.success {
+            // Collect the backend request failure metrics.
+            collect_backend_request_failure_metrics(
+                backend.scheme().as_str(),
+                http::Method::GET.as_str(),
+            );
+
+            // if the status code is not OK.
+            let mut buffer = String::new();
+            response
+                .reader
+                .read_to_string(&mut buffer)
+                .await
+                .unwrap_or_default();
+
+            let error_message = response.error_message.unwrap_or_default();
+            error!("backend get failed: {} {}", error_message, buffer.as_str());
+
+            self.storage.download_cache_piece_failed(piece_id)?;
+            return Err(Error::BackendError(Box::new(BackendError {
+                message: error_message,
+                status_code: Some(response.http_status_code.unwrap_or_default()),
+                header: Some(response.http_header.unwrap_or_default()),
+            })));
+        }
+
+        // Collect the backend request finished metrics.
+        collect_backend_request_finished_metrics(
+            backend.scheme().as_str(),
+            http::Method::GET.as_str(),
+            start_time.elapsed(),
+        );
+
+        // Record the finish of downloading piece.
+        match self
+            .storage
+            .download_cache_piece_from_source_finished(
+                piece_id,
+                task_id,
+                offset,
+                length,
+                &mut response.reader,
+                self.config.storage.write_piece_timeout,
+            )
+            .await
+        {
+            Ok(piece) => {
+                collect_download_piece_traffic_metrics(
+                    &TrafficType::BackToSource,
+                    self.id_generator.task_type(task_id) as i32,
+                    length,
+                );
+
+                Ok(piece)
+            }
+            Err(err) => {
+                error!("download cache piece finished: {}", err);
+                if let Some(err) = self.storage.download_cache_piece_failed(piece_id).err() {
+                    error!("set cache piece metadata failed: {}", err)
+                };
+
+                Err(err)
+            }
+        }
+    }
+
+    /// download_cache_from_local downloads a single piece from local cache. Fake the download piece
+    /// from the local cache, just collect the metrics.
+    #[instrument(skip_all)]
+    pub fn download_cache_from_local(&self, task_id: &str, length: u64) {
+        collect_download_piece_traffic_metrics(
+            &TrafficType::LocalPeer,
+            self.id_generator.task_type(task_id) as i32,
+            length,
+        );
     }
 
     /// persistent_cache_id generates a new persistent cache piece id.

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -15,7 +15,9 @@
  */
 
 use crate::grpc::dfdaemon_upload::DfdaemonUploadClient;
-use dragonfly_api::dfdaemon::v2::{DownloadPersistentCachePieceRequest, DownloadPieceRequest};
+use dragonfly_api::dfdaemon::v2::{
+    DownloadCachePieceRequest, DownloadPersistentCachePieceRequest, DownloadPieceRequest,
+};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_storage::metadata;
@@ -48,6 +50,15 @@ pub trait Downloader: Send + Sync {
     /// download_persistent_cache_piece downloads a persistent cache piece from the other peer by different
     /// protocols.
     async fn download_persistent_cache_piece(
+        &self,
+        addr: &str,
+        number: u32,
+        host_id: &str,
+        task_id: &str,
+    ) -> Result<(Vec<u8>, u64, String)>;
+
+    /// download_cache_piece downloads a cache piece from the other peer by different protocols.
+    async fn download_cache_piece(
         &self,
         addr: &str,
         number: u32,
@@ -365,6 +376,72 @@ impl Downloader for GRPCDownloader {
 
         let Some(content) = piece.content else {
             error!("persistent cache piece content is missing");
+            return Err(Error::InvalidParameter);
+        };
+
+        // Calculate the digest of the piece metadata and compare it with the expected digest,
+        // it verifies the integrity of the piece metadata.
+        let piece_metadata = metadata::Piece {
+            number,
+            length: piece.length,
+            offset: piece.offset,
+            digest: piece.digest.clone(),
+            ..Default::default()
+        };
+
+        if let Some(expected_digest) = response.digest {
+            let digest = piece_metadata.calculate_digest();
+            if expected_digest != digest {
+                return Err(Error::DigestMismatch(
+                    expected_digest.to_string(),
+                    digest.to_string(),
+                ));
+            }
+        }
+
+        Ok((content, piece.offset, piece.digest))
+    }
+
+    /// download_cache_piece downloads a cache piece from the other peer by the gRPC protocol.
+    #[instrument(skip_all)]
+    async fn download_cache_piece(
+        &self,
+        addr: &str,
+        number: u32,
+        host_id: &str,
+        task_id: &str,
+    ) -> Result<(Vec<u8>, u64, String)> {
+        let entry = self.client_entry(addr).await?;
+        let request_guard = RequestGuard::new(entry.active_requests.clone());
+        let response = match entry
+            .client
+            .download_cache_piece(
+                DownloadCachePieceRequest {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    piece_number: number,
+                },
+                self.config.download.piece_timeout,
+            )
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                // If the request fails, it will drop the request guard and remove the client
+                // entry to avoid using the invalid client.
+                drop(request_guard);
+                self.remove_client_entry(addr).await;
+                return Err(err);
+            }
+        };
+
+        let Some(piece) = response.piece else {
+            error!("resource piece is missing");
+            return Err(Error::InvalidParameter);
+        };
+
+        let Some(content) = piece.content else {
+            error!("resource piece content is missing");
             return Err(Error::InvalidParameter);
         };
 


### PR DESCRIPTION
## Description
This pull request adds the `CacheTask` task type, completes the adaptation for `CacheTask` during gRPC download and piece processing, and finally adds the `cache` parameter to dfget for creating and managing `CacheTask`.

## Related Issue

### Changes
- Added `--cache` parameter to dfget to create and manage `CacheTask`.
- Added cache task and implemented its download logic. Implemented piece download execution for cache tasks in `piece.rs` and `piece_download.rs`.
- Added handling for cache peer and cache task in `dragonfly-client/grpc/scheduler.rs`.
- Added cache task support to dfdaemon gRPC servers.

## Motivation and Context
To introduce the `CacheTask` task type to avoid disk interactions, thereby increasing response speed.

## Screenshots (if appropriate)
