### PR TITLE
fix(fs): handle unsupported fallocate errors gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "bincode",
  "bytes",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.16"
+version = "1.0.17"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.16" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.16" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.16" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.16" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.16" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.16" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.16" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.17" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.17" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.17" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.17" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.17" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.17" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.17" }
 dragonfly-api = "=2.1.62"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -16,6 +16,7 @@
 
 use dragonfly_client_core::Result;
 use tokio::fs;
+use tracing::warn;
 
 /// fallocate allocates the space for the file and fills it with zero, only on Linux.
 #[allow(unused_variables)]
@@ -43,9 +44,9 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
                 Ok(_) => return Ok(()),
                 Err(rustix::io::Errno::INTR) => continue,
                 Err(err)
-                    if err == rustix::io::Errno::NOTSUP || err == rustix::io::Errno::OPNOTSUP =>
+                    if err == rustix::io::Errno::NOTSUP || err == rustix::io::Errno::OPNOTSUPP =>
                 {
-                    log::warn!("fallocate not supported, skipping preallocation");
+                    warn!("fallocate not supported, skipping preallocation");
                     return Ok(());
                 }
                 Err(err) => {

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -42,6 +42,12 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
             match fallocate(fd, flags, offset, length) {
                 Ok(_) => return Ok(()),
                 Err(rustix::io::Errno::INTR) => continue,
+                Err(err)
+                    if err == rustix::io::Errno::NOTSUP || err == rustix::io::Errno::OPNOTSUP =>
+                {
+                    log::warn!("fallocate not supported, skipping preallocation");
+                    return Ok(());
+                }
                 Err(err) => {
                     return Err(Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes minor updates to the workspace versioning and improves filesystem compatibility in the project.

Version updates:

* Bumped the workspace package version in `Cargo.toml` from `1.0.16` to `1.0.17`, and updated all internal dependencies to use the new version for consistency. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

Filesystem compatibility:

* Updated the `fallocate` function in `dragonfly-client-util/src/fs/mod.rs` to gracefully handle unsupported fallocate operations by logging a warning and skipping preallocation, improving compatibility with filesystems that do not support this feature.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
