### PR TITLE
chore(deps): bump api to v2.1.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.64"
+version = "2.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eaf31d15182476947339d873431a04912be41cb9d75c7f4dada712d2d6d0df"
+checksum = "7044a2572066a5e08d70a01514fb0605ea8b68b6c144f6fabfd1cfdaa822600c"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "bincode",
  "bytes",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.18"
+version = "1.0.19"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,14 +22,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.18" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.18" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.18" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.18" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.18" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.18" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.18" }
-dragonfly-api = "=2.1.64"
+dragonfly-client = { path = "dragonfly-client", version = "1.0.19" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.19" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.19" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.19" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.19" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.19" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.19" }
+dragonfly-api = "=2.1.65"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace and dependency versions in the `Cargo.toml` file to keep the project up to date with the latest releases. The changes ensure that all internal crates and the `dragonfly-api` dependency use the most recent versions, which may include important bug fixes or new features.

Version updates:

* Bumped the workspace package version from `1.0.18` to `1.0.19` in `Cargo.toml`.
* Updated all internal crate dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-util`, `dragonfly-client-init`) from version `1.0.18` to `1.0.19` in `Cargo.toml`.
* Updated the `dragonfly-api` dependency from version `2.1.64` to `2.1.65` in `Cargo.toml`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
