### PR TITLE
feat: remove loging to file in dfget dfcache and dfinit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "bincode",
  "bytes",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.19"
+version = "1.0.20"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.19" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.19" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.19" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.19" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.19" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.19" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.19" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.20" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.20" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.20" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.20" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.20" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.20" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.20" }
 dragonfly-api = "=2.1.65"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/dfcache.rs
+++ b/dragonfly-client-config/src/dfcache.rs
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-use std::path::PathBuf;
-
 /// NAME is the name of dfcache.
 pub const NAME: &str = "dfcache";
 
 // DEFAULT_OUTPUT_FILE_MODE defines the default file mode for output files when downloading with dfcache
 // using the `--transfer-from-dfdaemon=true` option.
 pub const DEFAULT_OUTPUT_FILE_MODE: u32 = 0o644;
-
-/// default_dfcache_log_dir is the default log directory for dfcache.
-#[inline]
-pub fn default_dfcache_log_dir() -> PathBuf {
-    crate::default_log_dir().join(NAME)
-}
 
 /// default_dfcache_persistent_replica_count is the default replica count of the persistent cache task.
 #[inline]

--- a/dragonfly-client-config/src/dfget.rs
+++ b/dragonfly-client-config/src/dfget.rs
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-use std::path::PathBuf;
-
 /// NAME is the name of dfget.
 pub const NAME: &str = "dfget";
 
 // DEFAULT_OUTPUT_FILE_MODE defines the default file mode for output files when downloading with dfget
 // using the `--transfer-from-dfdaemon=true` option.
 pub const DEFAULT_OUTPUT_FILE_MODE: u32 = 0o644;
-
-/// default_dfget_log_dir is the default log directory for dfget.
-pub fn default_dfget_log_dir() -> PathBuf {
-    crate::default_log_dir().join(NAME)
-}

--- a/dragonfly-client-config/src/dfinit.rs
+++ b/dragonfly-client-config/src/dfinit.rs
@@ -33,11 +33,6 @@ pub fn default_dfinit_config_path() -> PathBuf {
     crate::default_config_dir().join("dfinit.yaml")
 }
 
-/// default_dfinit_log_dir is the default log directory for dfinit.
-pub fn default_dfinit_log_dir() -> PathBuf {
-    crate::default_log_dir().join(NAME)
-}
-
 /// default_container_runtime_containerd_config_path is the default containerd configuration path.
 #[inline]
 fn default_container_runtime_containerd_config_path() -> PathBuf {
@@ -358,12 +353,6 @@ mod tests {
     fn test_default_dfinit_config_path() {
         let expected = crate::default_config_dir().join("dfinit.yaml");
         assert_eq!(default_dfinit_config_path(), expected);
-    }
-
-    #[test]
-    fn test_default_dfinit_log_dir() {
-        let expected = crate::default_log_dir().join(NAME);
-        assert_eq!(default_dfinit_log_dir(), expected);
     }
 
     #[test]

--- a/dragonfly-client-init/src/bin/main.rs
+++ b/dragonfly-client-init/src/bin/main.rs
@@ -15,7 +15,7 @@
  */
 
 use clap::Parser;
-use dragonfly_client::tracing::init_tracing;
+use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_config::dfinit;
 use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_init::container_runtime;
@@ -50,20 +50,6 @@ struct Args {
     )]
     log_level: Level,
 
-    #[arg(
-        long,
-        default_value_os_t = dfinit::default_dfinit_log_dir(),
-        help = "Specify the log directory"
-    )]
-    log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 24,
-        help = "Specify the max number of log files"
-    )]
-    log_max_files: usize,
-
     #[arg(long, default_value_t = false, help = "Specify whether to print log")]
     console: bool,
 
@@ -84,19 +70,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let args = Args::parse();
 
     // Initialize tracing.
-    let _guards = init_tracing(
-        dfinit::NAME,
-        args.log_dir,
-        args.log_level,
-        args.log_max_files,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        args.console,
-    );
+    let _guards = init_command_tracing(args.log_level, args.console);
 
     // Load config.
     let config = dfinit::Config::load(&args.config).inspect_err(|err| {

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -109,20 +109,6 @@ pub struct ExportCommand {
     )]
     log_level: Level,
 
-    #[arg(
-        long,
-        default_value_os_t = dfcache::default_dfcache_log_dir(),
-        help = "Specify the log directory"
-    )]
-    log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    log_max_files: usize,
-
     #[arg(long, default_value_t = false, help = "Specify whether to print log")]
     console: bool,
 }
@@ -141,19 +127,7 @@ impl ExportCommand {
         Args::parse();
 
         // Initialize tracing.
-        let _guards = init_tracing(
-            dfcache::NAME,
-            self.log_dir.clone(),
-            self.log_level,
-            self.log_max_files,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            self.console,
-        );
+        let _guards = init_command_tracing(self.log_level, self.console);
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -108,20 +108,6 @@ pub struct ImportCommand {
     )]
     log_level: Level,
 
-    #[arg(
-        long,
-        default_value_os_t = dfcache::default_dfcache_log_dir(),
-        help = "Specify the log directory"
-    )]
-    log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    log_max_files: usize,
-
     #[arg(long, default_value_t = false, help = "Specify whether to print log")]
     console: bool,
 }
@@ -140,19 +126,7 @@ impl ImportCommand {
         Args::parse();
 
         // Initialize tracing.
-        let _guards = init_tracing(
-            dfcache::NAME,
-            self.log_dir.clone(),
-            self.log_level,
-            self.log_max_files,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            self.console,
-        );
+        let _guards = init_command_tracing(self.log_level, self.console);
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {

--- a/dragonfly-client/src/bin/dfcache/main.rs
+++ b/dragonfly-client/src/bin/dfcache/main.rs
@@ -17,7 +17,7 @@
 use clap::{Parser, Subcommand};
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
 use dragonfly_client::grpc::health::HealthClient;
-use dragonfly_client::tracing::init_tracing;
+use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{dfcache, dfdaemon};
 use dragonfly_client_core::Result;

--- a/dragonfly-client/src/bin/dfcache/stat.rs
+++ b/dragonfly-client/src/bin/dfcache/stat.rs
@@ -55,20 +55,6 @@ pub struct StatCommand {
     )]
     log_level: Level,
 
-    #[arg(
-        long,
-        default_value_os_t = dfcache::default_dfcache_log_dir(),
-        help = "Specify the log directory"
-    )]
-    log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    log_max_files: usize,
-
     #[arg(long, default_value_t = false, help = "Specify whether to print log")]
     console: bool,
 }
@@ -87,19 +73,7 @@ impl StatCommand {
         Args::parse();
 
         // Initialize tracing.
-        let _guards = init_tracing(
-            dfcache::NAME,
-            self.log_dir.clone(),
-            self.log_level,
-            self.log_max_files,
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-            self.console,
-        );
+        let _guards = init_command_tracing(self.log_level, self.console);
 
         // Get dfdaemon download client.
         let dfdaemon_download_client =

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -24,7 +24,7 @@ use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
 use dragonfly_client::grpc::health::HealthClient;
 use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
-use dragonfly_client::tracing::init_tracing;
+use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_backend::{hdfs, object_storage, BackendFactory, DirEntry};
 use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{self, dfdaemon, dfget};
@@ -277,20 +277,6 @@ struct Args {
     )]
     log_level: Level,
 
-    #[arg(
-        long,
-        default_value_os_t = dfget::default_dfget_log_dir(),
-        help = "Specify the log directory"
-    )]
-    log_dir: PathBuf,
-
-    #[arg(
-        long,
-        default_value_t = 6,
-        help = "Specify the max number of log files"
-    )]
-    log_max_files: usize,
-
     #[arg(long, default_value_t = false, help = "Specify whether to print log")]
     console: bool,
 
@@ -311,19 +297,7 @@ async fn main() -> anyhow::Result<()> {
     let args = convert_args(Args::parse());
 
     // Initialize tracing.
-    let _guards = init_tracing(
-        dfget::NAME,
-        args.log_dir.clone(),
-        args.log_level,
-        args.log_max_files,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        args.console,
-    );
+    let _guards = init_command_tracing(args.log_level, args.console);
 
     // Validate command line arguments.
     if let Err(err) = validate_args(&args) {

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -220,3 +220,52 @@ pub fn init_tracing(
 
     guards
 }
+
+/// init_command_tracing initializes the tracing system for command line tools.
+#[allow(clippy::too_many_arguments)]
+pub fn init_command_tracing(log_level: Level, console: bool) -> Vec<WorkerGuard> {
+    let mut guards = vec![];
+
+    // Setup stdout layer.
+    let (stdout_writer, stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
+    guards.push(stdout_guard);
+
+    // Initialize stdout layer.
+    let stdout_filter = if console {
+        LevelFilter::DEBUG
+    } else {
+        LevelFilter::OFF
+    };
+    let stdout_logging_layer = Layer::new()
+        .with_writer(stdout_writer)
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(false)
+        .with_thread_names(false)
+        .with_thread_ids(false)
+        .with_timer(ChronoLocal::rfc_3339())
+        .pretty()
+        .with_filter(stdout_filter);
+
+    // Setup env filter for log level.
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::default().add_directive(log_level.into()));
+
+    // Enable console subscriber layer for tracing spawn tasks on `127.0.0.1:6669` when log level is TRACE.
+    let console_subscriber_layer = if log_level == Level::TRACE {
+        Some(console_subscriber::spawn())
+    } else {
+        None
+    };
+
+    let subscriber = Registry::default()
+        .with(env_filter)
+        .with(console_subscriber_layer)
+        .with(stdout_logging_layer);
+    subscriber.init();
+
+    std::panic::set_hook(Box::new(tracing_panic::panic_hook));
+    info!("tracing initialized level: {}", log_level);
+
+    guards
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request primarily updates the project version and dependency versions to `1.0.20` in `Cargo.toml`, and introduces a new tracing initialization function for command line tools. It also removes redundant log directory helper functions from several config files, simplifying the codebase.

Version and dependency updates:

* Bumped the workspace and all internal package versions from `1.0.19` to `1.0.20` in `Cargo.toml` to ensure consistency across the project. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

Tracing improvements:

* Added a new `init_command_tracing` function to `dragonfly-client/src/tracing/mod.rs` for initializing tracing in command line tools, including support for console output and improved log filtering.

Codebase simplification (removal of unused log directory helpers):

* Removed the `default_dfcache_log_dir` function from `dragonfly-client-config/src/dfcache.rs`, as it is no longer needed.
* Removed the `default_dfget_log_dir` function from `dragonfly-client-config/src/dfget.rs`.
* Removed the `default_dfinit_log_dir` function from `dragonfly-client-config/src/dfinit.rs`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
