### PR TITLE
feat: support config_path of io.containerd.cri.v1.images for containerd v2

### DIFF
--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -55,14 +55,13 @@ impl Containerd {
         let mut containerd_config = content
             .parse::<DocumentMut>()
             .or_err(ErrorType::ParseError)?;
-        
-        // Get the containerd version for config_path parsing, default to v2 if not set.
 
+        // Get the containerd version for config_path parsing, default to containerd 1.x if not set.
         // https://github.com/containerd/containerd/blob/main/docs/hosts.md#cri.
         let version = containerd_config
             .get("version")
             .and_then(|v| v.as_integer())
-            .unwrap_or(2); // default v2
+            .unwrap_or(2);
         info!("containerd version: {}", version);
 
         let plugin_key = if version == 3 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support config_path of io.containerd.cri.v1.images when there is no io.containerd.grpc.v1.cri in containerd v2

## Related Issue

https://github.com/dragonflyoss/client/issues/1356

## Motivation and Context

Support dragonfly in containerd v2

## Screenshots (if appropriate)
