### PR TITLE
feat: rename plugin_key to plugin_id in dfinit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "bincode",
  "bytes",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "base64 0.22.1",
  "bytesize",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.20"
+version = "1.0.21"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -22,13 +22,13 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.20" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.20" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.20" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.20" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.20" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.20" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.20" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.21" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.21" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.21" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.21" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.21" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.21" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.21" }
 dragonfly-api = "=2.1.65"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace and dependency versions in `Cargo.toml` and refactors variable naming for clarity in the `containerd.rs` implementation. Additionally, it improves test naming for better context.

Version updates:

* Bumped the workspace package version and all internal dependency versions from `1.0.20` to `1.0.21` in `Cargo.toml` to keep dependencies consistent and up-to-date. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L25-R31)

Code refactoring for clarity:

* Renamed the variable `plugin_key` to `plugin_id` throughout the `Containerd` implementation in `dragonfly-client-init/src/container_runtime/containerd.rs` for improved code readability and consistency. [[1]](diffhunk://#diff-48523f0807331532cfa4f106f6e918689177fe6fe04d78777c913ea667af65a6L67-R77) [[2]](diffhunk://#diff-48523f0807331532cfa4f106f6e918689177fe6fe04d78777c913ea667af65a6L108-R111)

Test improvements:

* Renamed the test function from `test_containerd_config_with_existing_config_path` to `test_containerd_config_with_v2_config_path` to better reflect the purpose of the test in `containerd.rs`.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/client/issues/1356
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
