### PR TITLE
fix(grpc): correct download server IP retrieval

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -787,7 +787,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let task_manager = self.task.clone();
 
         // Get the download server info from the config.
-        let download_ip = self.config.storage.server.ip.unwrap().to_string();
+        let download_ip = self.config.host.ip.unwrap().to_string();
         let download_tcp_port = self.config.storage.server.tcp_port;
         let download_quic_port = self.config.storage.server.quic_port;
 
@@ -1495,7 +1495,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let task_manager = self.task.clone();
 
         // Get the download server info from the config.
-        let download_ip = self.config.storage.server.ip.unwrap().to_string();
+        let download_ip = self.config.host.ip.unwrap().to_string();
         let download_tcp_port = self.config.storage.server.tcp_port;
         let download_quic_port = self.config.storage.server.quic_port;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the logic for determining the download server IP address in the `DfdaemonUploadServerHandler` implementation. The change ensures the IP is consistently sourced from the correct configuration field.

* The download server IP address is now retrieved from `self.config.host.ip` instead of `self.config.storage.server.ip` in the `dragonfly-client/src/grpc/dfdaemon_upload.rs` file. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L790-R790) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1498-R1498)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
