### PR TITLE
feat(export): add overwrite option for output files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.68"
+version = "2.1.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e51cf42713d1fa0e6a25b1a9cc9e7d22c267438067287ce933259e5a05b3565"
+checksum = "6abfaeb9c1215768cc93ca126cc18a2fcc68f795621ebd0437f28c5dfd46437d"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.2
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.23" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.23" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.23" }
-dragonfly-api = "=2.1.68"
+dragonfly-api = "=2.1.70"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -968,7 +968,7 @@ impl Default for Dynconfig {
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct StorageServer {
-    /// ip is the listen ip of the gRPC server.
+    /// ip is the listen ip of the storage server.
     pub ip: Option<IpAddr>,
 
     /// port is the port to the tcp server.

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -141,7 +141,10 @@ impl Storage {
     /// download_task_failed updates the metadata of the task when the task downloads failed.
     #[instrument(skip_all)]
     pub async fn download_task_failed(&self, id: &str) -> Result<metadata::Task> {
-        self.metadata.download_task_failed(id)
+        let metadata = self.metadata.download_task_failed(id)?;
+        self.content.delete_task(id).await?;
+
+        Ok(metadata)
     }
 
     /// prefetch_task_started updates the metadata of the task when the task prefetches started.
@@ -308,7 +311,10 @@ impl Storage {
         &self,
         id: &str,
     ) -> Result<metadata::PersistentCacheTask> {
-        self.metadata.download_persistent_cache_task_failed(id)
+        let metadata = self.metadata.download_persistent_cache_task_failed(id)?;
+        self.content.delete_persistent_cache_task(id).await?;
+
+        Ok(metadata)
     }
 
     /// upload_persistent_cache_task_finished updates the metadata of the cahce task when persistent cache task uploads finished.

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -17,7 +17,7 @@
 use crate::hashring::VNodeHashRing;
 use crate::shutdown;
 use dragonfly_api::common::v2::Host;
-use dragonfly_api::scheduler::v2::scheduler_client::SchedulerClient;
+use dragonfly_api::scheduler::v2::{scheduler_client::SchedulerClient, ListHostsRequest};
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -168,11 +168,8 @@ impl SeedPeerSelector {
     /// list_seed_peers lists the seed peers from scheduler.
     #[instrument(skip_all)]
     async fn list_seed_peers(&self) -> Result<Vec<Host>> {
-        let response = self
-            .scheduler_client
-            .clone()
-            .list_hosts(tonic::Request::new(()))
-            .await?;
+        let request = tonic::Request::new(ListHostsRequest { r#type: None });
+        let response = self.scheduler_client.clone().list_hosts(request).await?;
         let hosts = response.into_inner().hosts;
 
         // Filter for seed peer types, normal peer type is 0 and others are seed peers.

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -51,6 +51,13 @@ pub struct ExportCommand {
     transfer_from_dfdaemon: bool,
 
     #[arg(
+        long = "overwrite",
+        default_value_t = false,
+        help = "Specify whether to overwrite the output file if it already exists. If it is true, dfget will overwrite the output file. If it is false, dfget will return an error if the output file already exists. Cannot be used with `--force-hard-link=true`"
+    )]
+    overwrite: bool,
+
+    #[arg(
         long = "force-hard-link",
         default_value_t = false,
         help = "Specify whether the download file must be hard linked to the output path. If hard link is failed, download will be failed. If it is false, dfdaemon will copy the file to the output path if hard link is failed."
@@ -453,6 +460,7 @@ impl ExportCommand {
                 force_hard_link: self.force_hard_link,
                 digest: self.digest.clone(),
                 remote_ip: Some(local_ip().unwrap().to_string()),
+                overwrite: self.overwrite,
             })
             .await
             .inspect_err(|err| {
@@ -581,7 +589,7 @@ impl ExportCommand {
             }
         }
 
-        if absolute_path.exists() {
+        if !self.overwrite && absolute_path.exists() {
             return Err(Error::ValidationError(format!(
                 "output path {} is already exist",
                 self.output.to_string_lossy()

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -493,6 +493,22 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                                         {
                                             Ok(true) => {}
                                             Ok(false) => {
+                                                if download_clone.overwrite {
+                                                    if let Err(err) = task_manager_clone
+                                                        .copy_task(
+                                                            task_clone.id.as_str(),
+                                                            output_path,
+                                                        )
+                                                        .await
+                                                    {
+                                                        error!("copy task: {}", err);
+                                                        handle_error(&out_stream_tx, err).await;
+                                                        return;
+                                                    };
+
+                                                    return;
+                                                }
+
                                                 error!(
                                                     "output path {} is already exists",
                                                     output_path.display()
@@ -1063,6 +1079,19 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                                     {
                                         Ok(true) => {}
                                         Ok(false) => {
+                                            if request_clone.overwrite {
+                                                if let Err(err) = task_manager_clone
+                                                    .copy_task(task_clone.id.as_str(), output_path)
+                                                    .await
+                                                {
+                                                    error!("copy task: {}", err);
+                                                    handle_error(&out_stream_tx, err).await;
+                                                    return;
+                                                };
+
+                                                return;
+                                            }
+
                                             error!(
                                                 "output path {} is already exists",
                                                 output_path.display()

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -489,6 +489,22 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                                         {
                                             Ok(true) => {}
                                             Ok(false) => {
+                                                if download_clone.overwrite {
+                                                    if let Err(err) = task_manager_clone
+                                                        .copy_task(
+                                                            task_clone.id.as_str(),
+                                                            output_path,
+                                                        )
+                                                        .await
+                                                    {
+                                                        error!("copy task: {}", err);
+                                                        handle_error(&out_stream_tx, err).await;
+                                                        return;
+                                                    };
+
+                                                    return;
+                                                }
+
                                                 error!(
                                                     "output path {} is already exists",
                                                     output_path.display()
@@ -1262,6 +1278,19 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                                     {
                                         Ok(true) => {}
                                         Ok(false) => {
+                                            if request_clone.overwrite {
+                                                if let Err(err) = task_manager_clone
+                                                    .copy_task(task_clone.id.as_str(), output_path)
+                                                    .await
+                                                {
+                                                    error!("copy task: {}", err);
+                                                    handle_error(&out_stream_tx, err).await;
+                                                    return;
+                                                };
+
+                                                return;
+                                            }
+
                                             error!(
                                                 "output path {} is already exists",
                                                 output_path.display()

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1140,6 +1140,7 @@ fn make_download_task_request(
             content_for_calculating_task_id: header::get_content_for_calculating_task_id(&header),
             remote_ip: Some(remote_ip.to_string()),
             concurrent_piece_count: Some(config.download.concurrent_piece_count),
+            overwrite: false,
         }),
     })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several improvements and fixes across the storage, upload/download server handlers, configuration, and dependency management in the Dragonfly client. The most notable changes include enhanced overwrite handling during file operations, improved resource cleanup on task failures, updates to API usage, and a dependency bump for the `dragonfly-api` crate.

**Overwrite handling improvements:**

* Added logic in both `DfdaemonDownloadServerHandler` and `DfdaemonUploadServerHandler` to check for the `overwrite` flag when the output file already exists. If `overwrite` is true, the server attempts to copy the task output to the specified path, handling errors gracefully and avoiding duplicate error messages. This ensures better user experience and correctness when overwriting files. [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR496-R511) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR1082-R1094) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R492-R507) [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1281-R1293)
* Set the `overwrite` field to `false` by default in the download task request construction to clarify default behavior.

**Resource cleanup on task failures:**

* Updated the `Storage` implementation to delete associated content when a download or persistent cache task fails, ensuring no orphaned data remains and improving resource management. [[1]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL144-R147) [[2]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eL311-R317)

**API and dependency updates:**

* Updated the `dragonfly-api` dependency from version `2.1.68` to `2.1.70` in `Cargo.toml` to stay up-to-date with upstream changes.
* Modified the seed peer selector to use the new `ListHostsRequest` struct when listing hosts, aligning with the updated API. [[1]](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL20-R20) [[2]](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL171-R172)

**Documentation and minor improvements:**

* Clarified the documentation comment for the `ip` field in the `StorageServer` struct to specify it is the storage server's listen IP.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
