### PR TITLE
feat: Add QUIC Client and Server Implementation for Piece Download in dragonfly-client-storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,7 @@ dependencies = [
  "reqwest",
  "rocksdb",
  "rustls 0.22.4",
+ "rustls-pki-types",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -375,7 +375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
 ]
@@ -388,9 +388,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "block-buffer"
@@ -518,6 +518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +537,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -641,6 +653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +745,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1129,6 +1161,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "opendal",
+ "quinn",
  "reqwest",
  "reqwest-middleware",
  "thiserror 2.0.16",
@@ -1191,8 +1224,10 @@ dependencies = [
  "leaky-bucket",
  "num_cpus",
  "prost-wkt-types",
+ "quinn",
  "reqwest",
  "rocksdb",
+ "rustls 0.22.4",
  "serde",
  "tempfile",
  "tokio",
@@ -1226,6 +1261,7 @@ dependencies = [
  "openssl",
  "pnet",
  "protobuf 3.7.2",
+ "quinn",
  "rcgen",
  "reqwest",
  "reqwest-middleware",
@@ -1323,6 +1359,18 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
+dependencies = [
+ "getrandom 0.3.1",
+ "libm",
+ "rand 0.9.1",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -1530,8 +1578,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1624,7 +1674,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bfd649ac5e0f82ae98d547450f1d31af49742be255b5380c61fc8513b9df11"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -1952,7 +2002,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2272,7 +2322,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -2348,6 +2398,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,10 +2430,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2434,7 +2507,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -2535,6 +2608,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4-sys"
@@ -2709,7 +2788,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.9.2",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2976,7 +3055,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3566,7 +3645,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -3579,7 +3658,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "hex",
 ]
 
@@ -3841,6 +3920,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.31",
+ "socket2 0.6.0",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "fastbloom",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring 0.17.7",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,7 +4101,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -4256,6 +4392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,7 +4421,7 @@ version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -4292,7 +4434,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -4308,22 +4450,22 @@ dependencies = [
  "log",
  "ring 0.17.7",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.7",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.6",
  "subtle",
  "zeroize",
 ]
@@ -4338,7 +4480,19 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.9.2",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.0",
 ]
 
 [[package]]
@@ -4365,14 +4519,53 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.31",
+ "rustls-native-certs 0.8.1",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.6",
+ "security-framework 3.5.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
 version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring 0.17.7",
  "rustls-pki-types",
@@ -4448,7 +4641,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4456,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4620,6 +4826,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -4811,7 +5023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -5098,7 +5310,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5686,23 +5898,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -5723,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5733,9 +5947,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5746,9 +5960,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -5796,6 +6013,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5932,6 +6158,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5964,6 +6199,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6015,6 +6265,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6033,6 +6289,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6048,6 +6310,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6081,6 +6349,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6096,6 +6370,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6117,6 +6397,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6132,6 +6418,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6210,7 +6502,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,6 @@ dependencies = [
  "openssl",
  "pnet",
  "protobuf 3.7.2",
- "quinn",
  "rcgen",
  "reqwest",
  "reqwest-middleware",

--- a/dragonfly-client-core/Cargo.toml
+++ b/dragonfly-client-core/Cargo.toml
@@ -23,3 +23,4 @@ opendal.workspace = true
 url.workspace = true
 headers.workspace = true
 vortex-protocol.workspace = true
+quinn = "0.11.9"

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -250,6 +250,38 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for DFError {
     }
 }
 
+// --- Conversions for quinn (QUIC) errors ---
+// These allow using the ? operator directly with quinn APIs without repetitive map_err.
+impl From<quinn::ConnectError> for DFError {
+    fn from(err: quinn::ConnectError) -> Self {
+        DFError::Unknown(format!("quinn connect error: {}", err))
+    }
+}
+
+impl From<quinn::ConnectionError> for DFError {
+    fn from(err: quinn::ConnectionError) -> Self {
+        DFError::Unknown(format!("quinn connection error: {}", err))
+    }
+}
+
+impl From<quinn::WriteError> for DFError {
+    fn from(err: quinn::WriteError) -> Self {
+        DFError::Unknown(format!("quinn write error: {}", err))
+    }
+}
+
+impl From<quinn::ReadError> for DFError {
+    fn from(err: quinn::ReadError) -> Self {
+        DFError::Unknown(format!("quinn read error: {}", err))
+    }
+}
+
+impl From<quinn::ReadExactError> for DFError {
+    fn from(err: quinn::ReadExactError) -> Self {
+        DFError::Unknown(format!("quinn read exact error: {}", err))
+    }
+}
+
 /// SendTimeoutError is the error for send timeout.
 impl<T> From<tokio::sync::mpsc::error::SendTimeoutError<T>> for DFError {
     fn from(err: tokio::sync::mpsc::error::SendTimeoutError<T>) -> Self {

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -29,9 +29,11 @@ bytes.workspace = true
 bytesize.workspace = true
 leaky-bucket.workspace = true
 vortex-protocol.workspace = true
+rustls.workspace = true
 num_cpus = "1.17"
 bincode = "1.3.3"
 walkdir = "2.5.0"
+quinn = "0.11.9"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -18,6 +18,7 @@ dragonfly-api.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 rocksdb.workspace = true
+rustls-pki-types.workspace = true
 serde.workspace = true
 tracing.workspace = true
 prost-wkt-types.workspace = true

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -15,3 +15,4 @@
  */
 
 pub mod tcp;
+pub mod quic;

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-pub mod tcp;
 pub mod quic;
+pub mod tcp;

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -1,0 +1,288 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use bytes::{Bytes, BytesMut};
+use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_core::{Error as ClientError, Result as ClientResult};
+use dragonfly_client_util::tls::SkipServerVerification;
+use quinn::crypto::rustls::QuicClientConfig;
+use quinn::{ClientConfig, Endpoint, RecvStream, SendStream};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use tokio::io::AsyncRead; 
+use tokio::time;
+use tracing::{error, instrument};
+use vortex_protocol::{
+    tlv::{
+        download_persistent_cache_piece::DownloadPersistentCachePiece,
+        download_piece::DownloadPiece, error::Error as VortexError, persistent_cache_piece_content,
+        piece_content, Tag,
+    },
+    Header, Vortex, HEADER_SIZE,
+};
+
+/// QUICClient is a QUIC-based client for quic storage service.
+#[derive(Clone)]
+pub struct QUICClient {
+    /// config is the configuration of the dfdaemon.
+    config: Arc<Config>,
+
+    /// addr is the address of the QUIC server.
+    addr: String,
+}
+
+/// QUICClient implements the QUIC-based client for quic storage service.
+impl QUICClient {
+    /// Creates a new QUICClient instance.
+    pub fn new(config: Arc<Config>, addr: String) -> Self {
+        Self { config, addr }
+    }
+
+    /// Downloads a piece from the server using the vortex protocol.
+    ///
+    /// This is the main entry point for downloading a piece. It applies
+    /// a timeout based on the configuration and handles connection timeouts gracefully.
+    #[instrument(skip_all)]
+    pub async fn download_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<(impl AsyncRead, u64, String)> {
+        time::timeout(
+            self.config.download.piece_timeout,
+            self.handle_download_piece(number, task_id),
+        )
+        .await
+        .inspect_err(|err| {
+            error!("connect timeout to {}: {}", self.addr, err);
+        })?
+    }
+    /// Internal handler for downloading a piece.
+    ///
+    /// This method performs the actual protocol communication:
+    /// 1. Creates a download piece request.
+    /// 2. Establishes QUIC connection and sends the request.
+    /// 3. Reads and validates the response header.
+    /// 4. Processes the piece content based on the response type.
+    #[instrument(skip_all)]
+    async fn handle_download_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<(impl AsyncRead, u64, String)> {
+        let request: Bytes = Vortex::DownloadPiece(
+            Header::new_download_piece(),
+            DownloadPiece::new(task_id.to_string(), number),
+        )
+        .into();
+
+        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
+        let header = self.read_header(&mut reader).await?;
+        match header.tag() {
+            Tag::PieceContent => {
+                let piece_content: piece_content::PieceContent = self
+                    .read_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
+                    .await?;
+
+                let metadata = piece_content.metadata();
+                Ok((reader, metadata.offset, metadata.digest))
+            }
+            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            _ => Err(ClientError::Unknown(format!(
+                "unexpected tag: {:?}",
+                header.tag()
+            ))),
+        }
+    }
+
+    /// Downloads a persistent cache piece from the server using the vortex protocol.
+    ///
+    /// Similar to `download_piece` but specifically for persistent cache piece.
+    #[instrument(skip_all)]
+    pub async fn download_persistent_cache_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<(impl AsyncRead, u64, String)> {
+        time::timeout(
+            self.config.download.piece_timeout,
+            self.handle_download_persistent_cache_piece(number, task_id),
+        )
+        .await
+        .inspect_err(|err| {
+            error!("connect timeout to {}: {}", self.addr, err);
+        })?
+    }
+
+    /// Internal handler for downloading a persistent cache piece.
+    ///
+    /// Implements the same protocol flow as `handle_download_piece` but uses
+    /// persistent cache specific request/response types.
+    #[instrument(skip_all)]
+    async fn handle_download_persistent_cache_piece(
+        &self,
+        number: u32,
+        task_id: &str,
+    ) -> ClientResult<(impl AsyncRead, u64, String)> {
+        let request: Bytes = Vortex::DownloadPersistentCachePiece(
+            Header::new_download_persistent_cache_piece(),
+            DownloadPersistentCachePiece::new(task_id.to_string(), number),
+        )
+        .into();
+
+        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
+        let header = self.read_header(&mut reader).await?;
+        match header.tag() {
+            Tag::PersistentCachePieceContent => {
+                let persistent_cache_piece_content: persistent_cache_piece_content::PersistentCachePieceContent =
+                self.read_piece_content(&mut reader, persistent_cache_piece_content::METADATA_LENGTH_SIZE)
+                .await?;
+
+                let metadata = persistent_cache_piece_content.metadata();
+                Ok((reader, metadata.offset, metadata.digest))
+            }
+            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            _ => Err(ClientError::Unknown(format!(
+                "unexpected tag: {:?}",
+                header.tag()
+            ))),
+        }
+    }
+
+    /// Establishes QUIC connection and writes a vortex protocol request.
+    ///
+    /// This is a low-level utility function that handles the QUIC connection
+    /// lifecycle and request transmission. It ensures proper error handling
+    /// and connection cleanup.
+    #[instrument(skip_all)]
+    async fn connect_and_write_request(
+        &self,
+        request: Bytes,
+    ) -> ClientResult<(RecvStream, SendStream)> {
+        let crypto = quinn::rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(SkipServerVerification::new())
+            .with_no_client_auth();
+
+        let client_config = ClientConfig::new(Arc::new(
+            QuicClientConfig::try_from(crypto)
+                .map_err(|err| ClientError::Unknown(format!("failed to create quic client config: {}", err)))?,
+        ));
+
+        let endpoint = {
+            let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+            let mut endpoint = Endpoint::client(bind_addr)?;
+            endpoint.set_default_client_config(client_config);
+            endpoint
+        };
+
+        let remote_addr: SocketAddr = self.addr.parse().unwrap();
+        let connection = endpoint
+            .connect(remote_addr, "quic")?
+            .await
+            .inspect_err(|err| error!("failed to connect to {}: {}", self.addr, err))?;
+
+        let (mut writer, reader) = connection
+            .open_bi()
+            .await
+            .inspect_err(|err| error!("failed to open bi stream: {}", err))?;
+
+        writer
+            .write_all(&request)
+            .await
+            .inspect_err(|err| error!("failed to send request: {}", err))?;
+
+        Ok((reader, writer))
+    }
+
+    /// Reads and parses a vortex protocol header from the QUIC stream.
+    ///
+    /// The header contains metadata about the following message, including
+    /// the message type (tag) and payload length. This is critical for
+    /// proper protocol message framing.
+    #[instrument(skip_all)]
+    async fn read_header(&self, reader: &mut RecvStream) -> ClientResult<Header> {
+        let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
+        header_bytes.resize(HEADER_SIZE, 0);
+        reader
+            .read_exact(&mut header_bytes)
+            .await
+            .inspect_err(|err| error!("failed to receive header: {}", err))?;
+        
+        Header::try_from(header_bytes.freeze()).map_err(Into::into)
+    }
+
+    /// Reads and parses piece content with variable-length metadata.
+    ///
+    /// This generic function handles the two-stage reading process for
+    /// piece content: first reading the metadata length, then reading
+    /// the actual metadata, and finally constructing the complete message.
+    #[instrument(skip_all)]
+    async fn read_piece_content<T>(
+        &self,
+        reader: &mut RecvStream,
+        metadata_length_size: usize,
+    ) -> ClientResult<T>
+    where
+        T: TryFrom<Bytes, Error: Into<ClientError>>,
+    {
+        let mut metadata_length_bytes = BytesMut::with_capacity(metadata_length_size);
+        metadata_length_bytes.resize(metadata_length_size, 0);
+        reader
+            .read_exact(&mut metadata_length_bytes)
+            .await
+            .inspect_err(|err| error!("failed to receive metadata length: {}", err))?;
+        let metadata_length = u32::from_be_bytes(metadata_length_bytes[..].try_into()?) as usize;
+
+        let mut metadata_bytes = BytesMut::with_capacity(metadata_length);
+        metadata_bytes.resize(metadata_length, 0);
+        reader
+            .read_exact(&mut metadata_bytes)
+            .await
+            .inspect_err(|err| error!("failed to receive metadata: {}", err))?;
+
+        let mut content_bytes = BytesMut::with_capacity(metadata_length_size + metadata_length);
+        content_bytes.extend_from_slice(&metadata_length_bytes);
+        content_bytes.extend_from_slice(&metadata_bytes);
+        content_bytes.freeze().try_into().map_err(Into::into)
+    }
+
+    /// Reads and processes error responses from the server.
+    ///
+    /// When the server responds with an error tag, this function reads
+    /// the error payload and converts it into an appropriate client error.
+    /// This provides structured error handling for protocol-level failures.
+    #[instrument(skip_all)]
+    async fn read_error(&self, reader: &mut RecvStream, header_length: usize) -> ClientError {
+        let mut error_bytes = BytesMut::with_capacity(header_length);
+        error_bytes.resize(header_length, 0);
+        if let Err(err) = reader.read_exact(&mut error_bytes).await {
+            error!("failed to receive error: {}", err);
+            return ClientError::Unknown(err.to_string());
+        };
+
+        error_bytes
+            .freeze()
+            .try_into()
+            .map(|error: VortexError| {
+                ClientError::VortexProtocolStatus(error.code(), error.message().to_string())
+            })
+            .unwrap_or_else(|err| {
+                error!("failed to extract error: {}", err);
+                ClientError::Unknown(format!("failed to extract error: {}", err))
+            })
+    }
+}

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -15,3 +15,4 @@
  */
 
 pub mod tcp;
+pub mod quic;

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-pub mod tcp;
 pub mod quic;
+pub mod tcp;

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -1,0 +1,526 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::Storage;
+use bytes::{Bytes, BytesMut};
+use dragonfly_api::common::v2::TrafficType;
+use dragonfly_client_core::{Error as ClientError, Result as ClientResult};
+use dragonfly_client_metric::{
+    collect_upload_piece_failure_metrics, collect_upload_piece_started_metrics,
+};
+use dragonfly_client_util::{id_generator::IDGenerator, tls::generate_simple_self_signed_certs, shutdown};
+use leaky_bucket::RateLimiter;
+use quinn::{Endpoint, ServerConfig};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::io::{copy, AsyncRead};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, instrument, Span};
+use vortex_protocol::{
+    tlv::{
+        download_persistent_cache_piece::DownloadPersistentCachePiece,
+        download_piece::DownloadPiece,
+        error::{Code, Error},
+        persistent_cache_piece_content::PersistentCachePieceContent,
+        piece_content::PieceContent,
+        Tag,
+    },
+    Header, Vortex, HEADER_SIZE,
+};
+
+/// QUICServer is a QUIC-based server for dfdaemon upload service.
+pub struct QUICServer {
+    /// addr is the address of the QUIC server.
+    addr: SocketAddr,
+
+    /// handler is the request handler.
+    handler: QUICServerHandler,
+
+    /// shutdown is used to shutdown the QUIC server.
+    shutdown: shutdown::Shutdown,
+
+    /// _shutdown_complete is used to notify the QUIC server is shutdown.
+    _shutdown_complete: mpsc::UnboundedSender<()>,
+}
+
+/// QUICServer implements the QUIC server.
+impl QUICServer {
+    /// Creates a new QUICServer.
+    pub fn new(
+        addr: SocketAddr,
+        id_generator: Arc<IDGenerator>,
+        storage: Arc<Storage>,
+        upload_rate_limiter: Arc<RateLimiter>,
+        shutdown: shutdown::Shutdown,
+        shutdown_complete_tx: mpsc::UnboundedSender<()>,
+    ) -> Self {
+        Self {
+            addr,
+            handler: QUICServerHandler {
+                id_generator,
+                storage,
+                upload_rate_limiter,
+            },
+            shutdown,
+            _shutdown_complete: shutdown_complete_tx,
+        }
+    }
+
+        /// Starts the storage quic server.
+    pub async fn run(&mut self) -> ClientResult<()> {
+        // Configure TLS for the QUIC server.
+        let (certs, key) = generate_simple_self_signed_certs("quic", vec!["quic".into()])?;
+        let server_config = ServerConfig::with_single_cert(certs, key)
+            .map_err(|err| ClientError::Unknown(format!("failed to create server config: {}", err)))?;
+        // Create a QUIC endpoint and bind it.
+        let endpoint = Endpoint::server(server_config, self.addr)?;
+        info!("storage quic server listening on {}", self.addr);
+
+        loop {
+            tokio::select! {
+                Some(conn) = endpoint.accept() => {
+                    debug!("QUIC connection incoming");
+                    let handler = self.handler.clone();
+                    tokio::spawn(async move {
+                       if let Err(err) = handler.handle(conn).await {
+                            error!("failed to handle connection: {}", err);
+                        }
+                    });
+                },
+                _ = self.shutdown.recv() => {
+                    info!("quic server shutting down");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// QUICServerHandler handles QUIC connections and requests.
+#[derive(Clone)]
+pub struct QUICServerHandler {
+    /// id_generator is the id generator.
+    id_generator: Arc<IDGenerator>,
+
+    /// storage is the local storage.
+    storage: Arc<Storage>,
+
+    /// upload_rate_limiter is the rate limiter of the upload speed in bps(bytes per second).
+    upload_rate_limiter: Arc<RateLimiter>,
+}
+
+/// QUICServerHandler implements the request handler.
+impl QUICServerHandler {
+    /// handle handles a single QUIC connection.
+    #[instrument(skip_all)]
+    async fn handle(&self, conn: quinn::Incoming) -> ClientResult<()> {
+    let connection = conn.await?;
+        let remote_address = connection.remote_address().to_string();
+        debug!("accepted connection from {}", remote_address);
+
+        // A QUIC connection can have multiple streams.
+        loop {
+            match connection.accept_bi().await {
+                Ok((send, recv)) => {
+                    info!("new bidirectional stream accepted");
+                    let handler = self.clone();
+                    let remote_address = remote_address.clone();
+                    tokio::spawn(async move {
+                        if let Err(err) = handler.handle_stream(recv, send, remote_address).await {
+                            error!("failed to handle stream: {}", err);
+                        }
+                    });
+                }
+                Err(err) => {
+                    // Downgrade common close cases to debug to reduce noisy logs.
+                    match err {
+                        quinn::ConnectionError::ApplicationClosed(_) => {
+                            debug!("peer closed connection (application closed): {}", err);
+                        }
+                        quinn::ConnectionError::LocallyClosed => {
+                            debug!("connection closed locally: {}", err);
+                        }
+                        _ => {
+                            error!("failed to accept bidirectional stream: {}", err);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles a single QUIC stream for the Dragonfly P2P protocol.
+    ///
+    /// This is the main entry point for processing incoming QUIC streams.
+    /// It reads the protocol header to determine the request type and dispatches
+    /// to the appropriate handler. Supports both regular piece downloads and
+    /// persistent cache piece downloads with proper request/response framing.
+    #[instrument(skip_all, fields(host_id, remote_address, task_id, piece_id))]
+    async fn handle_stream(
+        &self,
+        mut reader: quinn::RecvStream,
+        mut writer: quinn::SendStream,
+        remote_address: String,
+    ) -> ClientResult<()> {
+        let header = self.read_header(&mut reader).await?;
+        match header.tag() {
+            Tag::DownloadPiece => {
+                let download_piece: DownloadPiece = self
+                    .read_download_piece(&mut reader, header.length() as usize)
+                    .await?;
+
+                // Generate the host id.
+                let host_id = self.id_generator.host_id();
+
+                // Get the task id from the request.
+                let task_id = download_piece.task_id();
+
+                // Get the interested piece number from the request.
+                let piece_number = download_piece.piece_number();
+
+                // Generate the piece id.
+                let piece_id = self.storage.piece_id(task_id, piece_number);
+
+                Span::current().record("host_id", host_id);
+                Span::current().record("remote_address", remote_address.as_str());
+                Span::current().record("task_id", task_id);
+                Span::current().record("piece_id", piece_id.as_str());
+
+                // Collect upload piece started metrics.
+                collect_upload_piece_started_metrics();
+                info!("start upload piece content");
+
+                match self.handle_piece(piece_id.as_str(), task_id).await {
+                    Ok((piece_content, mut content_reader)) => {
+                        let piece_content_bytes: Bytes = piece_content.into();
+
+                        let header = Header::new_piece_content(piece_content_bytes.len() as u32);
+                        let header_bytes: Bytes = header.into();
+
+                        let mut response =
+                            BytesMut::with_capacity(HEADER_SIZE + piece_content_bytes.len());
+                        response.extend_from_slice(&header_bytes);
+                        response.extend_from_slice(&piece_content_bytes);
+
+                        self.write_response(response.freeze(), &mut writer).await?;
+                        self.write_stream(&mut content_reader, &mut writer).await?;
+                        // Gracefully finish the stream so the client sees EOF.
+                        if let Err(err) = writer.finish() {
+                            error!("failed to finish stream: {}", err);
+                        }
+                    }
+                    Err(err) => {
+                        // Collect upload piece failure metrics.
+                        collect_upload_piece_failure_metrics();
+
+                        let error_response: Bytes =
+                            Vortex::Error(Header::new_error(err.len() as u32), err).into();
+                        self.write_response(error_response, &mut writer).await?;
+                        if let Err(err) = writer.finish() {
+                            error!("failed to finish stream after error: {}", err);
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            Tag::DownloadPersistentCachePiece => {
+                let download_persistent_cache_piece: DownloadPersistentCachePiece = self
+                    .read_download_piece(&mut reader, header.length() as usize)
+                    .await?;
+
+                // Generate the host id.
+                let host_id = self.id_generator.host_id();
+
+                // Get the task id from the request.
+                let task_id = download_persistent_cache_piece.task_id();
+
+                // Get the interested piece number from the request.
+                let piece_number = download_persistent_cache_piece.piece_number();
+
+                // Generate the piece id.
+                let piece_id = self.storage.piece_id(task_id, piece_number);
+
+                Span::current().record("host_id", host_id);
+                Span::current().record("remote_address", remote_address.as_str());
+                Span::current().record("task_id", task_id);
+                Span::current().record("piece_id", piece_id.as_str());
+
+                // Collect upload piece started metrics.
+                collect_upload_piece_started_metrics();
+                info!("start upload persistent cache piece content");
+
+                match self
+                    .handle_persistent_cache_piece(piece_id.as_str(), task_id)
+                    .await
+                {
+                    Ok((persistent_cache_piece_content, mut content_reader)) => {
+                        let persistent_cache_piece_content_bytes: Bytes =
+                            persistent_cache_piece_content.into();
+
+                        let header = Header::new_persistent_cache_piece_content(
+                            persistent_cache_piece_content_bytes.len() as u32,
+                        );
+                        let header_bytes: Bytes = header.into();
+
+                        let mut response = BytesMut::with_capacity(
+                            HEADER_SIZE + persistent_cache_piece_content_bytes.len(),
+                        );
+                        response.extend_from_slice(&header_bytes);
+                        response.extend_from_slice(&persistent_cache_piece_content_bytes);
+
+                        self.write_response(response.freeze(), &mut writer).await?;
+                        self.write_stream(&mut content_reader, &mut writer).await?;
+                        if let Err(err) = writer.finish() {
+                            error!("failed to finish stream: {}", err);
+                        }
+                    }
+                    Err(err) => {
+                        // Collect upload piece failure metrics.
+                        collect_upload_piece_failure_metrics();
+
+                        let error_response: Bytes =
+                            Vortex::Error(Header::new_error(err.len() as u32), err).into();
+                        self.write_response(error_response, &mut writer).await?;
+                        if let Err(err) = writer.finish() {
+                            error!("failed to finish stream after error: {}", err);
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            _ => Err(ClientError::Unsupported(format!(
+                "unsupported tag: {:?}",
+                header.tag()
+            ))),
+        }
+    }
+
+    /// Handles download piece request and retrieves piece content.
+    ///
+    /// This function fetches piece metadata from local storage, applies
+    /// upload rate limiting, and prepares both the piece metadata and
+    /// content stream for transmission. It's the core handler for regular
+    /// piece download requests in the P2P network.
+    #[instrument(skip_all)]
+    async fn handle_piece(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+    ) -> Result<(PieceContent, impl AsyncRead), Error> {
+        // Get the piece metadata from the local storage.
+        let piece = match self.storage.get_piece(piece_id) {
+            Ok(Some(piece)) => piece,
+            Ok(None) => {
+                error!("piece {} not found in local storage", piece_id);
+                return Err(Error::new(
+                    Code::NotFound,
+                    format!("piece {} not found", piece_id),
+                ));
+            }
+            Err(err) => {
+                error!("get piece {} from local storage error: {:?}", piece_id, err);
+                return Err(Error::new(
+                    Code::Internal,
+                    format!("failed to get piece: {}", err),
+                ));
+            }
+        };
+
+        // Acquire the upload rate limiter.
+        self.upload_rate_limiter
+            .acquire(piece.length as usize)
+            .await;
+
+        // Upload the piece content.
+        let reader = self
+            .storage
+            .upload_piece(piece_id, task_id, None)
+            .await
+            .map_err(|err| {
+                error!("failed to get piece content: {}", err);
+                Error::new(
+                    Code::Internal,
+                    format!("failed to get piece {} content: {}", piece_id, err),
+                )
+            })?;
+
+        Ok((
+            PieceContent::new(
+                piece.number,
+                piece.offset,
+                piece.length,
+                piece.digest.clone(),
+                piece.parent_id.clone().unwrap_or_default(),
+                TrafficType::RemotePeer as u8,
+                piece.cost().unwrap_or_default(),
+                piece.created_at,
+            ),
+            reader,
+        ))
+    }
+
+    /// Handles download persistent cache piece request and retrieves content.
+    ///
+    /// Similar to handle_piece but specifically for persistent cache pieces
+    /// which have different storage semantics and metadata structure. This
+    /// enables efficient serving of frequently accessed content from the
+    /// persistent cache layer.
+    #[instrument(skip_all)]
+    async fn handle_persistent_cache_piece(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+    ) -> Result<(PersistentCachePieceContent, impl AsyncRead), Error> {
+        // Get the piece metadata from the local storage.
+        let piece = match self.storage.get_persistent_cache_piece(piece_id) {
+            Ok(Some(piece)) => piece,
+            Ok(None) => {
+                error!("piece {} not found in local storage", piece_id);
+                return Err(Error::new(
+                    Code::NotFound,
+                    format!("piece {} not found", piece_id),
+                ));
+            }
+            Err(err) => {
+                error!("get piece {} from local storage error: {:?}", piece_id, err);
+                return Err(Error::new(
+                    Code::Internal,
+                    format!("failed to get piece: {}", err),
+                ));
+            }
+        };
+
+        // Acquire the upload rate limiter.
+        self.upload_rate_limiter
+            .acquire(piece.length as usize)
+            .await;
+
+        // Upload the piece content.
+        let reader = self
+            .storage
+            .upload_persistent_cache_piece(piece_id, task_id, None)
+            .await
+            .map_err(|err| {
+                error!("failed to get piece content: {}", err);
+                Error::new(
+                    Code::Internal,
+                    format!("failed to get piece {} content: {}", piece_id, err),
+                )
+            })?;
+
+        Ok((
+            PersistentCachePieceContent::new(
+                piece.number,
+                piece.offset,
+                piece.length,
+                piece.digest.clone(),
+                piece.parent_id.clone().unwrap_or_default(),
+                TrafficType::RemotePeer as u8,
+                piece.cost().unwrap_or_default(),
+                piece.created_at,
+            ),
+            reader,
+        ))
+    }
+
+    /// Reads and parses a vortex protocol header from the QUIC stream.
+    ///
+    /// The header contains metadata about the following message, including
+    /// the message type (tag) and payload length. This is critical for
+    /// proper protocol message framing.
+    async fn read_header(&self, reader: &mut quinn::RecvStream) -> ClientResult<Header> {
+        let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
+        header_bytes.resize(HEADER_SIZE, 0);
+        reader
+            .read_exact(&mut header_bytes)
+            .await
+            .inspect_err(|err| error!("failed to receive header: {}", err))?;
+
+        Header::try_from(header_bytes.freeze()).map_err(Into::into)
+    }
+
+    /// Reads and parses a download piece message from the QUIC stream.
+    ///
+    /// This function reads a fixed-length payload based on the header length
+    /// and attempts to parse it into the specified type T. The type T must
+    /// implement TryFrom<Bytes> for deserialization from the raw bytes.
+    pub async fn read_download_piece<T>(
+        &self,
+        reader: &mut quinn::RecvStream,
+        header_length: usize,
+    ) -> ClientResult<T>
+    where
+        T: TryFrom<Bytes, Error: Into<ClientError>>,
+    {
+        let mut download_piece_bytes = BytesMut::with_capacity(header_length);
+        download_piece_bytes.resize(header_length, 0);
+
+        reader
+            .read_exact(&mut download_piece_bytes)
+            .await
+            .inspect_err(|err| {
+                error!("failed to receive download piece: {}", err)
+    })?;
+
+        download_piece_bytes.freeze().try_into().map_err(Into::into)
+    }
+
+    /// Writes a complete response message to the QUIC stream.
+    ///
+    /// This function sends the provided bytes as a response and ensures
+    /// all data is flushed to the underlying transport. This is typically
+    /// used for sending headers and small payloads in a single operation.
+    #[instrument(skip_all)]
+    async fn write_response(
+        &self,
+        request: Bytes,
+        writer: &mut quinn::SendStream,
+    ) -> ClientResult<()> {
+        writer
+            .write_all(&request)
+            .await
+            .inspect_err(|err| error!("failed to send request: {}", err))?;
+
+        Ok(())
+    }
+
+    /// Streams data from a reader directly to the QUIC writer.
+    ///
+    /// This function efficiently copies all data from the provided stream
+    /// to the QUIC connection using tokio's copy utility. It's designed for
+    /// streaming large piece content without loading everything into memory.
+    /// The operation is flushed to ensure data delivery.
+    #[instrument(skip_all)]
+    async fn write_stream<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        stream: &mut R,
+        writer: &mut quinn::SendStream,
+    ) -> ClientResult<()> {
+        copy(stream, writer)
+            .await
+            .inspect_err(|err| error!("copy failed: {}", err))?;
+
+        Ok(())
+    }
+}
+

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -47,6 +47,7 @@ rustix = { version = "1.1.2", features = ["fs"] }
 base64 = "0.22.1"
 pnet = "0.35.0"
 protobuf = "3.7.2"
+quinn = "0.11.9"
 
 
 [dev-dependencies]

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -47,8 +47,7 @@ rustix = { version = "1.1.2", features = ["fs"] }
 base64 = "0.22.1"
 pnet = "0.35.0"
 protobuf = "3.7.2"
-quinn = "0.11.9"
 
 [dev-dependencies]
 tempfile.workspace = true
-mocktail = "0.3.0"
+mocktail.workspace = true

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -49,7 +49,6 @@ pnet = "0.35.0"
 protobuf = "3.7.2"
 quinn = "0.11.9"
 
-
 [dev-dependencies]
 tempfile.workspace = true
-mocktail.workspace = true
+mocktail = "0.3.0"

--- a/dragonfly-client-util/src/tls/mod.rs
+++ b/dragonfly-client-util/src/tls/mod.rs
@@ -108,64 +108,6 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
     }
 }
 
-/// SkipServerVerification is a verifier for QUIC Client that does not verify the server certificate.
-/// It is used for testing and should not be used in production.
-#[derive(Debug)]
-pub struct SkipServerVerification(Arc<quinn::rustls::crypto::CryptoProvider>);
-
-impl SkipServerVerification {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self(Arc::new(
-            quinn::rustls::crypto::ring::default_provider(),
-        )))
-    }
-}
-
-impl quinn::rustls::client::danger::ServerCertVerifier for SkipServerVerification {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp: &[u8],
-        _now: UnixTime,
-    ) -> Result<quinn::rustls::client::danger::ServerCertVerified, quinn::rustls::Error> {
-        Ok(quinn::rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &quinn::rustls::DigitallySignedStruct,
-    ) -> Result<quinn::rustls::client::danger::HandshakeSignatureValid, quinn::rustls::Error> {
-        quinn::rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &quinn::rustls::DigitallySignedStruct,
-    ) -> Result<quinn::rustls::client::danger::HandshakeSignatureValid, quinn::rustls::Error> {
-        quinn::rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<quinn::rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
-}
-
 /// Generate a CA certificate from PEM format files.
 /// Generate CA by openssl with PEM format files:
 /// openssl req -x509 -sha256 -days 36500 -nodes -newkey rsa:4096 -keyout ca.key -out ca.crt

--- a/dragonfly-client-util/src/tls/mod.rs
+++ b/dragonfly-client-util/src/tls/mod.rs
@@ -108,6 +108,64 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
     }
 }
 
+/// SkipServerVerification is a verifier for QUIC Client that does not verify the server certificate.
+/// It is used for testing and should not be used in production.
+#[derive(Debug)]
+pub struct SkipServerVerification(Arc<quinn::rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self(Arc::new(
+            quinn::rustls::crypto::ring::default_provider(),
+        )))
+    }
+}
+
+impl quinn::rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<quinn::rustls::client::danger::ServerCertVerified, quinn::rustls::Error> {
+        Ok(quinn::rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &quinn::rustls::DigitallySignedStruct,
+    ) -> Result<quinn::rustls::client::danger::HandshakeSignatureValid, quinn::rustls::Error> {
+        quinn::rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &quinn::rustls::DigitallySignedStruct,
+    ) -> Result<quinn::rustls::client::danger::HandshakeSignatureValid, quinn::rustls::Error> {
+        quinn::rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<quinn::rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
 /// Generate a CA certificate from PEM format files.
 /// Generate CA by openssl with PEM format files:
 /// openssl req -x509 -sha256 -days 36500 -nodes -newkey rsa:4096 -keyout ca.key -out ca.crt

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -30,7 +30,7 @@ use dragonfly_client::tracing::init_tracing;
 use dragonfly_client_backend::BackendFactory;
 use dragonfly_client_config::{dfdaemon, VersionValueParser};
 use dragonfly_client_metric::Metrics;
-use dragonfly_client_storage::{server::tcp::TCPServer, server::quic::QUICServer, Storage};
+use dragonfly_client_storage::{server::quic::QUICServer, server::tcp::TCPServer, Storage};
 use dragonfly_client_util::{id_generator::IDGenerator, net::Interface, shutdown};
 use leaky_bucket::RateLimiter;
 use std::net::SocketAddr;

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -438,6 +438,19 @@ impl Piece {
                     )
                     .await?
             }
+            ("quic", Some(ip), _, Some(port)) => {
+                // Lazily create a QUIC downloader via factory to avoid holding all three.
+                let quic_downloader = piece_downloader::DownloaderFactory::new("quic", self.config.clone())?
+                    .build();
+                quic_downloader
+                    .download_piece(
+                        format!("{}:{}", ip, port).as_str(),
+                        number,
+                        host_id,
+                        task_id,
+                    )
+                    .await?
+            }
             _ => {
                 warn!("fall back to grpc downloader");
                 let host = parent.host.clone().ok_or_else(|| {
@@ -808,6 +821,18 @@ impl Piece {
         ) {
             ("tcp", Some(ip), Some(port), _) => {
                 self.tcp_downloader
+                    .download_persistent_cache_piece(
+                        format!("{}:{}", ip, port).as_str(),
+                        number,
+                        host_id,
+                        task_id,
+                    )
+                    .await?
+            }
+            ("quic", Some(ip), _, Some(port)) => {
+                let quic_downloader = piece_downloader::DownloaderFactory::new("quic", self.config.clone())?
+                    .build();
+                quic_downloader
                     .download_persistent_cache_piece(
                         format!("{}:{}", ip, port).as_str(),
                         number,

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -440,8 +440,8 @@ impl Piece {
             }
             ("quic", Some(ip), _, Some(port)) => {
                 // Lazily create a QUIC downloader via factory to avoid holding all three.
-                let quic_downloader = piece_downloader::DownloaderFactory::new("quic", self.config.clone())?
-                    .build();
+                let quic_downloader =
+                    piece_downloader::DownloaderFactory::new("quic", self.config.clone())?.build();
                 quic_downloader
                     .download_piece(
                         format!("{}:{}", ip, port).as_str(),
@@ -830,8 +830,8 @@ impl Piece {
                     .await?
             }
             ("quic", Some(ip), _, Some(port)) => {
-                let quic_downloader = piece_downloader::DownloaderFactory::new("quic", self.config.clone())?
-                    .build();
+                let quic_downloader =
+                    piece_downloader::DownloaderFactory::new("quic", self.config.clone())?.build();
                 quic_downloader
                     .download_persistent_cache_piece(
                         format!("{}:{}", ip, port).as_str(),

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -18,7 +18,7 @@ use crate::grpc::dfdaemon_upload::DfdaemonUploadClient;
 use dragonfly_api::dfdaemon::v2::{DownloadPersistentCachePieceRequest, DownloadPieceRequest};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_storage::{client::tcp::TCPClient, client::quic::QUICClient, metadata};
+use dragonfly_client_storage::{client::quic::QUICClient, client::tcp::TCPClient, metadata};
 use dragonfly_client_util::pool::{Builder as PoolBuilder, Entry, Factory, Pool};
 use std::io::Cursor;
 use std::sync::Arc;

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -18,7 +18,7 @@ use crate::grpc::dfdaemon_upload::DfdaemonUploadClient;
 use dragonfly_api::dfdaemon::v2::{DownloadPersistentCachePieceRequest, DownloadPieceRequest};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_storage::{client::tcp::TCPClient, metadata};
+use dragonfly_client_storage::{client::tcp::TCPClient, client::quic::QUICClient, metadata};
 use dragonfly_client_util::pool::{Builder as PoolBuilder, Entry, Factory, Pool};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -74,6 +74,11 @@ impl DownloaderFactory {
                 DEFAULT_DOWNLOADER_IDLE_TIMEOUT,
             )),
             "grpc" => Arc::new(GRPCDownloader::new(
+                config.clone(),
+                DEFAULT_DOWNLOADER_CAPACITY,
+                DEFAULT_DOWNLOADER_IDLE_TIMEOUT,
+            )),
+            "quic" => Arc::new(QUICDownloader::new(
                 config.clone(),
                 DEFAULT_DOWNLOADER_CAPACITY,
                 DEFAULT_DOWNLOADER_IDLE_TIMEOUT,
@@ -280,6 +285,112 @@ impl Downloader for GRPCDownloader {
         }
 
         Ok((Box::new(Cursor::new(content)), piece.offset, piece.digest))
+    }
+}
+
+/// QUICDownloader is the downloader for downloading pieces by the QUIC protocol.
+/// It will reuse the quic clients to download pieces from the other peers by
+/// peer's address.
+pub struct QUICDownloader {
+    /// client_pool is the pool of the quic clients.
+    client_pool: Pool<String, QUICClient, QUICClientFactory>,
+}
+
+/// Factory for creating QUICClient instances.
+struct QUICClientFactory {
+    config: Arc<Config>,
+}
+
+/// QUICClientFactory implements the Factory trait for creating QUICClient instances.
+#[tonic::async_trait]
+impl Factory<String, QUICClient> for QUICClientFactory {
+    type Error = Error;
+
+    /// Creates a new QUICClient for the given address.
+    async fn make_client(&self, addr: &String) -> Result<QUICClient> {
+        Ok(QUICClient::new(self.config.clone(), addr.clone()))
+    }
+}
+
+/// QUICDownloader implements the downloader with the QUIC protocol.
+impl QUICDownloader {
+    /// new returns a new QUICDownloader.
+    pub fn new(config: Arc<Config>, capacity: usize, idle_timeout: Duration) -> Self {
+        Self {
+            client_pool: PoolBuilder::new(QUICClientFactory {
+                config: config.clone(),
+            })
+            .capacity(capacity)
+            .idle_timeout(idle_timeout)
+            .build(),
+        }
+    }
+
+    /// get_client_entry returns a client entry by the address.
+    async fn get_client_entry(&self, addr: &str) -> Result<Entry<QUICClient>> {
+        self.client_pool.entry(&addr.to_string()).await
+    }
+
+    /// remove_client_entry removes the client if it is idle.
+    async fn remove_client_entry(&self, addr: &str) {
+        self.client_pool.remove_entry(&addr.to_string()).await;
+    }
+}
+
+/// QUICDownloader implements the Downloader trait.
+#[tonic::async_trait]
+impl Downloader for QUICDownloader {
+    /// download_piece downloads a piece from the other peer by the QUIC protocol.
+    #[instrument(skip_all)]
+    async fn download_piece(
+        &self,
+        addr: &str,
+        number: u32,
+        _host_id: &str,
+        task_id: &str,
+    ) -> Result<(Box<dyn AsyncRead + Send + Unpin>, u64, String)> {
+        let entry = self.get_client_entry(addr).await?;
+        let request_guard = entry.request_guard();
+
+        match entry.client.download_piece(number, task_id).await {
+            Ok((reader, offset, digest)) => Ok((Box::new(reader), offset, digest)),
+            Err(err) => {
+                // If the request fails, it will drop the request guard and remove the client
+                // entry to avoid using the invalid client.
+                drop(request_guard);
+                self.remove_client_entry(addr).await;
+                Err(err)
+            }
+        }
+    }
+
+    /// download_persistent_cache_piece downloads a persistent cache piece from the other peer by
+    /// the QUIC protocol.
+    #[instrument(skip_all)]
+    async fn download_persistent_cache_piece(
+        &self,
+        addr: &str,
+        number: u32,
+        _host_id: &str,
+        task_id: &str,
+    ) -> Result<(Box<dyn AsyncRead + Send + Unpin>, u64, String)> {
+        let entry = self.get_client_entry(addr).await?;
+        let request_guard = entry.request_guard();
+
+        match entry
+            .client
+            .download_persistent_cache_piece(number, task_id)
+            .await
+        {
+            Ok((reader, offset, digest)) => Ok((Box::new(reader), offset, digest)),
+            Err(err) => {
+                // If the request fails, it will drop the request guard and remove the client
+                // entry to avoid using the invalid client.
+                drop(request_guard);
+                self.remove_client_entry(addr).await;
+                Err(err)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This implementation adds QUIC-based client and server components to the dragonfly-client-storage directory to enable efficient piece downloading functionality. The solution provides a reliable, high-performance QUIC communication layer for distributing file pieces across the Dragonfly P2P network.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dragonflyoss/design/pull/8

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
