### PR TITLE
refactor(request-sdk): move seed-peer filtering to server side

### DIFF
--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -168,13 +168,12 @@ impl SeedPeerSelector {
     /// list_seed_peers lists the seed peers from scheduler.
     #[instrument(skip_all)]
     async fn list_seed_peers(&self) -> Result<Vec<Host>> {
-        let request = tonic::Request::new(ListHostsRequest { r#type: None });
-        let response = self.scheduler_client.clone().list_hosts(request).await?;
-        let hosts = response.into_inner().hosts;
-
-        // Filter for seed peer types, normal peer type is 0 and others are seed peers.
+        // Filter for seed peer types, seed peer type is 1.
         // refer to dragonfly-client-config/src/dfdaemon.rs#HostType.
-        let seed_peers: Vec<Host> = hosts.into_iter().filter(|host| host.r#type != 0).collect();
+        let request = tonic::Request::new(ListHostsRequest { r#type: Some(1) });
+        let response = self.scheduler_client.clone().list_hosts(request).await?;
+        let seed_peers = response.into_inner().hosts.into_iter().collect();
+
         Ok(seed_peers)
     }
 


### PR DESCRIPTION
This pull request updates the logic for listing seed peers in the `SeedPeerSelector` by filtering for seed peer types directly in the request rather than post-processing the response. This change simplifies the code and ensures that only seed peers are returned from the scheduler.

Seed peer selection logic:

* [`dragonfly-client-util/src/request/selector.rs`](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL171-L177): Modified the `list_seed_peers` method to set the request type to `Some(1)` so that only seed peers are returned, removing the need to filter the hosts after receiving the response.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
