### PR TITLE
refactor(quic): integrate QUIC and downloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ hostname = "^0.4"
 tonic-health = "0.12.3"
 hashring = "0.3.6"
 reqwest-tracing = "0.5"
+quinn = "0.11.9"
 mocktail = "0.3.0"
 
 [profile.release]

--- a/dragonfly-client-core/Cargo.toml
+++ b/dragonfly-client-core/Cargo.toml
@@ -23,4 +23,4 @@ opendal.workspace = true
 url.workspace = true
 headers.workspace = true
 vortex-protocol.workspace = true
-quinn = "0.11.9"
+quinn.workspace = true

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -170,6 +170,38 @@ pub enum DFError {
     #[error(transparent)]
     VortexProtocolError(#[from] vortex_protocol::error::Error),
 
+    /// QuinnConnectError is the error for quinn connect.
+    #[error(transparent)]
+    QuinnConnectError(#[from] quinn::ConnectError),
+
+    /// QuinnConnectionError is the error for quinn connection.
+    #[error(transparent)]
+    QuinnConnectionError(#[from] quinn::ConnectionError),
+
+    /// QuinnWriteError is the error for quinn write.
+    #[error(transparent)]
+    QuinnWriteError(#[from] quinn::WriteError),
+
+    /// QuinnReadError is the error for quinn read.
+    #[error(transparent)]
+    QuinnReadError(#[from] quinn::ReadError),
+
+    /// QuinnReadExactError is the error for quinn read exact.
+    #[error(transparent)]
+    QuinnReadExactError(#[from] quinn::ReadExactError),
+
+    /// QuinnRustlsNoInitialCipherSuite is the error for quinn no initial cipher suite.
+    #[error(transparent)]
+    QuinnRustlsNoInitialCipherSuite(#[from] quinn::crypto::rustls::NoInitialCipherSuite),
+
+    /// QuinnRustlsError is the error for rustls.
+    #[error(transparent)]
+    QuinnRustlsError(#[from] quinn::rustls::Error),
+
+    /// QuinnClosedStream is the error for quinn closed stream.
+    #[error(transparent)]
+    QuinnClosedStream(#[from] quinn::ClosedStream),
+
     /// TonicStatus is the error for tonic status.
     #[error(transparent)]
     TonicStatus(#[from] tonic::Status),
@@ -247,38 +279,6 @@ pub enum DFError {
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for DFError {
     fn from(e: tokio::sync::mpsc::error::SendError<T>) -> Self {
         Self::MpscSend(e.to_string())
-    }
-}
-
-// --- Conversions for quinn (QUIC) errors ---
-// These allow using the ? operator directly with quinn APIs without repetitive map_err.
-impl From<quinn::ConnectError> for DFError {
-    fn from(err: quinn::ConnectError) -> Self {
-        DFError::Unknown(format!("quinn connect error: {}", err))
-    }
-}
-
-impl From<quinn::ConnectionError> for DFError {
-    fn from(err: quinn::ConnectionError) -> Self {
-        DFError::Unknown(format!("quinn connection error: {}", err))
-    }
-}
-
-impl From<quinn::WriteError> for DFError {
-    fn from(err: quinn::WriteError) -> Self {
-        DFError::Unknown(format!("quinn write error: {}", err))
-    }
-}
-
-impl From<quinn::ReadError> for DFError {
-    fn from(err: quinn::ReadError) -> Self {
-        DFError::Unknown(format!("quinn read error: {}", err))
-    }
-}
-
-impl From<quinn::ReadExactError> for DFError {
-    fn from(err: quinn::ReadExactError) -> Self {
-        DFError::Unknown(format!("quinn read exact error: {}", err))
     }
 }
 

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -31,10 +31,10 @@ bytesize.workspace = true
 leaky-bucket.workspace = true
 vortex-protocol.workspace = true
 rustls.workspace = true
+quinn.workspace = true
 num_cpus = "1.17"
 bincode = "1.3.3"
 walkdir = "2.5.0"
-quinn = "0.11.9"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -16,11 +16,14 @@
 
 use bytes::{Bytes, BytesMut};
 use dragonfly_client_config::dfdaemon::Config;
-use dragonfly_client_core::{Error as ClientError, Result as ClientResult};
+use dragonfly_client_core::{
+    error::{ErrorType, OrErr},
+    Error as ClientError, Result as ClientResult,
+};
 use quinn::crypto::rustls::QuicClientConfig;
 use quinn::{ClientConfig, Endpoint, RecvStream, SendStream};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::AsyncRead;
 use tokio::time;
@@ -172,26 +175,22 @@ impl QUICClient {
         &self,
         request: Bytes,
     ) -> ClientResult<(RecvStream, SendStream)> {
-        let crypto = quinn::rustls::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(NoVerifier::new())
-            .with_no_client_auth();
+        let client_config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(
+            quinn::rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(NoVerifier::new())
+                .with_no_client_auth(),
+        )?));
 
-        let client_config =
-            ClientConfig::new(Arc::new(QuicClientConfig::try_from(crypto).map_err(
-                |err| ClientError::Unknown(format!("failed to create quic client config: {}", err)),
-            )?));
+        // Port is zero to let the OS assign an ephemeral port.
+        let mut endpoint =
+            Endpoint::client(SocketAddr::new(self.config.storage.server.ip.unwrap(), 0))?;
+        endpoint.set_default_client_config(client_config);
 
-        let endpoint = {
-            let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
-            let mut endpoint = Endpoint::client(bind_addr)?;
-            endpoint.set_default_client_config(client_config);
-            endpoint
-        };
-
-        let remote_addr: SocketAddr = self.addr.parse().unwrap();
+        // Connect's server name used for verifying the certificate. Since we used
+        // NoVerifier, it can be anything.
         let connection = endpoint
-            .connect(remote_addr, "quic")?
+            .connect(self.addr.parse().or_err(ErrorType::ParseError)?, "d7y")?
             .await
             .inspect_err(|err| error!("failed to connect to {}: {}", self.addr, err))?;
 
@@ -292,6 +291,7 @@ impl QUICClient {
 #[derive(Debug)]
 struct NoVerifier(Arc<quinn::rustls::crypto::CryptoProvider>);
 
+/// NoVerifier implements a no-op server certificate verifier.
 impl NoVerifier {
     pub fn new() -> Arc<Self> {
         Arc::new(Self(Arc::new(
@@ -300,7 +300,9 @@ impl NoVerifier {
     }
 }
 
+/// NoVerifier implements the ServerCertVerifier trait to skip certificate verification.
 impl quinn::rustls::client::danger::ServerCertVerifier for NoVerifier {
+    /// verify_server_cert always returns Ok, effectively skipping verification.
     fn verify_server_cert(
         &self,
         _end_entity: &CertificateDer<'_>,
@@ -312,6 +314,7 @@ impl quinn::rustls::client::danger::ServerCertVerifier for NoVerifier {
         Ok(quinn::rustls::client::danger::ServerCertVerified::assertion())
     }
 
+    /// verify_tls12_signature verifies TLS 1.2 signatures using the provided algorithms.
     fn verify_tls12_signature(
         &self,
         message: &[u8],
@@ -326,6 +329,7 @@ impl quinn::rustls::client::danger::ServerCertVerifier for NoVerifier {
         )
     }
 
+    /// verify_tls13_signature verifies TLS 1.3 signatures using the provided algorithms.
     fn verify_tls13_signature(
         &self,
         message: &[u8],
@@ -340,6 +344,7 @@ impl quinn::rustls::client::danger::ServerCertVerifier for NoVerifier {
         )
     }
 
+    /// supported_verify_schemes returns the supported signature schemes.
     fn supported_verify_schemes(&self) -> Vec<quinn::rustls::SignatureScheme> {
         self.0.signature_verification_algorithms.supported_schemes()
     }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -28,8 +28,10 @@ use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_backend::{hdfs, object_storage, BackendFactory, DirEntry};
 use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{self, dfdaemon, dfget};
-use dragonfly_client_core::error::{ErrorType, OrErr};
-use dragonfly_client_core::{Error, Result};
+use dragonfly_client_core::{
+    error::{ErrorType, OrErr},
+    Error, Result,
+};
 use dragonfly_client_util::{fs::fallocate, http::header_vec_to_hashmap};
 use glob::Pattern;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors and improves QUIC (using the `quinn` crate) support across the client and storage components, with a particular focus on error handling, configuration, and code clarity. It introduces more granular error variants for QUIC operations, simplifies downloader instantiation, and streamlines connection handling and logging for QUIC servers.

### QUIC error handling improvements

* Added specific error variants for QUIC operations (connect, connection, write, read, etc.) to the `DFError` enum in `dragonfly-client-core/src/error/mod.rs`, enabling more precise error reporting and propagation. Removed old conversion implementations that mapped all QUIC errors to `Unknown`. [[1]](diffhunk://#diff-30b34d1fd4f012f66569fffc95749e5627c7a8bb3720dbcea2fa6659a7a5f85bR173-R204) [[2]](diffhunk://#diff-30b34d1fd4f012f66569fffc95749e5627c7a8bb3720dbcea2fa6659a7a5f85bL253-L284)

### QUIC crate dependency management

* Updated `Cargo.toml` files to use workspace dependencies for `quinn`, ensuring consistent versioning and easier dependency management across crates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R120) [[2]](diffhunk://#diff-f98e164844f1b2f843ad116d8fcb9a8c66714535ffa2671a0bd631748ea368daL26-R26) [[3]](diffhunk://#diff-646c14b277a6afe2521324f3047193b744dfb61e924e1e1c6a1c71e7d12dd302R34-L37)

### QUIC client and server connection improvements

* Refactored QUIC client connection setup in `dragonfly-client-storage/src/client/quic.rs` to streamline configuration, error handling, and certificate verification (with improved documentation for the no-op verifier). [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L19-R26) [[2]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L175-R193) [[3]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8R294) [[4]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8R303-R305) [[5]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8R317) [[6]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8R332) [[7]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8R347)
* Improved QUIC server connection acceptance and logging in `dragonfly-client-storage/src/server/quic.rs`, including more robust error handling and clearer remote address tracking. [[1]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L86-R105) [[2]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L134-R156) [[3]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L184-R181) [[4]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L206-R203) [[5]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L228-R225) [[6]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L240-R234) [[7]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L266-R258) [[8]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L295-R287) [[9]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L306-R296)

### Downloader instantiation and usage

* Refactored the `Piece` struct in `dragonfly-client/src/resource/piece.rs` to instantiate the QUIC downloader once during construction, instead of lazily creating a new one for each download. Updated download logic to use the cached downloader instance. [[1]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R76-R78) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515R112) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L442-R446) [[4]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L833-R834)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
