### PR TITLE
feat(request-sdk): public the request mod errors

### DIFF
--- a/dragonfly-client-util/src/request/mod.rs
+++ b/dragonfly-client-util/src/request/mod.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-mod errors;
+pub mod errors;
 mod selector;
 
 use crate::http::headermap_to_hashmap;


### PR DESCRIPTION
This pull request makes a small change to module visibility in the `dragonfly-client-util/src/request/mod.rs` file. The change exposes the `errors` and `selector` modules for use outside of their current scope.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
