### PR TITLE
feat(dependencies): update tcp and quic config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "bincode",
  "bytes",
@@ -1222,7 +1222,6 @@ dependencies = [
  "dragonfly-client-util",
  "fs2",
  "leaky-bucket",
- "nix 0.30.1",
  "num_cpus",
  "prost-wkt-types",
  "quinn",
@@ -1231,6 +1230,7 @@ dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
  "serde",
+ "socket2 0.6.0",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
@@ -2686,15 +2686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,19 +2828,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -3567,7 +3545,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "protobuf 3.7.2",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.25"
+version = "1.0.26"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.25" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.25" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.25" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.25" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.25" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.25" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.25" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.25" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.26" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.26" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.26" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.26" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.26" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.26" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.26" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.26" }
 dragonfly-api = "=2.1.70"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -35,7 +35,7 @@ num_cpus = "1.17"
 bincode = "1.3.3"
 walkdir = "2.5.0"
 quinn = "0.11.9"
-nix = { version = "0.30.1", features = ["socket", "net"] }
+socket2 = "0.6.0"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -16,3 +16,17 @@
 
 pub mod quic;
 pub mod tcp;
+
+use std::time::Duration;
+
+/// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
+const DEFAULT_SEND_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
+/// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
+const DEFAULT_RECV_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
+/// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
+const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// DEFAULT_MAX_IDLE_TIMEOUT is the default maximum idle timeout for connections.
+const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(300);

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -16,3 +16,17 @@
 
 pub mod quic;
 pub mod tcp;
+
+use std::time::Duration;
+
+/// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
+const DEFAULT_SEND_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
+/// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
+const DEFAULT_RECV_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
+/// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
+const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// DEFAULT_MAX_IDLE_TIMEOUT is the default maximum idle timeout for connections.
+const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(300);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the network configuration and buffer management for both QUIC and TCP clients and servers in the `dragonfly-client-storage` package. The changes standardize buffer sizes and keepalive settings, switch from the `nix` crate to `socket2` for socket operations, and ensure consistent configuration of TCP and QUIC transport parameters. Additionally, all workspace dependencies are bumped to version 1.0.26.

**Network Configuration Improvements:**

* Introduced constants for default send/receive buffer sizes and keepalive intervals in both `client/mod.rs` and `server/mod.rs`, used throughout the client and server implementations for consistent configuration.
* QUIC client and server transport settings now use these constants for keepalive interval, idle timeout, send/receive window sizes, and stream receive window sizes, replacing hardcoded values. [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L195-R196) [[2]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L94-R98)

**TCP Socket Management Enhancements:**

* Migrated from the `nix` crate to the `socket2` crate for TCP socket configuration, allowing direct setting of buffer sizes, keepalive intervals, and TCP_NODELAY for both client and server sockets. [[1]](diffhunk://#diff-646c14b277a6afe2521324f3047193b744dfb61e924e1e1c6a1c71e7d12dd302L38-R38) [[2]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dR20-R23) [[3]](diffhunk://#diff-e6030761b3759d42663011530a4dd2aacabf42891109d7be3965239b7c8ed048R26)
* Updated TCP client connection logic to configure socket options immediately after connecting, and similarly updated TCP server to configure socket options before binding and listening. [[1]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL175-R183) [[2]](diffhunk://#diff-e6030761b3759d42663011530a4dd2aacabf42891109d7be3965239b7c8ed048L87-R116)

**Dependency and Version Updates:**

* Bumped the workspace and all `dragonfly-client-*` crate dependencies from version 1.0.25 to 1.0.26 in `Cargo.toml` for consistency. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)
* Removed the `nix` dependency from `dragonfly-client-storage/Cargo.toml` and added `socket2` as a replacement.

**Code Cleanup:**

* Removed unnecessary imports of `Duration` and the BBR congestion controller in QUIC client/server files, as congestion control is now set via the new configuration approach. [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L24-L31) [[2]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L31)

**Linux-specific TCP Congestion Control:**

* Updated the Linux-specific logic for setting TCP congestion control to BBR using `socket2` instead of `nix`, improving cross-platform compatibility and code clarity.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
