### PR TITLE
fix(tcp): remove fast open setting

### DIFF
--- a/dragonfly-client-storage/Cargo.toml
+++ b/dragonfly-client-storage/Cargo.toml
@@ -36,7 +36,6 @@ bincode = "1.3.3"
 walkdir = "2.5.0"
 quinn = "0.11.9"
 socket2 = "0.6.0"
-nix = { version = "0.30.1", features = ["socket", "net"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -179,18 +179,6 @@ impl TCPClient {
         socket.set_tcp_keepalive(
             &TcpKeepalive::new().with_interval(super::DEFAULT_KEEPALIVE_INTERVAL),
         )?;
-        #[cfg(target_os = "linux")]
-        {
-            use nix::sys::socket::{setsockopt, sockopt::TcpFastOpenConnect};
-            use std::os::fd::AsFd;
-            use tracing::{info, warn};
-
-            if let Err(err) = setsockopt(&socket.as_fd(), TcpFastOpenConnect, &true) {
-                warn!("failed to set tcp fast open: {}", err);
-            } else {
-                info!("set tcp fast open to true");
-            }
-        }
 
         let (reader, mut writer) = stream.into_split();
         writer.write_all(&request).await.inspect_err(|err| {

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -99,7 +99,7 @@ impl TCPServer {
         )?;
         #[cfg(target_os = "linux")]
         {
-            use nix::sys::socket::{setsockopt, sockopt::TcpFastOpenConnect};
+            use nix::sys::socket::{setsockopt, sockopt::TcpFastOpen};
             use std::os::fd::AsFd;
             use tracing::{info, warn};
 
@@ -109,7 +109,7 @@ impl TCPServer {
                 info!("set tcp congestion to cubic");
             }
 
-            if let Err(err) = setsockopt(&socket.as_fd(), TcpFastOpenConnect, &true) {
+            if let Err(err) = setsockopt(&socket.as_fd(), TcpFastOpen, &3u32) {
                 warn!("failed to set tcp fast open: {}", err);
             } else {
                 info!("set tcp fast open to true");

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -99,20 +99,12 @@ impl TCPServer {
         )?;
         #[cfg(target_os = "linux")]
         {
-            use nix::sys::socket::{setsockopt, sockopt::TcpFastOpen};
-            use std::os::fd::AsFd;
             use tracing::{info, warn};
 
             if let Err(err) = socket.set_tcp_congestion("cubic".as_bytes()) {
                 warn!("failed to set tcp congestion: {}", err);
             } else {
                 info!("set tcp congestion to cubic");
-            }
-
-            if let Err(err) = setsockopt(&socket.as_fd(), TcpFastOpen, &3u32) {
-                warn!("failed to set tcp fast open: {}", err);
-            } else {
-                info!("set tcp fast open to true");
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates how the TCP Fast Open option is set for both the TCP client and server. Instead of passing a boolean value, it now passes an integer value (`3u32`) to the `setsockopt` function, which may be required for compatibility with certain system APIs or to enable specific Fast Open features.

**Networking configuration changes:**

* Updated the `setsockopt` call in both `TCPClient` and `TCPServer` implementations to pass `3u32` instead of `true` for the `TcpFastOpenConnect` option, likely to align with system expectations for enabling TCP Fast Open. (`dragonfly-client-storage/src/client/tcp.rs`, [[1]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL188-R188); `dragonfly-client-storage/src/server/tcp.rs`, [[2]](diffhunk://#diff-e6030761b3759d42663011530a4dd2aacabf42891109d7be3965239b7c8ed048L112-R112)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
