### PR TITLE
refactor(dfdaemon): remove unused HostType variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,6 @@ dependencies = [
  "dragonfly-client-util",
  "fs2",
  "leaky-bucket",
- "nix 0.30.1",
  "num_cpus",
  "prost-wkt-types",
  "quinn",
@@ -2687,15 +2686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,19 +2828,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -3568,7 +3545,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "protobuf 3.7.2",
  "protobuf-codegen",

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -899,14 +899,6 @@ pub enum HostType {
     #[default]
     #[serde(rename = "super")]
     Super,
-
-    /// Strong indicates the peer is strong seed peer.
-    #[serde(rename = "strong")]
-    Strong,
-
-    /// Weak indicates the peer is weak seed peer.
-    #[serde(rename = "weak")]
-    Weak,
 }
 
 /// HostType implements Display.
@@ -915,8 +907,6 @@ impl fmt::Display for HostType {
         match self {
             HostType::Normal => write!(f, "normal"),
             HostType::Super => write!(f, "super"),
-            HostType::Strong => write!(f, "strong"),
-            HostType::Weak => write!(f, "weak"),
         }
     }
 }
@@ -1984,8 +1974,6 @@ key: /etc/ssl/private/client.pem
         // Test whether the Display implementation is correct.
         assert_eq!(HostType::Normal.to_string(), "normal");
         assert_eq!(HostType::Super.to_string(), "super");
-        assert_eq!(HostType::Strong.to_string(), "strong");
-        assert_eq!(HostType::Weak.to_string(), "weak");
 
         // Test if the default value is HostType::Super.
         let default_host_type: HostType = Default::default();
@@ -1996,26 +1984,18 @@ key: /etc/ssl/private/client.pem
     fn serialize_host_type_correctly() {
         let normal: HostType = serde_json::from_str("\"normal\"").unwrap();
         let super_seed: HostType = serde_json::from_str("\"super\"").unwrap();
-        let strong_seed: HostType = serde_json::from_str("\"strong\"").unwrap();
-        let weak_seed: HostType = serde_json::from_str("\"weak\"").unwrap();
 
         assert_eq!(normal, HostType::Normal);
         assert_eq!(super_seed, HostType::Super);
-        assert_eq!(strong_seed, HostType::Strong);
-        assert_eq!(weak_seed, HostType::Weak);
     }
 
     #[test]
     fn serialize_host_type() {
         let normal_json = serde_json::to_string(&HostType::Normal).unwrap();
         let super_json = serde_json::to_string(&HostType::Super).unwrap();
-        let strong_json = serde_json::to_string(&HostType::Strong).unwrap();
-        let weak_json = serde_json::to_string(&HostType::Weak).unwrap();
 
         assert_eq!(normal_json, "\"normal\"");
         assert_eq!(super_json, "\"super\"");
-        assert_eq!(strong_json, "\"strong\"");
-        assert_eq!(weak_json, "\"weak\"");
     }
 
     #[test]
@@ -2029,7 +2009,7 @@ key: /etc/ssl/private/client.pem
     fn validate_seed_peer() {
         let valid_seed_peer = SeedPeer {
             enable: true,
-            kind: HostType::Weak,
+            kind: HostType::Super,
         };
 
         assert!(valid_seed_peer.validate().is_ok());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request simplifies the `HostType` enum in the `dragonfly-client-config` crate by removing the `Strong` and `Weak` variants, along with all related logic and tests. The changes help streamline the codebase and reduce unnecessary complexity.

Enum simplification:

* Removed the `Strong` and `Weak` variants from the `HostType` enum in `dfdaemon.rs`, leaving only `Normal` and `Super` as valid host types.

Display and serialization logic updates:

* Updated the `fmt::Display` implementation for `HostType` to remove handling for the deleted variants.
* Removed test cases and serialization/deserialization logic related to the `Strong` and `Weak` variants, ensuring tests only cover the remaining valid variants. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL1987-L1988) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL1999-L2018)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
