### PR TITLE
fix(resource): add defer for residual piece cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "rolling-file",
  "rustls 0.22.4",
  "rustls-pki-types",
+ "scopeguard",
  "serde",
  "serde_json",
  "sysinfo",

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -90,6 +90,7 @@ path-absolutize = "3.1.1"
 fastrand = "2.3.0"
 glob = "0.3.3"
 console-subscriber = "0.4.1"
+scopeguard = "1.2.0"
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
This pull request introduces improved resource cleanup for piece metadata in the `Task` implementation to ensure incomplete or canceled pieces are properly handled. The changes utilize the `scopeguard` crate's `defer!` macro to automatically clean up residual piece metadata when a piece download is interrupted or incomplete, reducing the risk of inconsistent state.

**Dependency Addition:**

* Added the `scopeguard` crate as a new dependency in `Cargo.toml` to support deferred cleanup logic.

**Resource Cleanup Enhancements:**

* Imported and enabled the `defer!` macro from `scopeguard` in `src/lib.rs`.

* In the async tasks for downloading pieces from a parent or source in `task.rs`, added deferred cleanup logic using `defer!` to mark unfinished pieces as failed, ensuring piece metadata is consistent if the download is incomplete or canceled. This logic was added to three separate async download task spawns:
  - Download from parent [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1193-R1213) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1232)
  - Download from source (two locations) [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1466-R1485) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1862-R1881)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
