### PR TITLE
ci(docker): update runner configuration for CI job

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,6 +11,11 @@ reviewers:
   - chlins
   - CormickKneey
   - xujihui1985
+  - fcgxz2003
+  - jim3ma
+  - bergwolf
+  - hyy0322
+  - yyzai384
 
 # A number of reviewers added to the pull request
 numberOfReviewers: 3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Push Client Image
     runs-on:
       group: Default
-      labels: [oracle-24cpu-384gb-x86-64]
+      labels: [oracle-vm-32cpu-128gb-x86-64]
     timeout-minutes: 600
     steps:
       - name: Check out code
@@ -107,7 +107,9 @@ jobs:
 
   push_client_debug_image_to_registry:
     name: Push Client Debug Image
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:
+      group: Default
+      labels: [oracle-vm-32cpu-128gb-x86-64]
     timeout-minutes: 600
     steps:
       - name: Check out code
@@ -202,7 +204,9 @@ jobs:
 
   push_dfinit_image_to_registry:
     name: Push Dfinit Image
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:
+      group: Default
+      labels: [oracle-vm-32cpu-128gb-x86-64]
     timeout-minutes: 600
     steps:
       - name: Check out code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the GitHub Actions workflow configuration for the Docker client image build job. The change modifies the runner specification to use a specific runner group and label, instead of the previous generic self-hosted runner settings.

- **Workflow runner configuration update:**
  * In `.github/workflows/docker.yml`, the `push_client_image_to_registry` job now specifies `group: Default` and `labels: [oracle-24cpu-384gb-x86-64]` for its runner, replacing the previous `[self-hosted, Linux, X64]` configuration. This ensures the job runs on a more specific and presumably more powerful or suitable runner.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
