### PR TITLE
feat(grpc): add list_task_entries functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.70"
+version = "2.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6abfaeb9c1215768cc93ca126cc18a2fcc68f795621ebd0437f28c5dfd46437d"
+checksum = "e812ac5c6719ff250b5c6cb2675c812cda12c8108e1c40360848f1cd5d4032d8"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.2
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.28" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.28" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.28" }
-dragonfly-api = "=2.1.70"
+dragonfly-api = "=2.1.72"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -1500,7 +1500,6 @@ impl DfdaemonDownloadClient {
         request: ListTaskEntriesRequest,
     ) -> ClientResult<ListTaskEntriesResponse> {
         let request = Self::make_request(request);
-        info!("list task entries request: {:?}", request);
         let response = self.client.clone().list_task_entries(request).await?;
         Ok(response.into_inner())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces support for listing task entries in the upload server and client, updates the `dragonfly-api` dependency, and adds related metrics collection. The main focus is on enabling and instrumenting the `list_task_entries` functionality in the gRPC upload API.

**List task entries feature:**

* Implemented the `list_task_entries` gRPC method in the `DfdaemonUploadServerHandler`, including tracing, metrics collection, backend invocation, and response construction.
* Added `list_task_entries` and `stat_task` methods to the `DfdaemonUploadClient`, enabling clients to call these new endpoints.

**Dependency updates:**

* Updated the `dragonfly-api` dependency version from `2.1.70` to `2.1.72` in `Cargo.toml` to support new API features.

**Metrics and imports:**

* Imported new types and metrics for `list_task_entries`, including `Entry`, `ListTaskEntriesRequest`, `ListTaskEntriesResponse`, and relevant metric collection functions. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L29-R37) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L44-R47)

**Logging and cleanup:**

* Removed a redundant info log from the `list_task_entries` method in the download client for cleaner logs.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
