### PR TITLE
refactor(storage): consolidate task preparation logic

### DIFF
--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -112,10 +112,10 @@ impl Storage {
         self.content.is_same_dev_inode_as_task(id, to).await
     }
 
-    /// prepare_download_task_started prepares the metadata of the task when the task downloads
+    /// prepare_download_task prepares the metadata of the task when the task downloads
     /// started.
-    pub async fn prepare_download_task_started(&self, id: &str) -> Result<metadata::Task> {
-        self.metadata.download_task_started(id, None, None, None)
+    pub fn prepare_download_task(&self, id: &str) -> Result<(metadata::Task, bool)> {
+        self.metadata.prepare_download_task(id)
     }
 
     /// download_task_started updates the metadata of the task and create task content
@@ -130,12 +130,8 @@ impl Storage {
     ) -> Result<metadata::Task> {
         self.content.create_task(id, content_length).await?;
 
-        self.metadata.download_task_started(
-            id,
-            Some(piece_length),
-            Some(content_length),
-            response_header,
-        )
+        self.metadata
+            .download_task_started(id, piece_length, content_length, response_header)
     }
 
     /// download_task_finished updates the metadata of the task when the task downloads finished.
@@ -374,16 +370,6 @@ impl Storage {
             });
     }
 
-    /// prepare_download_cache_task_started prepares the metadata of the cache task when the cache task downloads
-    /// started.
-    pub async fn prepare_download_cache_task_started(
-        &self,
-        id: &str,
-    ) -> Result<metadata::CacheTask> {
-        self.metadata
-            .download_cache_task_started(id, None, None, None)
-    }
-
     /// download_cache_task_started updates the metadata of the cache task and create cache task content
     /// when the cache task downloads started.
     #[instrument(skip_all)]
@@ -397,12 +383,8 @@ impl Storage {
         let mut cache = self.cache.clone();
         cache.put_task(id, content_length).await;
 
-        self.metadata.download_cache_task_started(
-            id,
-            Some(piece_length),
-            Some(content_length),
-            response_header,
-        )
+        self.metadata
+            .download_cache_task_started(id, piece_length, content_length, response_header)
     }
 
     /// download_cache_task_finished updates the metadata of the cache task when the cache task downloads finished.

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -421,13 +421,49 @@ where
 }
 
 impl<E: StorageEngineOwned> Metadata<E> {
+    /// prepare_download_task prepares the metadata of the download task.
+    #[instrument(skip_all)]
+    pub fn prepare_download_task(&self, id: &str) -> Result<(Task, bool)> {
+        let task = match self.db.get::<Task>(id.as_bytes())? {
+            Some(mut task) => {
+                // Reuse existing task if all conditions are met:
+                // 1. Content length is defined.
+                // 2. Piece length is defined.
+                // 3. Task status is not failed.
+                if task.content_length().is_some()
+                    && task.piece_length().is_some()
+                    && !task.is_failed()
+                {
+                    return Ok((task, true));
+                } else {
+                    // If reuse conditions are not met, update metadata and retry with HEAD request.
+                    task.updated_at = Utc::now().naive_utc();
+                    task.failed_at = None;
+                    task
+                }
+            }
+            None => {
+                // If the task does not exist, create a new task.
+                Task {
+                    id: id.to_string(),
+                    updated_at: Utc::now().naive_utc(),
+                    created_at: Utc::now().naive_utc(),
+                    ..Default::default()
+                }
+            }
+        };
+
+        self.db.put(id.as_bytes(), &task)?;
+        Ok((task, false))
+    }
+
     /// download_task_started updates the metadata of the task when the task downloads started.
     #[instrument(skip_all)]
     pub fn download_task_started(
         &self,
         id: &str,
-        piece_length: Option<u64>,
-        content_length: Option<u64>,
+        piece_length: u64,
+        content_length: u64,
         response_header: Option<HeaderMap>,
     ) -> Result<Task> {
         // Convert the response header to hashmap.
@@ -441,29 +477,15 @@ impl<E: StorageEngineOwned> Metadata<E> {
                 // If the task exists, update the task metadata.
                 task.updated_at = Utc::now().naive_utc();
                 task.failed_at = None;
-
-                // Protect content length to be overwritten by None.
-                if content_length.is_some() {
-                    task.content_length = content_length;
-                }
-
-                // Protect piece length to be overwritten by None.
-                if piece_length.is_some() {
-                    task.piece_length = piece_length;
-                }
-
-                // If the task has the response header, the response header
-                // will not be covered.
-                if task.response_header.is_empty() {
-                    task.response_header = response_header;
-                }
-
+                task.content_length = Some(content_length);
+                task.piece_length = Some(piece_length);
+                task.response_header = response_header;
                 task
             }
             None => Task {
                 id: id.to_string(),
-                piece_length,
-                content_length,
+                piece_length: Some(piece_length),
+                content_length: Some(content_length),
                 response_header,
                 updated_at: Utc::now().naive_utc(),
                 created_at: Utc::now().naive_utc(),
@@ -853,8 +875,8 @@ impl<E: StorageEngineOwned> Metadata<E> {
     pub fn download_cache_task_started(
         &self,
         id: &str,
-        piece_length: Option<u64>,
-        content_length: Option<u64>,
+        piece_length: u64,
+        content_length: u64,
         response_header: Option<HeaderMap>,
     ) -> Result<CacheTask> {
         // Convert the response header to hashmap.
@@ -868,29 +890,15 @@ impl<E: StorageEngineOwned> Metadata<E> {
                 // If the task exists, update the task metadata.
                 task.updated_at = Utc::now().naive_utc();
                 task.failed_at = None;
-
-                // Protect content length to be overwritten by None.
-                if content_length.is_some() {
-                    task.content_length = content_length;
-                }
-
-                // Protect piece length to be overwritten by None.
-                if piece_length.is_some() {
-                    task.piece_length = piece_length;
-                }
-
-                // If the task has the response header, the response header
-                // will not be covered.
-                if task.response_header.is_empty() {
-                    task.response_header = response_header;
-                }
-
+                task.content_length = Some(content_length);
+                task.piece_length = Some(piece_length);
+                task.response_header = response_header;
                 task
             }
             None => CacheTask {
                 id: id.to_string(),
-                piece_length,
-                content_length,
+                piece_length: Some(piece_length),
+                content_length: Some(content_length),
                 response_header,
                 updated_at: Utc::now().naive_utc(),
                 created_at: Utc::now().naive_utc(),
@@ -1283,7 +1291,7 @@ mod tests {
 
         // Test download_task_started.
         metadata
-            .download_task_started(task_id, Some(1024), Some(1024), None)
+            .download_task_started(task_id, 1024, 1024, None)
             .unwrap();
         let task = metadata
             .get_task(task_id)
@@ -1323,7 +1331,7 @@ mod tests {
         // Test get_tasks.
         let task_id = "a535b115f18d96870f0422ac891f91dd162f2f391e4778fb84279701fcd02dd1";
         metadata
-            .download_task_started(task_id, Some(1024), None, None)
+            .download_task_started(task_id, 1024, 0, None)
             .unwrap();
         let tasks = metadata.get_tasks().unwrap();
         assert_eq!(tasks.len(), 2);
@@ -1343,7 +1351,7 @@ mod tests {
 
         // Test download_task_started.
         metadata
-            .download_cache_task_started(task_id, Some(1024), Some(1024), None)
+            .download_cache_task_started(task_id, 1024, 1024, None)
             .unwrap();
         let task = metadata
             .get_cache_task(task_id)
@@ -1383,7 +1391,7 @@ mod tests {
         // Test get_cache_tasks.
         let task_id = "a535b115f18d96870f0422ac891f91dd162f2f391e4778fb84279701fcd02dd1";
         metadata
-            .download_cache_task_started(task_id, Some(1024), None, None)
+            .download_cache_task_started(task_id, 1024, 0, None)
             .unwrap();
         let tasks = metadata.get_cache_tasks().unwrap();
         assert_eq!(tasks.len(), 2);

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -138,9 +138,8 @@ impl Task {
         id: &str,
         request: Download,
     ) -> ClientResult<metadata::Task> {
-        let task = self.storage.prepare_download_task_started(id).await?;
-
-        if task.content_length.is_some() && task.piece_length.is_some() {
+        let (task, reused) = self.storage.prepare_download_task(id)?;
+        if reused {
             // Attempt to create a hard link from the task file to the output path.
             //
             // Behavior based on force_hard_link setting:


### PR DESCRIPTION
This pull request refactors the logic for preparing download tasks in the storage layer, improving how task metadata is reused and introducing clearer checks for resumable tasks. The changes streamline the process of determining when a download task can be resumed and ensure that metadata is managed more robustly.

**Download Task Preparation and Reuse**

* Refactored the task preparation method in `Storage` to `prepare_download_task`, which now returns both the task metadata and a boolean indicating whether the task can be reused. This replaces the previous `prepare_download_task_started` method and clarifies the API for consumers.
* Added a new method `prepare_download_task` in `Metadata`, which checks if an existing task can be reused based on content length, piece length, and failure status. If the task cannot be reused, its metadata is updated; if it doesn't exist, a new task is created.
* Updated the usage in the `Task` resource to use the new `prepare_download_task` method and handle the reuse flag, simplifying the logic for linking files when tasks are reused.

**Resumable Task Checks**

* Added an `is_task_resumable` method to `Storage`, which determines if a task is resumable by checking for content length, piece length, and ensuring the task has not failed. This provides a clear interface for resumability checks.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
