### PR TITLE
chore: bump version to v1.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "bincode",
  "bytes",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.29"
+version = "1.0.30"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.29" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.29" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.29" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.29" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.29" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.29" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.29" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.29" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.30" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.30" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.30" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.30" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.30" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.30" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.30" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.30" }
 dragonfly-api = "=2.1.78"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
This pull request updates the workspace version and dependency versions in the `Cargo.toml` file to 1.0.30. This ensures all workspace packages are consistent and up-to-date.

Version updates:

* Bumped the overall workspace package version from `1.0.29` to `1.0.30` in `Cargo.toml`.
* Updated all internal workspace dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-metric`, `dragonfly-client-util`, `dragonfly-client-init`) to version `1.0.30` in `Cargo.toml`.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
