### PR TITLE
feat(deps): remove quinn dependency from dragonfly-client-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1156,13 +1156,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
  "hyper-util",
  "opendal",
- "quinn",
  "reqwest",
  "reqwest-middleware",
  "thiserror 2.0.16",
@@ -1176,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -1193,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1208,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "bincode",
  "bytes",
@@ -1242,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1682,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.30"
+version = "1.0.31"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.30" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.30" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.30" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.30" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.30" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.30" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.30" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.30" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.31" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.31" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.31" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.31" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.31" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.31" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.31" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.31" }
 dragonfly-api = "=2.1.78"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-core/Cargo.toml
+++ b/dragonfly-client-core/Cargo.toml
@@ -23,4 +23,3 @@ opendal.workspace = true
 url.workspace = true
 headers.workspace = true
 vortex-protocol.workspace = true
-quinn = "0.11.9"

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -250,38 +250,6 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for DFError {
     }
 }
 
-// --- Conversions for quinn (QUIC) errors ---
-// These allow using the ? operator directly with quinn APIs without repetitive map_err.
-impl From<quinn::ConnectError> for DFError {
-    fn from(err: quinn::ConnectError) -> Self {
-        DFError::Unknown(format!("quinn connect error: {}", err))
-    }
-}
-
-impl From<quinn::ConnectionError> for DFError {
-    fn from(err: quinn::ConnectionError) -> Self {
-        DFError::Unknown(format!("quinn connection error: {}", err))
-    }
-}
-
-impl From<quinn::WriteError> for DFError {
-    fn from(err: quinn::WriteError) -> Self {
-        DFError::Unknown(format!("quinn write error: {}", err))
-    }
-}
-
-impl From<quinn::ReadError> for DFError {
-    fn from(err: quinn::ReadError) -> Self {
-        DFError::Unknown(format!("quinn read error: {}", err))
-    }
-}
-
-impl From<quinn::ReadExactError> for DFError {
-    fn from(err: quinn::ReadExactError) -> Self {
-        DFError::Unknown(format!("quinn read exact error: {}", err))
-    }
-}
-
 /// SendTimeoutError is the error for send timeout.
 impl<T> From<tokio::sync::mpsc::error::SendTimeoutError<T>> for DFError {
     fn from(err: tokio::sync::mpsc::error::SendTimeoutError<T>) -> Self {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request removes the dependency on the `quinn` crate from the workspace and refactors error handling for QUIC-related operations in both the client and server code. Instead of using custom `From<quinn::Error>` conversions, the code now consistently uses the `OrErr` trait and `ErrorType::ConnectError` for error mapping. Additionally, all crate versions are bumped to `1.0.31`.

Dependency and version updates:
- Removed the `quinn` dependency from `dragonfly-client-core/Cargo.toml`, indicating that direct usage of the `quinn` crate is no longer needed in this crate.
- Updated the workspace and all internal crate versions from `1.0.30` to `1.0.31` in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)

Error handling refactor:
- Removed all `From<quinn::Error>` implementations from `dragonfly-client-core/src/error/mod.rs`, eliminating the old error conversion approach for QUIC errors.
- Refactored QUIC-related async operations in both `dragonfly-client-storage/src/client/quic.rs` and `dragonfly-client-storage/src/server/quic.rs` to use `.or_err(ErrorType::ConnectError)?` for error mapping, ensuring consistent and explicit error handling. [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L207-R223) [[2]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L236-R241) [[3]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L260-R275) [[4]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L107-R112) [[5]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L470-R476) [[6]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L494-R501) [[7]](diffhunk://#diff-dbf426132604e055f41fcdd40db868a0904c8b28925917584ab74881f33b87b9L513-R521)
- Updated imports in `dragonfly-client-storage/src/server/quic.rs` to bring in the `OrErr` trait and `ErrorType` for the new error handling approach.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
