### PR TITLE
feat(http): add default proxy rule filtered query params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-core",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "bincode",
  "bytes",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.31"
+version = "1.0.32"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.31" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.31" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.31" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.31" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.31" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.31" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.31" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.31" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.32" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.32" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.32" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.32" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.32" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.32" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.32" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.32" }
 dragonfly-api = "=2.1.78"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -21,6 +21,7 @@ use dragonfly_client_core::{
 };
 use dragonfly_client_util::{
     http::basic_auth,
+    http::query_params::default_proxy_rule_filtered_query_params,
     tls::{generate_ca_cert_from_pem, generate_cert_from_pem},
 };
 use local_ip_address::{local_ip, local_ipv6};
@@ -28,7 +29,6 @@ use rcgen::Certificate;
 use regex::Regex;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
@@ -286,109 +286,6 @@ pub fn default_proxy_read_buffer_size() -> usize {
 fn default_prefetch_rate_limit() -> ByteSize {
     // Default rate limit is 2GiB/s.
     ByteSize::gib(2)
-}
-
-/// default_s3_filtered_query_params is the default filtered query params with s3 protocol to generate the task id.
-#[inline]
-fn s3_filtered_query_params() -> Vec<String> {
-    vec![
-        "X-Amz-Algorithm".to_string(),
-        "X-Amz-Credential".to_string(),
-        "X-Amz-Date".to_string(),
-        "X-Amz-Expires".to_string(),
-        "X-Amz-SignedHeaders".to_string(),
-        "X-Amz-Signature".to_string(),
-        "X-Amz-Security-Token".to_string(),
-        "X-Amz-User-Agent".to_string(),
-    ]
-}
-
-/// gcs_filtered_query_params is the filtered query params with gcs protocol to generate the task id.
-#[inline]
-fn gcs_filtered_query_params() -> Vec<String> {
-    vec![
-        "X-Goog-Algorithm".to_string(),
-        "X-Goog-Credential".to_string(),
-        "X-Goog-Date".to_string(),
-        "X-Goog-Expires".to_string(),
-        "X-Goog-SignedHeaders".to_string(),
-        "X-Goog-Signature".to_string(),
-    ]
-}
-
-/// oss_filtered_query_params is the filtered query params with oss protocol to generate the task id.
-#[inline]
-fn oss_filtered_query_params() -> Vec<String> {
-    vec![
-        "OSSAccessKeyId".to_string(),
-        "Expires".to_string(),
-        "Signature".to_string(),
-        "SecurityToken".to_string(),
-    ]
-}
-
-/// obs_filtered_query_params is the filtered query params with obs protocol to generate the task id.
-#[inline]
-fn obs_filtered_query_params() -> Vec<String> {
-    vec![
-        "AccessKeyId".to_string(),
-        "Signature".to_string(),
-        "Expires".to_string(),
-        "X-Obs-Date".to_string(),
-        "X-Obs-Security-Token".to_string(),
-    ]
-}
-
-/// cos_filtered_query_params is the filtered query params with cos protocol to generate the task id.
-#[inline]
-fn cos_filtered_query_params() -> Vec<String> {
-    vec![
-        "q-sign-algorithm".to_string(),
-        "q-ak".to_string(),
-        "q-sign-time".to_string(),
-        "q-key-time".to_string(),
-        "q-header-list".to_string(),
-        "q-url-param-list".to_string(),
-        "q-signature".to_string(),
-        "x-cos-security-token".to_string(),
-    ]
-}
-
-/// containerd_filtered_query_params is the filtered query params with containerd to generate the task id.
-#[inline]
-fn containerd_filtered_query_params() -> Vec<String> {
-    vec!["ns".to_string()]
-}
-
-/// default_proxy_rule_filtered_query_params is the default filtered query params to generate the task id.
-#[inline]
-pub fn default_proxy_rule_filtered_query_params() -> Vec<String> {
-    let mut visited = HashSet::new();
-    for query_param in s3_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    for query_param in gcs_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    for query_param in oss_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    for query_param in obs_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    for query_param in cos_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    for query_param in containerd_filtered_query_params() {
-        visited.insert(query_param);
-    }
-
-    visited.into_iter().collect()
 }
 
 /// default_proxy_registry_mirror_addr is the default registry mirror address.
@@ -1047,7 +944,7 @@ pub struct Storage {
     /// +-----------------+          +----------------------------+
     ///                                             |
     ///                                          Preheat
-    ///```   
+    ///```
     #[serde(with = "bytesize_serde", default = "default_storage_cache_capacity")]
     pub cache_capacity: ByteSize,
 }
@@ -1663,48 +1560,9 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tokio::fs;
-
-    #[test]
-    fn default_proxy_rule_filtered_query_params_contains_all_params() {
-        let mut expected = HashSet::new();
-        expected.extend(s3_filtered_query_params());
-        expected.extend(gcs_filtered_query_params());
-        expected.extend(oss_filtered_query_params());
-        expected.extend(obs_filtered_query_params());
-        expected.extend(cos_filtered_query_params());
-        expected.extend(containerd_filtered_query_params());
-
-        let actual = default_proxy_rule_filtered_query_params();
-        let actual_set: HashSet<_> = actual.into_iter().collect();
-
-        assert_eq!(actual_set, expected);
-    }
-
-    #[test]
-    fn default_proxy_rule_removes_duplicates() {
-        let params: Vec<String> = default_proxy_rule_filtered_query_params();
-        let param_count = params.len();
-
-        let unique_params: HashSet<_> = params.into_iter().collect();
-        assert_eq!(unique_params.len(), param_count);
-    }
-
-    #[test]
-    fn default_proxy_rule_filtered_query_params_contains_key_properties() {
-        let params = default_proxy_rule_filtered_query_params();
-        let param_set: HashSet<_> = params.into_iter().collect();
-
-        assert!(param_set.contains("X-Amz-Signature"));
-        assert!(param_set.contains("X-Goog-Signature"));
-        assert!(param_set.contains("OSSAccessKeyId"));
-        assert!(param_set.contains("X-Obs-Security-Token"));
-        assert!(param_set.contains("q-sign-algorithm"));
-        assert!(param_set.contains("ns"));
-    }
 
     #[test]
     fn deserialize_server_correctly() {

--- a/dragonfly-client-util/src/http/mod.rs
+++ b/dragonfly-client-util/src/http/mod.rs
@@ -23,6 +23,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 
 pub mod basic_auth;
+pub mod query_params;
 
 /// headermap_to_hashmap converts a headermap to a hashmap.
 pub fn headermap_to_hashmap(header: &HeaderMap<HeaderValue>) -> HashMap<String, String> {

--- a/dragonfly-client-util/src/http/query_params.rs
+++ b/dragonfly-client-util/src/http/query_params.rs
@@ -1,0 +1,164 @@
+/*
+ *     Copyright 2025 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+
+/// default_s3_filtered_query_params is the default filtered query params with s3 protocol to generate the task id.
+#[inline]
+fn s3_filtered_query_params() -> Vec<String> {
+    vec![
+        "X-Amz-Algorithm".to_string(),
+        "X-Amz-Credential".to_string(),
+        "X-Amz-Date".to_string(),
+        "X-Amz-Expires".to_string(),
+        "X-Amz-SignedHeaders".to_string(),
+        "X-Amz-Signature".to_string(),
+        "X-Amz-Security-Token".to_string(),
+        "X-Amz-User-Agent".to_string(),
+    ]
+}
+
+/// gcs_filtered_query_params is the filtered query params with gcs protocol to generate the task id.
+#[inline]
+fn gcs_filtered_query_params() -> Vec<String> {
+    vec![
+        "X-Goog-Algorithm".to_string(),
+        "X-Goog-Credential".to_string(),
+        "X-Goog-Date".to_string(),
+        "X-Goog-Expires".to_string(),
+        "X-Goog-SignedHeaders".to_string(),
+        "X-Goog-Signature".to_string(),
+    ]
+}
+
+/// oss_filtered_query_params is the filtered query params with oss protocol to generate the task id.
+#[inline]
+fn oss_filtered_query_params() -> Vec<String> {
+    vec![
+        "OSSAccessKeyId".to_string(),
+        "Expires".to_string(),
+        "Signature".to_string(),
+        "SecurityToken".to_string(),
+    ]
+}
+
+/// obs_filtered_query_params is the filtered query params with obs protocol to generate the task id.
+#[inline]
+fn obs_filtered_query_params() -> Vec<String> {
+    vec![
+        "AccessKeyId".to_string(),
+        "Signature".to_string(),
+        "Expires".to_string(),
+        "X-Obs-Date".to_string(),
+        "X-Obs-Security-Token".to_string(),
+    ]
+}
+
+/// cos_filtered_query_params is the filtered query params with cos protocol to generate the task id.
+#[inline]
+fn cos_filtered_query_params() -> Vec<String> {
+    vec![
+        "q-sign-algorithm".to_string(),
+        "q-ak".to_string(),
+        "q-sign-time".to_string(),
+        "q-key-time".to_string(),
+        "q-header-list".to_string(),
+        "q-url-param-list".to_string(),
+        "q-signature".to_string(),
+        "x-cos-security-token".to_string(),
+    ]
+}
+
+/// containerd_filtered_query_params is the filtered query params with containerd to generate the task id.
+#[inline]
+fn containerd_filtered_query_params() -> Vec<String> {
+    vec!["ns".to_string()]
+}
+
+/// default_proxy_rule_filtered_query_params is the default filtered query params to generate the task id.
+#[inline]
+pub fn default_proxy_rule_filtered_query_params() -> Vec<String> {
+    let mut visited = HashSet::new();
+    for query_param in s3_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    for query_param in gcs_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    for query_param in oss_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    for query_param in obs_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    for query_param in cos_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    for query_param in containerd_filtered_query_params() {
+        visited.insert(query_param);
+    }
+
+    visited.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn default_proxy_rule_filtered_query_params_contains_all_params() {
+        let mut expected = HashSet::new();
+        expected.extend(s3_filtered_query_params());
+        expected.extend(gcs_filtered_query_params());
+        expected.extend(oss_filtered_query_params());
+        expected.extend(obs_filtered_query_params());
+        expected.extend(cos_filtered_query_params());
+        expected.extend(containerd_filtered_query_params());
+
+        let actual = default_proxy_rule_filtered_query_params();
+        let actual_set: HashSet<_> = actual.into_iter().collect();
+
+        assert_eq!(actual_set, expected);
+    }
+
+    #[test]
+    fn default_proxy_rule_removes_duplicates() {
+        let params: Vec<String> = default_proxy_rule_filtered_query_params();
+        let param_count = params.len();
+
+        let unique_params: HashSet<_> = params.into_iter().collect();
+        assert_eq!(unique_params.len(), param_count);
+    }
+
+    #[test]
+    fn default_proxy_rule_filtered_query_params_contains_key_properties() {
+        let params = default_proxy_rule_filtered_query_params();
+        let param_set: HashSet<_> = params.into_iter().collect();
+
+        assert!(param_set.contains("X-Amz-Signature"));
+        assert!(param_set.contains("X-Goog-Signature"));
+        assert!(param_set.contains("OSSAccessKeyId"));
+        assert!(param_set.contains("X-Obs-Security-Token"));
+        assert!(param_set.contains("q-sign-algorithm"));
+        assert!(param_set.contains("ns"));
+    }
+}

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -206,7 +206,7 @@ impl Selector for SeedPeerSelector {
 
         // The number of replicas cannot exceed the total number of seed peers.
         let expected_replicas = std::cmp::min(replicas as usize, seed_peers.hashring.len());
-        debug!("expected replicas: {}", expected_replicas);
+        debug!("task {} expected replicas: {}", task_id, expected_replicas);
 
         // Get replica nodes from the hash ring.
         let vnodes = seed_peers

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -30,7 +30,10 @@ use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{self, dfdaemon, dfget};
 use dragonfly_client_core::error::{ErrorType, OrErr};
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_util::{fs::fallocate, http::header_vec_to_hashmap};
+use dragonfly_client_util::{
+    fs::fallocate, http::header_vec_to_hashmap,
+    http::query_params::default_proxy_rule_filtered_query_params,
+};
 use glob::Pattern;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use local_ip_address::local_ip;
@@ -62,7 +65,7 @@ Examples:
 
   # Download a file from HDFS.
   $ dfget hdfs://<host>:<port>/<path> -O /tmp/file.txt --hdfs-delegation-token=<delegation_token>
-  
+
   # Download a file from Amazon Simple Storage Service(S3).
   $ dfget s3://<bucket>/<path> -O /tmp/file.txt --storage-access-key-id=<access_key_id> --storage-access-key-secret=<access_key_secret>
 
@@ -850,7 +853,7 @@ async fn download(
     // If the `filtered_query_params` is not provided, then use the default value.
     let filtered_query_params = args
         .filtered_query_params
-        .unwrap_or_else(dfdaemon::default_proxy_rule_filtered_query_params);
+        .unwrap_or_else(default_proxy_rule_filtered_query_params);
 
     // Dfget needs to notify dfdaemon to transfer the piece content of downloading file via unix domain socket
     // when the `transfer_from_dfdaemon` is true. Otherwise, dfdaemon will download the file and hardlink or


### PR DESCRIPTION
This pull request refactors how filtered query parameters are managed and used when generating task IDs for proxy requests in the Dragonfly client. The main change is moving the logic for determining default filtered query parameters out of `dragonfly-client-config` and into a new module in `dragonfly-client-util`, consolidating related code and tests. This improves code organization and ensures that default query parameters are consistently applied when none are provided.

**Refactoring and Code Organization:**

* Moved all filtered query parameter logic (for S3, GCS, OSS, OBS, COS, containerd, and the default proxy rule) from `dragonfly-client-config/src/dfdaemon.rs` to a new module `dragonfly-client-util/src/http/query_params.rs`, including associated tests. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL291-L393) [[2]](diffhunk://#diff-c2b8cdda2e240c6eacd27362f59a05cc5ac0ee6d6fd31d2c1dac37b48d40661dR1-R164)
* Updated imports in `dragonfly-client-config/src/dfdaemon.rs`, `dragonfly-client-util/src/http/mod.rs`, and `dragonfly-client-util/src/request/mod.rs` to use the new `query_params` module for `default_proxy_rule_filtered_query_params`. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR24-L31) [[2]](diffhunk://#diff-400949f43c53c2d5833a394806a0d9cd7360a7c9f99b9ad101c5f58e3c44e98dR26) [[3]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L20-R20)

**Behavioral Improvements:**

* In the proxy logic (`dragonfly-client-util/src/request/mod.rs`), now uses the default filtered query parameters if none are specified in the request, ensuring consistent and correct task ID generation. [[1]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225R416-R421) [[2]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L426-R449)

**Debug Logging Enhancements:**

* Improved debug logging to include the task ID when logging selected seed peers and expected replicas, making logs more informative for troubleshooting. [[1]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L426-R449) [[2]](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL209-R209)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
