### PR TITLE
feat(client): add parent_addr logging to download_piece

### DIFF
--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::time;
-use tracing::{error, instrument};
+use tracing::{error, instrument, Span};
 use vortex_protocol::{
     tlv::{
         download_persistent_cache_piece::DownloadPersistentCachePiece,
@@ -53,12 +53,14 @@ impl TCPClient {
     ///
     /// This is the main entry point for downloading a piece. It applies
     /// a timeout based on the configuration and handles connection timeouts gracefully.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(parent_addr))]
     pub async fn download_piece(
         &self,
         number: u32,
         task_id: &str,
     ) -> ClientResult<(impl AsyncRead, u64, String)> {
+        Span::current().record("parent_addr", self.addr.as_str());
+
         time::timeout(
             self.config.download.piece_timeout,
             self.handle_download_piece(number, task_id),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request enhances the observability of piece downloads in both the QUIC and TCP clients by improving tracing instrumentation. The changes add a new `parent_addr` field to the tracing spans, allowing you to see which parent address is associated with each download operation in the logs.

**Tracing enhancements:**

* Added the `parent_addr` field to the tracing span in the `download_piece` method for both `QUICClient` and `TCPClient`, enabling better identification of the source address in traces. [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L61-R68) [[2]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL56-R63)
* Imported `Span` from the `tracing` crate in `tcp.rs` to support span field recording.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
