### PR TITLE
refactor(grpc): replace handle_error with handle_backend_error

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -427,6 +427,17 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
 
+        // Define the backend error handler to send the error to the stream.
+        async fn handle_backend_error(
+            out_stream_tx: &Sender<Result<DownloadTaskResponse, Status>>,
+            err: Status,
+        ) {
+            out_stream_tx
+                .send_timeout(Err(err), super::REQUEST_TIMEOUT)
+                .await
+                .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
+        }
+
         tokio::spawn(
             async move {
                 match task_manager_clone
@@ -576,7 +587,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                             status_code: err.status_code.map(|code| code.as_u16() as i32),
                         }) {
                             Ok(json) => {
-                                handle_error(
+                                handle_backend_error(
                                     &out_stream_tx,
                                     Status::with_details(
                                         Code::Internal,


### PR DESCRIPTION
This pull request refactors error handling for both download and upload gRPC server handlers by introducing a new asynchronous function to handle backend errors in a consistent and reusable way. The main focus is on improving code maintainability and clarity in error reporting.

Refactoring error handling:

* Added a new async function `handle_backend_error` in both `DfdaemonDownloadServerHandler` and `DfdaemonUploadServerHandler` to encapsulate the logic for sending backend errors to the output stream, replacing the previous direct calls to `handle_error` (`dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`). [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR430-R440) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R430-R440)
* Updated error handling calls to use the new `handle_backend_error` function instead of the previous `handle_error` function in both server handlers (`dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`). [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL579-R590) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L555-R566)<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
