### PR TITLE
feat(grpc): add timeout to sync pieces requests

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -155,7 +155,7 @@ fn default_download_piece_timeout() -> Duration {
 /// default_collected_download_piece_timeout is the default timeout for collecting one piece from the parent in the stream.
 #[inline]
 fn default_collected_download_piece_timeout() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(90)
 }
 
 /// default_download_concurrent_piece_count is the default number of concurrent pieces to download.

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -2010,8 +2010,11 @@ impl DfdaemonUploadClient {
     pub async fn sync_pieces(
         &self,
         request: SyncPiecesRequest,
+        collected_piece_timeout: Duration,
     ) -> ClientResult<tonic::Response<tonic::codec::Streaming<SyncPiecesResponse>>> {
-        let request = Self::make_request(request);
+        let mut request = tonic::Request::new(request);
+        request.set_timeout(collected_piece_timeout);
+
         let response = self.client.clone().sync_pieces(request).await?;
         Ok(response)
     }
@@ -2106,9 +2109,12 @@ impl DfdaemonUploadClient {
     pub async fn sync_persistent_cache_pieces(
         &self,
         request: SyncPersistentCachePiecesRequest,
+        collected_piece_timeout: Duration,
     ) -> ClientResult<tonic::Response<tonic::codec::Streaming<SyncPersistentCachePiecesResponse>>>
     {
-        let request = Self::make_request(request);
+        let mut request = tonic::Request::new(request);
+        request.set_timeout(collected_piece_timeout);
+
         let response = self
             .client
             .clone()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request improves the handling of timeouts when syncing pieces and persistent cache pieces by allowing a configurable timeout to be set for gRPC requests. The changes ensure that the piece collection process uses the appropriate timeout for waiting on metadata responses, enhancing reliability and control over network operations.

**Timeout handling improvements:**

* Updated the `sync_pieces` and `sync_persistent_cache_pieces` methods in `DfdaemonUploadClient` to accept a `collected_piece_timeout` parameter and set this as the timeout for the gRPC request. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R2013-R2017) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R2112-R2117)
* Modified `PieceCollector` and `PersistentCachePieceCollector` to pass the `collected_piece_timeout` to the respective client methods when requesting piece metadata, ensuring timeouts are enforced at the call site. [[1]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L213-R224) [[2]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L470-R484)

**Client instantiation update:**

* Changed the instantiation of `DfdaemonUploadClient` in `PieceCollector` to use a boolean flag (`true`) indicating that the piece download timeout should be used for the metadata response, clarifying the intended behavior.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
