### PR TITLE
refactor(pool): update client factory to use address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,9 +1103,11 @@ dependencies = [
 name = "dragonfly-client-backend"
 version = "1.0.35"
 dependencies = [
+ "dashmap",
  "dragonfly-api",
  "dragonfly-client-core",
  "dragonfly-client-util",
+ "fastrand",
  "futures",
  "hyper 1.6.0",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ tonic-health = "0.12.3"
 hashring = "0.3.6"
 reqwest-tracing = "0.5"
 mocktail = "0.3.0"
+fastrand = "2.3.0"
 
 [profile.release]
 opt-level = 3

--- a/dragonfly-client-backend/Cargo.toml
+++ b/dragonfly-client-backend/Cargo.toml
@@ -26,6 +26,8 @@ opendal.workspace = true
 percent-encoding.workspace = true
 futures.workspace = true
 reqwest-tracing.workspace = true
+fastrand.workspace = true
+dashmap.workspace = true
 reqwest-retry = "0.7"
 libloading = "0.8.9"
 

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -69,6 +69,7 @@ vortex-protocol.workspace = true
 dashmap.workspace = true
 tonic-health.workspace = true
 hashring.workspace = true
+fastrand.workspace = true
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "chrono"] }
 tracing-panic = "0.1.2"
@@ -80,14 +81,12 @@ opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_
 rolling-file = "0.2.0"
 pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"] }
 prometheus = { version = "0.13", features = ["process"] }
-
 tower = { version = "0.4.13", features = ["limit", "load-shed", "buffer"] }
 indicatif = "0.18.0"
 http-body-util = "0.1.3"
 termion = "4.0.5"
 tabled = "0.20.0"
 path-absolutize = "3.1.1"
-fastrand = "2.3.0"
 glob = "0.3.3"
 console-subscriber = "0.4.1"
 scopeguard = "1.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the client pool implementation to support both a key and an address for client management, enabling more flexible connection handling and improved concurrency. The change is applied across the utility crate and all downloader types (gRPC, QUIC, TCP), and introduces a mechanism to distribute connections per address using randomized keys. Test code and usage patterns are also updated to reflect the new API.

### Client Pool API and Type Refactoring

* Changed the generic parameters for `Factory`, `Pool`, and `Builder` to separate key (`K`) and address (`A`) types, and updated all related methods and implementations to require both key and address when creating or retrieving clients. This allows for more flexible client identification and management. [[1]](diffhunk://#diff-52920cc7a57935a341b69eb40862109c05e0cff53bb5b20fc00786e89a92496cL102-R110) [[2]](diffhunk://#diff-52920cc7a57935a341b69eb40862109c05e0cff53bb5b20fc00786e89a92496cR127-R145) [[3]](diffhunk://#diff-52920cc7a57935a341b69eb40862109c05e0cff53bb5b20fc00786e89a92496cL167-R177) [[4]](diffhunk://#diff-52920cc7a57935a341b69eb40862109c05e0cff53bb5b20fc00786e89a92496cL186-R198) [[5]](diffhunk://#diff-52920cc7a57935a341b69eb40862109c05e0cff53bb5b20fc00786e89a92496cL209-R214)

### Downloader Implementations: Improved Connection Distribution

* Updated `GRPCDownloader`, `QUICDownloader`, and `TCPDownloader` to use the new pool API, introducing a `get_entry_key` method that generates a semi-random key per address to allow multiple concurrent connections to the same address, and updated all usages to pass both key and address. This helps distribute load and avoid contention on a single connection per address. [[1]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L125-R132) [[2]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L142-R166) [[3]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L164-R183) [[4]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L184-R203) [[5]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L232-R252) [[6]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L252-R272) [[7]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L296-R316) [[8]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R337-R339) [[9]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L330-R369) [[10]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L352-R386) [[11]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L361-R395) [[12]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L377-R412) [[13]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L390-R425) [[14]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L402-R437) [[15]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R458-R460) [[16]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L436-R491) [[17]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L458-R508) [[18]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L467-R517)

### Test and Usage Updates

* Updated all test and usage code to use the new `entry(&key, &addr)` API, ensuring that both key and address are provided when retrieving or creating clients from the pool. [[1]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L325-R325) [[2]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L454-R455) [[3]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L710-R718) [[4]](diffhunk://#diff-fa1268097df5106739708976eb7640440dd6f057e9c7f60745b3bb1dd8194225L730-R739)

### Connection Management Enhancements

* Added a constant `MAX_CONNECTIONS_PER_ADDRESS` to each downloader type, limiting the number of concurrent connections per address and using this in key randomization to distribute connections. [[1]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L125-R132) [[2]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R337-R339) [[3]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4R458-R460)

### Cleanup and Idle Client Handling

* Updated client removal and cleanup logic to use the new key/address scheme, ensuring that idle or failed clients are properly removed based on their unique key. [[1]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L142-R166) [[2]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L330-R369) [[3]](diffhunk://#diff-53eaf4b7e9d819d0105f0f0a5c6af8421891328cb381e5c0502f3a5afb47e9c4L436-R491)

Let me know if you want to walk through how this affects usage or if you have questions about the new key/address separation!
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
