### PR TITLE
chore(deps): update version to 1.0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "anyhow",
  "clap",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "bincode",
  "bytes",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.35"
+version = "1.0.36"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.35" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.35" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.35" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.35" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.35" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.35" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.35" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.35" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.36" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.36" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.36" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.36" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.36" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.36" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.36" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.36" }
 dragonfly-api = "=2.1.80"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -160,15 +160,13 @@ impl HTTP {
                 Ok(client)
             }
             // Default TLS client config with no validation.
-            None => {
-                match self
-                    .clients
-                    .entry(fastrand::usize(0..Self::MAX_CONNECTIONS_PER_ADDRESS))
-                {
-                    Entry::Occupied(o) => Ok(o.get().clone()),
-                    Entry::Vacant(_) => Err(Error::Unknown("reqwest client not found".to_string())),
-                }
-            }
+            None => match self
+                .clients
+                .entry(fastrand::usize(..Self::MAX_CONNECTIONS_PER_ADDRESS))
+            {
+                Entry::Occupied(o) => Ok(o.get().clone()),
+                Entry::Vacant(_) => Err(Error::Unknown("reqwest client not found".to_string())),
+            },
         }
     }
 }

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -20,10 +20,10 @@ pub mod tcp;
 use std::time::Duration;
 
 /// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
-const DEFAULT_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_SEND_BUFFER_SIZE: usize = 32 * 1024 * 1024;
 
 /// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
-const DEFAULT_RECV_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_RECV_BUFFER_SIZE: usize = 32 * 1024 * 1024;
 
 /// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
 const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -20,10 +20,10 @@ pub mod tcp;
 use std::time::Duration;
 
 /// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
-const DEFAULT_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_SEND_BUFFER_SIZE: usize = 32 * 1024 * 1024;
 
 /// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
-const DEFAULT_RECV_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_RECV_BUFFER_SIZE: usize = 32 * 1024 * 1024;
 
 /// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
 const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request primarily updates the workspace and dependency versions for all `dragonfly-client` crates from `1.0.35` to `1.0.36`, and includes a minor code simplification in the HTTP backend. These changes help keep the project dependencies consistent and improve code readability.

Version updates:

* Updated the workspace package version in `Cargo.toml` from `1.0.35` to `1.0.36`.
* Bumped all `dragonfly-client` dependency versions in `Cargo.toml` from `1.0.35` to `1.0.36` for consistency across the workspace.

Codebase simplification:

* Simplified the match statement for client retrieval in `dragonfly-client-backend/src/http.rs` by using the range syntax `..Self::MAX_CONNECTIONS_PER_ADDRESS` and removing unnecessary braces, improving readability.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
