### PR TITLE
fix(grpc): handle missing tasks in upload process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "bincode",
  "bytes",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.36"
+version = "1.0.37"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.36" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.36" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.36" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.36" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.36" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.36" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.36" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.36" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.37" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.37" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.37" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.37" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.37" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.37" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.37" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.37" }
 dragonfly-api = "=2.1.80"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the `DfdaemonUploadServerHandler` implementation in `dragonfly-client/src/grpc/dfdaemon_upload.rs` to improve task management and error handling. The main changes focus on consistently using the persistent cache task manager instead of the previous task manager and providing clearer error reporting when tasks are missing.

**Task management improvements:**

* Replaced usage of `self.task` and `task_manager` with `self.persistent_cache_task` and `persistent_cache_task_manager` throughout the handler to ensure that persistent cache tasks are managed correctly.
* Updated piece retrieval logic to use `persistent_cache_task_manager.piece` instead of the previous task manager, aligning with the persistent cache approach.

**Error handling enhancements:**

* Added checks for missing tasks and persistent cache tasks, logging errors and sending internal error statuses to the output stream if the requested task is not found. This prevents further processing and provides clearer feedback. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R892-R906) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1628-R1647)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
