### PR TITLE
chore(deps): update dragonfly-client dependencies to 1.0.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "headers 0.4.1",
  "hyper 1.6.0",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "bincode",
  "bytes",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.37"
+version = "1.0.38"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.0.37" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.37" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.37" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.37" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.37" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.37" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.37" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.37" }
+dragonfly-client = { path = "dragonfly-client", version = "1.0.38" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.0.38" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.0.38" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.0.38" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.0.38" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.0.38" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.0.38" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.0.38" }
 dragonfly-api = "=2.1.80"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace and dependency versions in the `Cargo.toml` file to `1.0.38`. This ensures that all internal packages consistently use the latest release version.

Version updates:

* Bumped the workspace package version from `1.0.37` to `1.0.38` in `Cargo.toml`.
* Updated all internal workspace dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-metric`, `dragonfly-client-util`, `dragonfly-client-init`) to version `1.0.38` in `Cargo.toml`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
