### PR TITLE
docs(readme): update GitHub Discussions link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find the full documentation on the [d7y.io](https://d7y.io).
 Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum][https://github.com/dragonflyoss/dragonfly/discussions]
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Mailing Lists**:
   - **Developers**: <dragonfly-developers@googlegroups.com>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small correction to the `README.md` file, fixing the markdown link syntax for the Github Discussions section to ensure the link is rendered properly.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4425
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
