### PR TITLE
Fix Missing Query Parameters

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1059,13 +1059,25 @@ fn make_registry_mirror_request(
 ) -> ClientResult<Request<hyper::body::Incoming>> {
     let header = request.headers().clone();
     let registry_mirror_uri = match header::get_registry(&header) {
-        Some(registry) => format!("{}{}", registry, request.uri().path())
-            .parse::<http::Uri>()
-            .or_err(ErrorType::ParseError)?,
+        Some(registry) => format!(
+            "{}{}",
+            registry,
+            request
+                .uri()
+                .path_and_query()
+                .map(|v| v.as_str())
+                .unwrap_or("/")
+        )
+        .parse::<http::Uri>()
+        .or_err(ErrorType::ParseError)?,
         None => format!(
             "{}{}",
             config.proxy.registry_mirror.addr,
-            request.uri().path()
+            request
+                .uri()
+                .path_and_query()
+                .map(|v| v.as_str())
+                .unwrap_or("/")
         )
         .parse::<http::Uri>()
         .or_err(ErrorType::ParseError)?,


### PR DESCRIPTION
Fix: Preserve Query Parameters in Proxy Requests

## Description

This PR fixes a bug in the seedclient's proxy module where query parameters from the original request URI were being stripped when forwarding requests to the backend registry (e.g., Harbor). Specifically, the `make_registry_mirror_request` function in `dragonfly-client/src/proxy/mod.rs` was only using `request.uri().path()`, which excludes the query string. This change modifies the code to use `request.uri().path_and_query()` to ensure the complete URI, including path and query parameters, is forwarded.

## Related Issue

Fixes https://github.com/dragonflyoss/client/issues/1463

## Motivation and Context

This change is required to resolve failures in `docker pull` operations when using the seedclient proxy in an architecture like `docker --> seed client --> proxy --> harbor`. The missing query parameters (e.g., `account`, `scope`, `service` for authentication and authorization) caused the backend registry (Harbor) to reject requests, leading to pull failures. This PR ensures the registry receives all necessary information from the original request URI.

## Screenshots (if appropriate)
N/A