### PR TITLE
refactor(client, server): update default buffer sizes and keepalive settings

### DIFF
--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -20,13 +20,19 @@ pub mod tcp;
 use std::time::Duration;
 
 /// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
-const DEFAULT_SEND_BUFFER_SIZE: usize = 32 * 1024 * 1024;
+const DEFAULT_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
 /// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
-const DEFAULT_RECV_BUFFER_SIZE: usize = 32 * 1024 * 1024;
+const DEFAULT_RECV_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
 /// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
-const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(3);
+
+/// DEFAULT_KEEPALIVE_TIME is the default time before starting keepalive messages.
+const DEFAULT_KEEPALIVE_TIME: Duration = Duration::from_secs(5);
+
+/// DEFAULT_KEEPALIVE_RETRIES is the default number of keepalive retries.
+const DEFAULT_KEEPALIVE_RETRIES: u32 = 3;
 
 /// DEFAULT_MAX_IDLE_TIMEOUT is the default maximum idle timeout for connections.
-const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(60);

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -27,7 +27,7 @@ use tokio::io::{
     self, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter, SeekFrom,
 };
 use tokio_util::io::InspectReader;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use walkdir::WalkDir;
 
 /// Content is the content of a piece.
@@ -343,6 +343,7 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
+        let reader = reader.take(expected_length);
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
@@ -352,6 +353,7 @@ impl Content {
             hasher.update(bytes);
         });
 
+        debug!("start to write piece to {:?}", task_path);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;
@@ -570,6 +572,7 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
+        let reader = reader.take(expected_length);
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
@@ -579,6 +582,7 @@ impl Content {
             hasher.update(bytes);
         });
 
+        debug!("start to write piece to {:?}", task_path);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -27,7 +27,7 @@ use tokio::io::{
     self, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter, SeekFrom,
 };
 use tokio_util::io::InspectReader;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use walkdir::WalkDir;
 
 /// Content is the content of a piece.
@@ -343,6 +343,7 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
+        let reader = reader.take(expected_length);
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
@@ -352,6 +353,7 @@ impl Content {
             hasher.update(bytes);
         });
 
+        debug!("start to write piece to {:?}", task_path);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;
@@ -570,6 +572,7 @@ impl Content {
             error!("seek {:?} failed: {}", task_path, err);
         })?;
 
+        let reader = reader.take(expected_length);
         let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
@@ -579,6 +582,7 @@ impl Content {
             hasher.update(bytes);
         });
 
+        debug!("start to write piece to {:?}", task_path);
         let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
             error!("copy {:?} failed: {}", task_path, err);
         })?;

--- a/dragonfly-client-storage/src/server/mod.rs
+++ b/dragonfly-client-storage/src/server/mod.rs
@@ -20,13 +20,19 @@ pub mod tcp;
 use std::time::Duration;
 
 /// DEFAULT_SEND_BUFFER_SIZE is the default size of the send buffer for network connections.
-const DEFAULT_SEND_BUFFER_SIZE: usize = 32 * 1024 * 1024;
+const DEFAULT_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
 /// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
-const DEFAULT_RECV_BUFFER_SIZE: usize = 32 * 1024 * 1024;
+const DEFAULT_RECV_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
 /// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
-const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(3);
+
+/// DEFAULT_KEEPALIVE_TIME is the default time before starting keepalive messages.
+const DEFAULT_KEEPALIVE_TIME: Duration = Duration::from_secs(5);
+
+/// DEFAULT_KEEPALIVE_RETRIES is the default number of keepalive retries.
+const DEFAULT_KEEPALIVE_RETRIES: u32 = 3;
 
 /// DEFAULT_MAX_IDLE_TIMEOUT is the default maximum idle timeout for connections.
-const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(60);

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -102,7 +102,10 @@ impl TCPServer {
         socket.set_send_buffer_size(super::DEFAULT_SEND_BUFFER_SIZE)?;
         socket.set_recv_buffer_size(super::DEFAULT_RECV_BUFFER_SIZE)?;
         socket.set_tcp_keepalive(
-            &TcpKeepalive::new().with_interval(super::DEFAULT_KEEPALIVE_INTERVAL),
+            &TcpKeepalive::new()
+                .with_interval(super::DEFAULT_KEEPALIVE_INTERVAL)
+                .with_time(super::DEFAULT_KEEPALIVE_TIME)
+                .with_retries(super::DEFAULT_KEEPALIVE_RETRIES),
         )?;
         #[cfg(target_os = "linux")]
         {
@@ -509,6 +512,7 @@ impl TCPServerHandler {
         stream: &mut R,
         writer: &mut OwnedWriteHalf,
     ) -> ClientResult<()> {
+        debug!("start to write stream to tcp writer");
         copy(stream, writer).await.inspect_err(|err| {
             error!("copy failed: {}", err);
         })?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the default network connection settings for both the client and server in the `dragonfly-client-storage` crate. The main changes focus on reducing buffer sizes, tightening keepalive and idle timeout settings, and enhancing TCP keepalive configuration for improved connection management.

**Network Buffer and Timeout Adjustments:**

- Reduced the default send and receive buffer sizes from 32MB to 16MB in both `client/mod.rs` and `server/mod.rs` to lower memory usage per connection.
- Decreased the default keepalive interval from 5 seconds to 3 seconds, and the maximum idle timeout from 300 seconds to 60 seconds, making connections more responsive to inactivity.

**TCP Keepalive Enhancements:**

- Introduced new TCP keepalive settings: added `DEFAULT_KEEPALIVE_TIME` (5 seconds before starting keepalives) and `DEFAULT_KEEPALIVE_RETRIES` (3 retries before considering the connection dead) in both client and server modules.
- Updated TCP socket configuration in both `TCPClient` and `TCPServer` to use the new keepalive time and retries, in addition to the interval, for more robust dead connection detection. [[1]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL182-R185) [[2]](diffhunk://#diff-e6030761b3759d42663011530a4dd2aacabf42891109d7be3965239b7c8ed048L105-R108)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
