### PR TITLE
refactor(dfdaemon): parent selector for selecting piece

### DIFF
--- a/dragonfly-client-util/src/net/mod.rs
+++ b/dragonfly-client-util/src/net/mod.rs
@@ -59,7 +59,7 @@ pub struct NetworkData {
 /// Interface methods provide functionality to get network interface information.
 impl Interface {
     /// DEFAULT_NETWORKS_REFRESH_INTERVAL is the default interval for refreshing network data.
-    const DEFAULT_NETWORKS_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+    const DEFAULT_NETWORKS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
     /// new creates a new Interface instance based on the provided IP address and rate limit.
     pub fn new(ip: IpAddr, rate_limit: ByteSize) -> Interface {

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -150,12 +150,8 @@ impl SeedPeerSelector {
                     hashring.add(addr);
                     hosts.insert(addr.to_string(), peer);
                 }
-                Ok(Err(err)) => {
-                    error!("health check error: {}", err);
-                }
-                Err(join_err) => {
-                    error!("task join error: {}", join_err);
-                }
+                Ok(Err(err)) => error!("health check failed: {}", err),
+                Err(err) => error!("task join error: {}", err),
             }
         }
 

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -24,9 +24,7 @@ use dragonfly_client::grpc::{
 };
 use dragonfly_client::health::Health;
 use dragonfly_client::proxy::Proxy;
-use dragonfly_client::resource::{
-    parent_selector::ParentSelector, persistent_cache_task::PersistentCacheTask, task::Task,
-};
+use dragonfly_client::resource::{persistent_cache_task::PersistentCacheTask, task::Task};
 use dragonfly_client::stats::Stats;
 use dragonfly_client::tracing::init_tracing;
 use dragonfly_client_backend::BackendFactory;
@@ -247,16 +245,6 @@ async fn main() -> Result<(), anyhow::Error> {
             .build(),
     );
 
-    // Initialize parent selector.
-    let parent_selector = ParentSelector::new(
-        config.clone(),
-        id_generator.host_id(),
-        id_generator.peer_id(),
-        shutdown.clone(),
-        shutdown_complete_tx.clone(),
-    );
-    let parent_selector = Arc::new(parent_selector);
-
     // Initialize task manager.
     let task = Task::new(
         config.clone(),
@@ -267,7 +255,8 @@ async fn main() -> Result<(), anyhow::Error> {
         download_rate_limiter.clone(),
         upload_rate_limiter.clone(),
         prefetch_rate_limiter.clone(),
-        parent_selector.clone(),
+        shutdown.clone(),
+        shutdown_complete_tx.clone(),
     )?;
     let task = Arc::new(task);
 
@@ -281,6 +270,8 @@ async fn main() -> Result<(), anyhow::Error> {
         download_rate_limiter.clone(),
         upload_rate_limiter.clone(),
         prefetch_rate_limiter.clone(),
+        shutdown.clone(),
+        shutdown_complete_tx.clone(),
     )?;
     let persistent_cache_task = Arc::new(persistent_cache_task);
 

--- a/dragonfly-client/src/resource/parent_selector.rs
+++ b/dragonfly-client/src/resource/parent_selector.rs
@@ -17,10 +17,9 @@
 use crate::grpc::dfdaemon_upload::DfdaemonUploadClient;
 use crate::resource::piece_collector::CollectedParent;
 use dashmap::DashMap;
-use dragonfly_api::common::v2::{Host, Peer};
+use dragonfly_api::common::v2::{Host, Peer, PersistentCachePeer};
 use dragonfly_api::dfdaemon::v2::SyncHostRequest;
 use dragonfly_client_config::dfdaemon::Config;
-use dragonfly_client_core::Error;
 use dragonfly_client_core::Result;
 use dragonfly_client_util::id_generator::IDGenerator;
 use dragonfly_client_util::shutdown::{self, Shutdown};
@@ -28,184 +27,318 @@ use rand::distr::weighted::WeightedIndex;
 use rand::distr::Distribution;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, warn, Instrument};
 
-/// Connection manages a single parent connection.
+/// Manages a single persistent connection to a parent peer.
+///
+/// This structure tracks the gRPC client, reference count of active requests,
+/// and shutdown signaling for background synchronization tasks.
 struct Connection {
-    /// client is the dfdaemon upload client for this parent.
-    client: DfdaemonUploadClient,
+    /// Number of active requests currently using this connection.
+    /// Used for reference counting to determine when cleanup is safe.
+    active_requests: Arc<AtomicUsize>,
 
-    /// connection_guard tracks how many download tasks are using this connection.
-    connection_guard: ConnectionGuard,
-
-    /// shutdown is used to signal the sync host to stop.
+    /// Shutdown signal to stop the background host sync task.
     shutdown: Shutdown,
 }
 
+/// Implements lifecycle management for parent peer connections.
 impl Connection {
-    /// new creates a new Connection.
-    pub fn new(client: DfdaemonUploadClient) -> Self {
+    /// Creates a new connection wrapper with zero active requests.
+    pub fn new() -> Self {
         Self {
-            client,
-            connection_guard: ConnectionGuard::new(Arc::new(AtomicUsize::new(0))),
+            active_requests: Arc::new(AtomicUsize::new(0)),
             shutdown: Shutdown::new(),
         }
     }
 
-    /// connection_guard increments the reference count.
-    pub fn connection_guard(&self) {
-        self.connection_guard.acquire();
-    }
-
-    /// active_count returns the number of active requests.
+    /// Returns the current number of active requests using this connection.
     pub fn active_requests(&self) -> usize {
-        self.connection_guard.active_requests()
+        self.active_requests.load(Ordering::SeqCst)
     }
 
-    /// release_request decrements the reference count.
-    pub fn release_request(&self) {
-        self.connection_guard.release();
+    /// Increments the active request counter.
+    pub fn increment_request(&self) {
+        self.active_requests.fetch_add(1, Ordering::SeqCst);
     }
 
-    /// shutdown triggers shutdown of the sync host.
+    /// Decrements the active request counter.
+    pub fn decrement_request(&self) {
+        self.active_requests.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    /// Triggers shutdown of the background host synchronization task.
     pub fn shutdown(&self) {
         self.shutdown.trigger();
     }
 }
 
-/// ConnectionGuard automatically manages reference counting for parent connections.
-pub struct ConnectionGuard {
-    active_requests: Arc<AtomicUsize>,
-}
-
-impl ConnectionGuard {
-    fn new(active_connections: Arc<AtomicUsize>) -> Self {
-        Self {
-            active_requests: active_connections,
-        }
-    }
-
-    fn active_requests(&self) -> usize {
-        self.active_requests.load(Ordering::SeqCst)
-    }
-
-    fn acquire(&self) {
-        self.active_requests.fetch_add(1, Ordering::SeqCst);
-    }
-
-    fn release(&self) {
-        self.active_requests.fetch_sub(1, Ordering::SeqCst);
-    }
-}
-
-impl Drop for ConnectionGuard {
-    fn drop(&mut self) {
-        self.active_requests.fetch_sub(1, Ordering::SeqCst);
-    }
-}
-
-/// ParentSelector manages parent connections and selects optimal parents.
+/// ParentSelector is the download parent selector configuration for dfdaemon. It will synchronize
+/// the host info in real-time from the parents and then select the parents for downloading.
+///
+/// The workflow diagram is as follows:
+///
+///```text
+///                              +----------+
+///              ----------------|  Parent  |---------------
+///              |               +----------+              |
+///          Host Load Quality                     Piece Metadata
+/// +------------|-----------------------------------------|------------+
+/// |            |                                         |            |
+/// |            |                 Peer                    |            |
+/// |            v                                         v            |
+/// |  +------------------+  Select Best Parent   +------------------+  |
+/// |  |  ParentSelector  | ------------------->  |  PieceCollector  |  |
+/// |  +------------------+                       +------------------+  |
+/// |                                                      |            |
+/// |                                             Download Piece From   |
+/// |                                                  Best Parent      |
+/// |                                                      |            |
+/// |                                                      v            |
+/// |                                                +------------+     |
+/// |                                                |  Download  |     |
+/// |                                                +------------+     |
+/// +-------------------------------------------------------------------+
+/// ```
 pub struct ParentSelector {
-    /// config is the configuration of the dfdaemon.
+    /// Config is the configuration of the dfdaemon.
     config: Arc<Config>,
 
-    /// timeout is the timeout for the sync host.
-    timeout: Duration,
+    /// Generator for host and peer identifiers.
+    id_generator: Arc<IDGenerator>,
 
-    /// host_id is the id of the host.
-    host_id: String,
-
-    /// peer_id is the id of the peer.
-    peer_id: String,
-
-    /// weights stores the latest host information and bandwidth weights for different parents.
+    /// Maps parent host IDs to their current bandwidth weights.
     weights: Arc<DashMap<String, u32>>,
 
-    /// connections stores parent connections with reference counting.
+    /// Active connections indexed by parent host ID and each connection tracks usage and manages its sync task.
     connections: Arc<DashMap<String, Connection>>,
 
-    /// shutdown is used to shutdown the garbage collector.
+    /// Global shutdown signal for the entire daemon.
     shutdown: shutdown::Shutdown,
 
     /// _shutdown_complete is used to notify the garbage collector is shutdown.
     _shutdown_complete: mpsc::UnboundedSender<()>,
 }
 
-/// ParentSelector implements the parent selector.
+/// Implements parent peer selection and connection management logic.
 impl ParentSelector {
-    /// new returns a ParentSelector.
+    /// Creates a new parent selector instance.
     #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
-        host_id: String,
-        peer_id: String,
+        id_generator: Arc<IDGenerator>,
         shutdown: shutdown::Shutdown,
         shutdown_complete_tx: mpsc::UnboundedSender<()>,
     ) -> ParentSelector {
-        let config = config.clone();
-        let timeout = config.download.parent_selector.timeout;
-        let weights = Arc::new(DashMap::new());
-
         Self {
             config,
-            timeout,
-            host_id,
-            peer_id,
-            weights,
+            id_generator,
+            weights: Arc::new(DashMap::new()),
             connections: Arc::new(DashMap::new()),
             shutdown,
             _shutdown_complete: shutdown_complete_tx,
         }
     }
 
-    /// sync_host is a sub thread to sync host info from the parent.
+    /// Selects the best parent from a list of candidates based on their load quality weights.
+    ///
+    /// This function performs weighted random selection where parents with higher weights
+    /// (better idle bandwidth) have a higher probability of being selected. If weight
+    /// calculation fails, falls back to uniform random selection.
+    pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
+        let weights: Vec<u32> = parents
+            .iter()
+            .map(|parent| {
+                let Some(parent_host) = parent.host.as_ref() else {
+                    warn!(
+                        "parent {} has no host info, defaulting weight to 0",
+                        parent.id
+                    );
+
+                    return 0;
+                };
+                let parent_host_id = parent_host.id.clone();
+
+                self.weights
+                    .get(&parent_host_id)
+                    .map(|w| *w)
+                    .unwrap_or_else(|| {
+                        warn!(
+                            "no weight info for parent {} {}, defaulting weight to 0",
+                            parent.id, parent_host_id
+                        );
+
+                        0
+                    })
+            })
+            .collect();
+
+        match WeightedIndex::new(weights) {
+            Ok(dist) => {
+                let mut rng = rand::rng();
+                let index = dist.sample(&mut rng);
+                let selected_parent = &parents[index];
+                debug!("selected parent {}", selected_parent.id);
+
+                selected_parent.clone()
+            }
+            Err(_) => parents[fastrand::usize(..parents.len())].clone(),
+        }
+    }
+
+    /// Registers multiple parents for host information synchronization.
+    ///
+    /// For each parent, this function:
+    /// - Creates a new gRPC connection if one doesn't exist.
+    /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
+    /// - Updates the connection's request counter.
+    pub async fn register(&self, parents: &[Peer]) -> Result<()> {
+        let dfdaemon_shutdown = self.shutdown.clone();
+        let mut join_set = JoinSet::new();
+        for parent in parents {
+            info!("register parent {}", parent.id);
+
+            let Some(parent_host) = parent.host.as_ref() else {
+                warn!("parent {} has no host info, skipping", parent.id);
+                continue;
+            };
+            let parent_host_id = parent_host.id.clone();
+
+            match self.connections.entry(parent_host_id.clone()) {
+                dashmap::mapref::entry::Entry::Occupied(entry) => {
+                    entry.get().increment_request();
+                    continue;
+                }
+                dashmap::mapref::entry::Entry::Vacant(entry) => {
+                    let dfdaemon_upload_client = DfdaemonUploadClient::new(
+                        self.config.clone(),
+                        format!("http://{}:{}", parent_host.ip, parent_host.port),
+                        false,
+                    )
+                    .await?;
+
+                    let connection = Connection::new();
+                    connection.increment_request();
+                    let shutdown = connection.shutdown.clone();
+                    entry.insert(connection);
+
+                    let weights = self.weights.clone();
+                    let host_id = self.id_generator.host_id();
+                    let peer_id = self.id_generator.peer_id();
+                    let dfdaemon_shutdown_clone = dfdaemon_shutdown.clone();
+                    join_set.spawn(
+                        Self::sync_host(
+                            host_id,
+                            peer_id,
+                            parent_host_id.clone(),
+                            weights,
+                            dfdaemon_upload_client,
+                            shutdown,
+                            dfdaemon_shutdown_clone,
+                        )
+                        .in_current_span(),
+                    );
+                }
+            }
+        }
+
+        tokio::spawn(async move {
+            while let Some(message) = join_set.join_next().await {
+                match message {
+                    Ok(Ok(_)) => debug!("sync host info completed"),
+                    Ok(Err(err)) => error!("sync host info failed: {}", err),
+                    Err(err) => error!("task join error: {}", err),
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Unregisters multiple parents and cleans up their connections.
+    ///
+    /// Decrements the request counter for each parent's connection. When a connection's
+    /// active request count reaches zero, it:
+    /// - Triggers connection shutdown.
+    /// - Removes the weight entry.
+    /// - Removes the connection from the pool.
+    pub fn unregister(&self, parents: &[Peer]) {
+        for parent in parents {
+            info!("unregister parent {}", parent.id);
+
+            let Some(parent_host) = parent.host.as_ref() else {
+                warn!("parent {} has no host info, skipping", parent.id);
+                continue;
+            };
+            let parent_host_id = parent_host.id.clone();
+
+            if let Some(connection) = self.connections.get(&parent_host_id) {
+                connection.decrement_request();
+                if connection.active_requests() == 0 {
+                    info!("cleaning up parent {} connection", parent_host_id);
+                    connection.shutdown();
+
+                    // Explicitly drop the reference to avoid holding the borrow
+                    // from self.connections.get() while trying to call remove().
+                    drop(connection);
+                    self.weights.remove(&parent_host_id);
+                    self.connections.remove(&parent_host_id);
+                }
+            }
+        }
+    }
+
+    /// Continuously synchronizes host metrics from a parent peer.
+    ///
+    /// This is a long-running background task that:
+    /// - Establishes a streaming gRPC connection to the parent.
+    /// - Receives periodic host status updates (CPU, bandwidth, etc.).
+    /// - Updates the parent's weight based on idle TX bandwidth.
+    /// - Runs until shutdown signal or connection failure.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     async fn sync_host(
         host_id: String,
         peer_id: String,
-        remote_host_id: String,
+        parent_host_id: String,
         weights: Arc<DashMap<String, u32>>,
-        timeout: Duration,
-        client: DfdaemonUploadClient,
+        dfdaemon_upload_client: DfdaemonUploadClient,
         mut shutdown: Shutdown,
         mut dfdaemon_shutdown: Shutdown,
     ) -> Result<()> {
-        let response = client
+        info!("sync host info from parent {}", parent_host_id);
+        let response = dfdaemon_upload_client
             .sync_host(SyncHostRequest { host_id, peer_id })
             .await
             .inspect_err(|err| {
-                error!("sync host from host {} failed: {}", remote_host_id, err);
+                error!(
+                    "sync host info from parent {} failed: {}",
+                    parent_host_id, err
+                );
             })?;
 
-        let out_stream = response.into_inner().timeout(timeout);
+        let out_stream = response.into_inner();
         tokio::pin!(out_stream);
-
         loop {
             tokio::select! {
                 result = out_stream.try_next() => {
                     match result.inspect_err(|err| {
-                        error!("sync host from host {} failed: {}", remote_host_id, err);
+                        error!("sync host info from parent {} failed: {}", parent_host_id, err);
                     })? {
                         Some(message) => {
-                            debug!("sync host from host {} received message", remote_host_id);
-                            let message = message?;
+                            let idle_tx_bandwidth = Self::get_idle_tx_bandwidth(&message);
 
-                            // Calculate weight from host information.
-                            let weight = Self::get_idle_upload_rate(&message) as u32;
-
-                            // Update the parent's host info with calculated weight.
-                            weights.insert(remote_host_id.clone(), weight);
+                            info!("update host {} idle TX bandwidth to {}", parent_host_id, idle_tx_bandwidth);
+                            weights.insert(parent_host_id.clone(), idle_tx_bandwidth as u32);
                         }
                         None => break,
                     }
                 }
                 _ = shutdown.recv() => {
-                    debug!("parent selector: shutdown signal received for host {}", remote_host_id);
+                    info!("sync host info from parent {} shutting down", parent_host_id);
                     break;
                 }
                 _ = dfdaemon_shutdown.recv() => {
@@ -218,22 +351,124 @@ impl ParentSelector {
         Ok(())
     }
 
-    /// select_parent selects the best parent for the task based on bandwidth.
-    pub fn select_parent(&self, parents: Vec<CollectedParent>) -> Option<CollectedParent> {
-        let remote_hosts: Vec<String> = parents
+    /// Calculates the idle transmission bandwidth of a host.
+    fn get_idle_tx_bandwidth(host: &Host) -> u64 {
+        let network = match &host.network {
+            Some(network) => network,
+            None => return 0,
+        };
+
+        debug!("host {} network info: {:?}", host.id, network);
+        let Some(tx_bandwidth) = network.tx_bandwidth else {
+            return 0;
+        };
+
+        if tx_bandwidth < network.max_tx_bandwidth {
+            network.max_tx_bandwidth - tx_bandwidth
+        } else {
+            0
+        }
+    }
+}
+
+/// PersistentCacheParentSelector is the download persistent cache parent selector configuration for dfdaemon. It will synchronize
+/// the host info in real-time from the parents and then select the parents for downloading.
+///
+/// The workflow diagram is as follows:
+///
+///```text
+///                              +----------+
+///              ----------------|  Parent  |---------------
+///              |               +----------+              |
+///          Host Load Quality                     Piece Metadata
+/// +------------|-----------------------------------------|------------+
+/// |            |                                         |            |
+/// |            |                 Peer                    |            |
+/// |            v                                         v            |
+/// |  +------------------+  Select Best Parent   +------------------+  |
+/// |  |  ParentSelector  | ------------------->  |  PieceCollector  |  |
+/// |  +------------------+                       +------------------+  |
+/// |                                                      |            |
+/// |                                             Download Piece From   |
+/// |                                                  Best Parent      |
+/// |                                                      |            |
+/// |                                                      v            |
+/// |                                                +------------+     |
+/// |                                                |  Download  |     |
+/// |                                                +------------+     |
+/// +-------------------------------------------------------------------+
+/// ```
+pub struct PersistentCacheParentSelector {
+    /// Config is the configuration of the dfdaemon.
+    config: Arc<Config>,
+
+    /// Generator for host and peer identifiers.
+    id_generator: Arc<IDGenerator>,
+
+    /// Maps parent host IDs to their current bandwidth weights.
+    weights: Arc<DashMap<String, u32>>,
+
+    /// Active connections indexed by parent host ID and each connection tracks usage and manages its sync task.
+    connections: Arc<DashMap<String, Connection>>,
+
+    /// Global shutdown signal for the entire daemon.
+    shutdown: shutdown::Shutdown,
+
+    /// _shutdown_complete is used to notify the garbage collector is shutdown.
+    _shutdown_complete: mpsc::UnboundedSender<()>,
+}
+
+/// Implements persistent cache parent peer selection and connection management logic.
+impl PersistentCacheParentSelector {
+    /// Creates a new persistent cache parent selector instance.
+    #[instrument(skip_all)]
+    pub fn new(
+        config: Arc<Config>,
+        id_generator: Arc<IDGenerator>,
+        shutdown: shutdown::Shutdown,
+        shutdown_complete_tx: mpsc::UnboundedSender<()>,
+    ) -> PersistentCacheParentSelector {
+        Self {
+            config,
+            id_generator,
+            weights: Arc::new(DashMap::new()),
+            connections: Arc::new(DashMap::new()),
+            shutdown,
+            _shutdown_complete: shutdown_complete_tx,
+        }
+    }
+
+    /// Selects the best persistent cache parent from a list of candidates based on their load quality weights.
+    ///
+    /// This function performs weighted random selection where parents with higher weights
+    /// (better idle bandwidth) have a higher probability of being selected. If weight
+    /// calculation fails, falls back to uniform random selection.
+    pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
+        let weights: Vec<u32> = parents
             .iter()
             .map(|parent| {
-                IDGenerator::new(
-                    parent.host.as_ref().unwrap().ip.clone(),
-                    parent.host.as_ref().unwrap().hostname.clone(),
-                    false,
-                )
-                .host_id()
+                let Some(parent_host) = parent.host.as_ref() else {
+                    warn!(
+                        "persistent cache parent {} has no host info, defaulting weight to 0",
+                        parent.id
+                    );
+
+                    return 0;
+                };
+                let parent_host_id = parent_host.id.clone();
+
+                self.weights
+                    .get(&parent_host_id)
+                    .map(|w| *w)
+                    .unwrap_or_else(|| {
+                        warn!(
+                            "no weight info for persistent cache parent {} {}, defaulting weight to 0",
+                            parent.id, parent_host_id
+                        );
+
+                        0
+                    })
             })
-            .collect();
-        let weights: Vec<u32> = remote_hosts
-            .iter()
-            .map(|remote_host| self.weights.get(remote_host).map(|w| *w).unwrap_or(0))
             .collect();
 
         match WeightedIndex::new(weights) {
@@ -241,151 +476,79 @@ impl ParentSelector {
                 let mut rng = rand::rng();
                 let index = dist.sample(&mut rng);
                 let selected_parent = &parents[index];
-                debug!("selected parent {}", selected_parent.id);
+                debug!("selected persistent cache parent {}", selected_parent.id);
 
-                Some(selected_parent.clone())
+                selected_parent.clone()
             }
-            Err(_) => parents.get(fastrand::usize(..parents.len())).cloned(),
+            Err(_) => parents[fastrand::usize(..parents.len())].clone(),
         }
     }
 
-    /// unregister_parents triggers shutdown.
-    pub fn unregister_parents(&self, parents: Vec<Peer>) {
-        for parent in parents {
-            let host_id = IDGenerator::new(
-                parent.host.as_ref().unwrap().ip.clone(),
-                parent.host.as_ref().unwrap().hostname.clone(),
-                false,
-            )
-            .host_id();
-
-            if let Some(connection) = self.connections.get(&host_id) {
-                connection.release_request();
-                if connection.active_requests() == 0 {
-                    info!("shutting down sync host for parent {}", host_id);
-                    connection.shutdown();
-                    drop(connection);
-                    self.weights.remove(&host_id);
-                    self.connections.remove(&host_id);
-                }
-            }
-        }
-    }
-
-    /// get_connection_client returns a client for the given parent, creating the connection if needed.
-    pub async fn get_connection_client(
-        &self,
-        parent: &Option<Host>,
-    ) -> Result<DfdaemonUploadClient> {
-        let Some(parent) = parent else {
-            error!("parent is not found");
-            return Err(Error::InvalidPeer(String::new()));
-        };
-
-        let remote_host_id =
-            IDGenerator::new(parent.ip.clone(), parent.hostname.clone(), false).host_id();
-
-        // Try to get existing connection
-        if let Some(connection) = self.connections.get(&remote_host_id) {
-            connection.connection_guard();
-            return Ok(connection.client.clone());
-        }
-
-        let client = DfdaemonUploadClient::new(
-            self.config.clone(),
-            format!("http://{}:{}", parent.ip, parent.port),
-            false,
-        )
-        .await?;
-
-        let connection = Connection::new(client.clone());
-        connection.connection_guard();
-
-        match self.connections.entry(remote_host_id.clone()) {
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                entry.insert(connection);
-                Ok(client)
-            }
-            dashmap::mapref::entry::Entry::Occupied(entry) => {
-                let existing_connection = entry.get();
-                existing_connection.connection_guard();
-                let client = existing_connection.client.clone();
-                Ok(client)
-            }
-        }
-    }
-
-    /// register_parents registers multiple parents.
-    pub async fn register_parents(&self, parents: &[CollectedParent]) -> Result<()> {
+    /// Registers multiple persistent cache parents for host information synchronization.
+    ///
+    /// For each parent, this function:
+    /// - Creates a new gRPC connection if one doesn't exist.
+    /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
+    /// - Updates the connection's request counter.
+    pub async fn register(&self, parents: &[PersistentCachePeer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
-
-        let mut join_set = JoinSet::<Result<()>>::new();
-
+        let mut join_set = JoinSet::new();
         for parent in parents {
-            let remote_host_id = IDGenerator::new(
-                parent.host.as_ref().unwrap().ip.clone(),
-                parent.host.as_ref().unwrap().hostname.clone(),
-                false,
-            )
-            .host_id();
+            info!("register persistent cache parent {}", parent.id);
 
-            // Check if connection already has active requests
-            if let Some(connection) = self.connections.get(&remote_host_id) {
-                if connection.active_requests() > 0 {
-                    debug!("sync host already running for parent {}", parent.id);
+            let Some(parent_host) = parent.host.as_ref() else {
+                warn!(
+                    "persistent cache parent {} has no host info, skipping",
+                    parent.id
+                );
+                continue;
+            };
+            let parent_host_id = parent_host.id.clone();
+
+            match self.connections.entry(parent_host_id.clone()) {
+                dashmap::mapref::entry::Entry::Occupied(entry) => {
+                    entry.get().increment_request();
                     continue;
                 }
-            }
-
-            // Get or create connection for the sync host.
-            let client = self.get_connection_client(&parent.host).await?;
-
-            // Start sync host for this parent.
-            let parent = parent.clone();
-            let weights = self.weights.clone();
-            let timeout = self.timeout;
-            let host_id = self.host_id.clone();
-            let peer_id = self.peer_id.clone();
-            let shutdown = self
-                .connections
-                .get(&remote_host_id)
-                .map(|conn| conn.shutdown.clone())
-                .unwrap_or_default();
-            let dfdaemon_shutdown_clone = dfdaemon_shutdown.clone();
-
-            join_set.spawn(
-                async move {
-                    info!("started sync host for parent {}", parent.id);
-
-                    if let Err(err) = Self::sync_host(
-                        host_id,
-                        peer_id,
-                        remote_host_id.clone(),
-                        weights.clone(),
-                        timeout,
-                        client,
-                        shutdown,
-                        dfdaemon_shutdown_clone,
+                dashmap::mapref::entry::Entry::Vacant(entry) => {
+                    let dfdaemon_upload_client = DfdaemonUploadClient::new(
+                        self.config.clone(),
+                        format!("http://{}:{}", parent_host.ip, parent_host.port),
+                        false,
                     )
-                    .await
-                    {
-                        error!("sync host for parent {} failed: {}", remote_host_id, err);
-                        return Err(err);
-                    }
+                    .await?;
 
-                    Ok(())
+                    let connection = Connection::new();
+                    connection.increment_request();
+                    let shutdown = connection.shutdown.clone();
+                    entry.insert(connection);
+
+                    let weights = self.weights.clone();
+                    let host_id = self.id_generator.host_id();
+                    let peer_id = self.id_generator.peer_id();
+                    let dfdaemon_shutdown_clone = dfdaemon_shutdown.clone();
+                    join_set.spawn(
+                        Self::sync_host(
+                            host_id,
+                            peer_id,
+                            parent_host_id.clone(),
+                            weights,
+                            dfdaemon_upload_client,
+                            shutdown,
+                            dfdaemon_shutdown_clone,
+                        )
+                        .in_current_span(),
+                    );
                 }
-                .in_current_span(),
-            );
+            }
         }
 
-        // Spawn a task to manage this JoinSet.
         tokio::spawn(async move {
-            while let Some(result) = join_set.join_next().await {
-                match result {
-                    Ok(Ok(_)) => debug!("parent sync host completed successfully"),
-                    Ok(Err(_)) => debug!("parent sync host failed"),
-                    Err(err) => debug!("parent sync host join error: {}", err),
+            while let Some(message) = join_set.join_next().await {
+                match message {
+                    Ok(Ok(_)) => debug!("sync host info completed"),
+                    Ok(Err(err)) => error!("sync host info failed: {}", err),
+                    Err(err) => error!("task join error: {}", err),
                 }
             }
         });
@@ -393,16 +556,119 @@ impl ParentSelector {
         Ok(())
     }
 
-    /// get_idle_upload_rate returns the available upload rate of a host.
-    fn get_idle_upload_rate(host: &Host) -> u64 {
+    /// Unregisters multiple persistent cache parents and cleans up their connections.
+    ///
+    /// Decrements the request counter for each parent's connection. When a connection's
+    /// active request count reaches zero, it:
+    /// - Triggers connection shutdown.
+    /// - Removes the weight entry.
+    /// - Removes the connection from the pool.
+    pub fn unregister(&self, parents: &[PersistentCachePeer]) {
+        for parent in parents {
+            info!("unregister persistent cache parent {}", parent.id);
+
+            let Some(parent_host) = parent.host.as_ref() else {
+                warn!(
+                    "persistent cache parent {} has no host info, skipping",
+                    parent.id
+                );
+                continue;
+            };
+            let parent_host_id = parent_host.id.clone();
+
+            if let Some(connection) = self.connections.get(&parent_host_id) {
+                connection.decrement_request();
+                if connection.active_requests() == 0 {
+                    info!("cleaning up parent {} connection", parent_host_id);
+                    connection.shutdown();
+
+                    // Explicitly drop the reference to avoid holding the borrow
+                    // from self.connections.get() while trying to call remove().
+                    drop(connection);
+                    self.weights.remove(&parent_host_id);
+                    self.connections.remove(&parent_host_id);
+                }
+            }
+        }
+    }
+
+    /// Continuously synchronizes host metrics from a persistent cache parent peer.
+    ///
+    /// This is a long-running background task that:
+    /// - Establishes a streaming gRPC connection to the parent.
+    /// - Receives periodic host status updates (CPU, bandwidth, etc.).
+    /// - Updates the parent's weight based on idle TX bandwidth.
+    /// - Runs until shutdown signal or connection failure.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn sync_host(
+        host_id: String,
+        peer_id: String,
+        parent_host_id: String,
+        weights: Arc<DashMap<String, u32>>,
+        dfdaemon_upload_client: DfdaemonUploadClient,
+        mut shutdown: Shutdown,
+        mut dfdaemon_shutdown: Shutdown,
+    ) -> Result<()> {
+        info!(
+            "sync host info from persistent cache parent {}",
+            parent_host_id
+        );
+        let response = dfdaemon_upload_client
+            .sync_host(SyncHostRequest { host_id, peer_id })
+            .await
+            .inspect_err(|err| {
+                error!(
+                    "sync host info from persistent cache parent {} failed: {}",
+                    parent_host_id, err
+                );
+            })?;
+
+        let out_stream = response.into_inner();
+        tokio::pin!(out_stream);
+        loop {
+            tokio::select! {
+                result = out_stream.try_next() => {
+                    match result.inspect_err(|err| {
+                        error!("sync host info from persistent cache parent {} failed: {}", parent_host_id, err);
+                    })? {
+                        Some(message) => {
+                            let idle_tx_bandwidth = Self::get_idle_tx_bandwidth(&message);
+
+                            info!("update host {} idle TX bandwidth to {}", parent_host_id, idle_tx_bandwidth);
+                            weights.insert(parent_host_id.clone(), idle_tx_bandwidth as u32);
+                        }
+                        None => break,
+                    }
+                }
+                _ = shutdown.recv() => {
+                    info!("sync host info from persistent cache parent {} shutting down", parent_host_id);
+                    break;
+                }
+                _ = dfdaemon_shutdown.recv() => {
+                    info!("persistent cache parent selector shutting down");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Calculates the idle transmission bandwidth of a host.
+    fn get_idle_tx_bandwidth(host: &Host) -> u64 {
         let network = match &host.network {
             Some(network) => network,
             None => return 0,
         };
 
-        let tx_bandwidth = network.tx_bandwidth.unwrap_or(0);
-        if tx_bandwidth < network.max_rx_bandwidth {
-            network.max_rx_bandwidth - tx_bandwidth
+        debug!("host {} network info: {:?}", host.id, network);
+        let Some(tx_bandwidth) = network.tx_bandwidth else {
+            return 0;
+        };
+
+        if tx_bandwidth < network.max_tx_bandwidth {
+            network.max_tx_bandwidth - tx_bandwidth
         } else {
             0
         }

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -58,8 +58,8 @@ pub struct CollectedPiece {
     /// length is the piece length.
     pub length: u64,
 
-    /// parent is the parent peer.
-    pub parent: CollectedParent,
+    /// parents is the parents providing the piece.
+    pub parents: Vec<CollectedParent>,
 }
 
 /// PieceCollector is used to collect pieces from peers.
@@ -249,27 +249,18 @@ impl PieceCollector {
                         None => continue,
                     };
 
-                    let parent = match parents.get(fastrand::usize(..parents.len())) {
-                        Some(parent) => parent,
-                        None => {
-                            error!(
-                                "collected_pieces does not contain parent for piece {}",
-                                message.number
-                            );
-                            continue;
-                        }
-                    };
-
                     info!(
-                        "picked up piece {}-{} metadata from parent {}",
-                        task_id, message.number, parent.id
+                        "receive piece {}-{} metadata from parents {:?}",
+                        task_id,
+                        message.number,
+                        parents.iter().map(|p| &p.id).collect::<Vec<&String>>()
                     );
 
                     collected_piece_tx
                         .send(CollectedPiece {
                             number: message.number,
                             length: message.length,
-                            parent: parent.clone(),
+                            parents,
                         })
                         .await
                         .inspect_err(|err| {
@@ -307,12 +298,8 @@ impl PieceCollector {
                         join_set.shutdown().await;
                     }
                 }
-                Ok(Err(err)) => {
-                    error!("sync pieces failed: {}", err);
-                }
-                Err(err) => {
-                    error!("sync pieces failed: {}", err);
-                }
+                Ok(Err(err)) => error!("sync pieces failed: {}", err),
+                Err(err) => error!("task join error: {}", err),
             }
         }
 
@@ -512,27 +499,18 @@ impl PersistentCachePieceCollector {
                         None => continue,
                     };
 
-                    let parent = match parents.get(fastrand::usize(..parents.len())) {
-                        Some(parent) => parent,
-                        None => {
-                            error!(
-                                "collected_pieces does not contain parent for piece {}",
-                                message.number
-                            );
-                            continue;
-                        }
-                    };
-
                     info!(
-                        "picked up piece {}-{} metadata from parent {}",
-                        task_id, message.number, parent.id
+                        "receive piece {}-{} metadata from parents {:?}",
+                        task_id,
+                        message.number,
+                        parents.iter().map(|p| &p.id).collect::<Vec<&String>>()
                     );
 
                     collected_piece_tx
                         .send(CollectedPiece {
                             number: message.number,
                             length: message.length,
-                            parent: parent.clone(),
+                            parents,
                         })
                         .await
                         .inspect_err(|err| {
@@ -570,297 +548,11 @@ impl PersistentCachePieceCollector {
                         join_set.shutdown().await;
                     }
                 }
-                Ok(Err(err)) => {
-                    error!("sync persistent cache pieces failed: {}", err);
-                }
-                Err(err) => {
-                    error!("sync persistent cache pieces failed: {}", err);
-                }
+                Ok(Err(err)) => error!("sync persistent cache pieces failed: {}", err),
+                Err(err) => error!("task join error: {}", err),
             }
         }
 
         Ok(())
-    }
-}
-/// PieceParentCollector is used to collect pieces from peers.
-pub struct PieceParentCollector {
-    /// config is the configuration of the dfdaemon.
-    config: Arc<Config>,
-
-    /// host_id is the id of the host.
-    host_id: String,
-
-    /// task_id is the id of the task.
-    task_id: String,
-
-    /// parents is the parent peers.
-    parents: Vec<CollectedParent>,
-
-    /// interested_pieces is the pieces interested by the collector.
-    interested_pieces: Vec<metadata::Piece>,
-
-    /// collected_pieces is a map to store the collected pieces from different parents.
-    collected_pieces: Arc<DashMap<u32, Vec<CollectedParent>>>,
-
-    /// candidate_parents is the candidates of the parents for parent selection.
-    candidate_parents: Arc<DashMap<u32, Vec<CollectedParent>>>,
-}
-
-/// PieceParentCollector is used to collect pieces from peers.
-impl PieceParentCollector {
-    /// new creates a new PieceCollector.
-    pub async fn new(
-        config: Arc<Config>,
-        host_id: &str,
-        task_id: &str,
-        interested_pieces: Vec<metadata::Piece>,
-        parents: Vec<CollectedParent>,
-    ) -> Self {
-        let collected_pieces = Arc::new(DashMap::with_capacity(interested_pieces.len()));
-        for interested_piece in &interested_pieces {
-            collected_pieces.insert(interested_piece.number, Vec::new());
-        }
-        let candidate_parents = Arc::new(DashMap::with_capacity(interested_pieces.len()));
-
-        Self {
-            config,
-            task_id: task_id.to_string(),
-            host_id: host_id.to_string(),
-            parents,
-            interested_pieces,
-            collected_pieces,
-            candidate_parents,
-        }
-    }
-
-    /// run runs the piece collector.
-    #[instrument(skip_all)]
-    pub async fn run(&self) -> Receiver<CollectedPiece> {
-        let config = self.config.clone();
-        let host_id = self.host_id.clone();
-        let task_id = self.task_id.clone();
-        let parents = self.parents.clone();
-        let candidate_parents = self.candidate_parents.clone();
-        let interested_pieces = self.interested_pieces.clone();
-        let collected_pieces = self.collected_pieces.clone();
-        let collected_piece_timeout = self.config.download.collected_piece_timeout;
-        let (collected_piece_tx, collected_piece_rx) = mpsc::channel(128 * 1024);
-        tokio::spawn(
-            async move {
-                Self::collect_from_parents(
-                    config,
-                    &host_id,
-                    &task_id,
-                    parents,
-                    candidate_parents,
-                    interested_pieces,
-                    collected_pieces,
-                    collected_piece_tx,
-                    collected_piece_timeout,
-                )
-                .await
-                .unwrap_or_else(|err| {
-                    error!("collect pieces failed: {}", err);
-                });
-            }
-            .in_current_span(),
-        );
-
-        collected_piece_rx
-    }
-
-    /// collect_from_parents collects pieces from multiple parents with load balancing strategy.
-    ///
-    /// The collection process works in two phases:
-    /// 1. **Synchronization Phase**: Waits for a configured duration (DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS)
-    ///    to collect the same piece information from different parents. This allows the collector
-    ///    to gather multiple sources for each piece.
-    ///
-    /// 2. **Selection Phase**: After the wait period, randomly selects one parent from the available
-    ///    candidates for each piece and forwards it to the piece downloader.
-    ///
-    /// **Load Balancing Strategy**:
-    /// The random parent selection is designed to distribute download load across multiple parents
-    /// during concurrent piece downloads. This approach ensures:
-    /// - Optimal utilization of bandwidth from multiple parent nodes
-    /// - Prevention of overwhelming any single parent with too many requests
-    /// - Better overall download performance through parallel connections
-    ///
-    /// This strategy is particularly effective when downloading multiple pieces simultaneously,
-    /// as it naturally spreads the workload across the available parent pool.
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
-    async fn collect_from_parents(
-        config: Arc<Config>,
-        host_id: &str,
-        task_id: &str,
-        parents: Vec<CollectedParent>,
-        candidate_parents: Arc<DashMap<u32, Vec<CollectedParent>>>,
-        interested_pieces: Vec<metadata::Piece>,
-        collected_pieces: Arc<DashMap<u32, Vec<CollectedParent>>>,
-        collected_piece_tx: Sender<CollectedPiece>,
-        collected_piece_timeout: Duration,
-    ) -> Result<()> {
-        // Create a task to collect pieces from peers.
-        let mut join_set = JoinSet::new();
-        for parent in parents.iter() {
-            #[allow(clippy::too_many_arguments)]
-            async fn sync_pieces(
-                config: Arc<Config>,
-                host_id: String,
-                task_id: String,
-                parent: CollectedParent,
-                candidate_parents: Arc<DashMap<u32, Vec<CollectedParent>>>,
-                interested_pieces: Vec<metadata::Piece>,
-                collected_pieces: Arc<DashMap<u32, Vec<CollectedParent>>>,
-                collected_piece_tx: Sender<CollectedPiece>,
-                collected_piece_timeout: Duration,
-            ) -> Result<CollectedParent> {
-                info!("sync pieces from parent {}", parent.id);
-
-                // If candidate_parent.host is None, skip it.
-                let host = parent.host.clone().ok_or_else(|| {
-                    error!("peer {:?} host is empty", parent);
-                    Error::InvalidPeer(parent.id.clone())
-                })?;
-
-                // Create a dfdaemon client.
-                let dfdaemon_upload_client = DfdaemonUploadClient::new(
-                    config.clone(),
-                    format!("http://{}:{}", host.ip, host.port),
-                    false,
-                )
-                .await
-                .inspect_err(|err| {
-                    error!(
-                        "create dfdaemon upload client from parent {} failed: {}",
-                        parent.id, err
-                    );
-                })?;
-
-                let response = dfdaemon_upload_client
-                    .sync_pieces(SyncPiecesRequest {
-                        host_id: host_id.to_string(),
-                        task_id: task_id.to_string(),
-                        interested_piece_numbers: interested_pieces
-                            .iter()
-                            .map(|piece| piece.number)
-                            .collect(),
-                    })
-                    .await
-                    .inspect_err(|err| {
-                        error!("sync pieces from parent {} failed: {}", parent.id, err);
-                    })?;
-
-                // If the response repeating timeout exceeds the piece download timeout, the stream will return error.
-                let out_stream = response.into_inner().timeout(collected_piece_timeout);
-                tokio::pin!(out_stream);
-
-                while let Some(message) = out_stream.try_next().await.inspect_err(|err| {
-                    error!("sync pieces from parent {} failed: {}", parent.id, err);
-                })? {
-                    let message = message?;
-
-                    if config.download.parent_selector.enable {
-                        match candidate_parents.entry(message.number) {
-                            dashmap::mapref::entry::Entry::Occupied(mut e) => {
-                                e.get_mut().push(parent.clone());
-                            }
-                            dashmap::mapref::entry::Entry::Vacant(e) => {
-                                e.insert(vec![parent.clone()]);
-                            }
-                        }
-                    }
-
-                    if let Some(mut parents) = collected_pieces.get_mut(&message.number) {
-                        parents.push(parent.clone());
-                    } else {
-                        continue;
-                    }
-
-                    // Wait for collecting the piece from different parents when the first
-                    // piece is collected.
-                    tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FROM_DIFFERENT_PARENTS).await;
-                    let parents = match collected_pieces.remove(&message.number) {
-                        Some((_, parents)) => parents,
-                        None => continue,
-                    };
-
-                    let parent = match parents.get(fastrand::usize(..parents.len())) {
-                        Some(parent) => parent,
-                        None => {
-                            error!(
-                                "collected_pieces does not contain parent for piece {}",
-                                message.number
-                            );
-                            continue;
-                        }
-                    };
-
-                    info!(
-                        "picked up piece {}-{} metadata from parent {}",
-                        task_id, message.number, parent.id
-                    );
-
-                    collected_piece_tx
-                        .send(CollectedPiece {
-                            number: message.number,
-                            length: message.length,
-                            parent: parent.clone(),
-                        })
-                        .await
-                        .inspect_err(|err| {
-                            error!("send CollectedPiece failed: {}", err);
-                        })?;
-                }
-
-                Ok(parent)
-            }
-
-            join_set.spawn(
-                sync_pieces(
-                    config.clone(),
-                    host_id.to_string(),
-                    task_id.to_string(),
-                    parent.clone(),
-                    candidate_parents.clone(),
-                    interested_pieces.clone(),
-                    collected_pieces.clone(),
-                    collected_piece_tx.clone(),
-                    collected_piece_timeout,
-                )
-                .in_current_span(),
-            );
-        }
-
-        // Wait for all tasks to finish.
-        while let Some(message) = join_set.join_next().await {
-            match message {
-                Ok(Ok(peer)) => {
-                    info!("peer {} sync pieces finished", peer.id);
-
-                    // If all pieces are collected, abort all tasks.
-                    if collected_pieces.is_empty() {
-                        info!("all pieces are collected, abort all tasks");
-                        join_set.abort_all();
-                    }
-                }
-                Ok(Err(err)) => {
-                    error!("sync pieces failed: {}", err);
-                }
-                Err(err) => {
-                    error!("sync pieces failed: {}", err);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// get_candidate_parents returns the list of parents that have a specific piece
-    pub fn get_candidate_parents(&self, piece_number: u32) -> Option<Vec<CollectedParent>> {
-        self.candidate_parents
-            .get(&piece_number)
-            .map(|parents| parents.clone())
     }
 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -16,7 +16,6 @@
 
 use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
 use crate::resource::parent_selector::ParentSelector;
-use crate::resource::piece_collector::CollectedParent;
 use dragonfly_api::common::v2::{
     Download, Hdfs, ObjectStorage, Peer, Piece, SizeScope, Task as CommonTask, TaskType,
     TrafficType,
@@ -49,6 +48,7 @@ use dragonfly_client_storage::{metadata, Storage};
 use dragonfly_client_util::{
     http::{hashmap_to_headermap, headermap_to_hashmap},
     id_generator::IDGenerator,
+    shutdown,
 };
 use leaky_bucket::RateLimiter;
 use reqwest::header::HeaderMap;
@@ -108,27 +108,30 @@ impl Task {
         download_rate_limiter: Arc<RateLimiter>,
         upload_rate_limiter: Arc<RateLimiter>,
         prefetch_rate_limiter: Arc<RateLimiter>,
-        parent_selector: Arc<ParentSelector>,
+        shutdown: shutdown::Shutdown,
+        shutdown_complete_tx: mpsc::UnboundedSender<()>,
     ) -> ClientResult<Self> {
-        let piece = piece::Piece::new(
-            config.clone(),
-            id_generator.clone(),
-            storage.clone(),
-            backend_factory.clone(),
-            download_rate_limiter,
-            upload_rate_limiter,
-            prefetch_rate_limiter,
-        )?;
-        let piece = Arc::new(piece);
-
         Ok(Self {
-            config,
-            id_generator,
+            config: config.clone(),
+            id_generator: id_generator.clone(),
             storage: storage.clone(),
             scheduler_client: scheduler_client.clone(),
             backend_factory: backend_factory.clone(),
-            piece: piece.clone(),
-            parent_selector: parent_selector.clone(),
+            piece: Arc::new(piece::Piece::new(
+                config.clone(),
+                id_generator.clone(),
+                storage.clone(),
+                backend_factory.clone(),
+                download_rate_limiter,
+                upload_rate_limiter,
+                prefetch_rate_limiter,
+            )?),
+            parent_selector: Arc::new(ParentSelector::new(
+                config.clone(),
+                id_generator.clone(),
+                shutdown.clone(),
+                shutdown_complete_tx.clone(),
+            )),
         })
     }
 
@@ -734,63 +737,32 @@ impl Task {
                     );
 
                     // Download the pieces from the parent.
-                    let partial_finished_pieces = if self.config.download.parent_selector.enable {
-                        match self
-                            .download_partial_with_scheduler_from_parent_selector(
-                                task,
-                                host_id,
-                                peer_id,
-                                response.candidate_parents.clone(),
-                                remaining_interested_pieces.clone(),
-                                request.is_prefetch,
-                                request.need_piece_content,
-                                download_progress_tx.clone(),
-                                in_stream_tx.clone(),
-                            )
-                            .await
-                        {
-                            Ok(partial_finished_pieces) => {
-                                info!(
-                                    "schedule {} finished {} pieces from parent",
-                                    schedule_count,
-                                    partial_finished_pieces.len()
-                                );
+                    let partial_finished_pieces = match self
+                        .download_partial_with_scheduler_from_parent(
+                            task,
+                            host_id,
+                            peer_id,
+                            response.candidate_parents.clone(),
+                            remaining_interested_pieces.clone(),
+                            request.is_prefetch,
+                            request.need_piece_content,
+                            download_progress_tx.clone(),
+                            in_stream_tx.clone(),
+                        )
+                        .await
+                    {
+                        Ok(partial_finished_pieces) => {
+                            info!(
+                                "schedule {} finished {} pieces from parent",
+                                schedule_count,
+                                partial_finished_pieces.len()
+                            );
 
-                                partial_finished_pieces
-                            }
-                            Err(err) => {
-                                error!("download from parent error: {:?}", err);
-                                Vec::new()
-                            }
+                            partial_finished_pieces
                         }
-                    } else {
-                        match self
-                            .download_partial_with_scheduler_from_parent(
-                                task,
-                                host_id,
-                                peer_id,
-                                response.candidate_parents.clone(),
-                                remaining_interested_pieces.clone(),
-                                request.is_prefetch,
-                                request.need_piece_content,
-                                download_progress_tx.clone(),
-                                in_stream_tx.clone(),
-                            )
-                            .await
-                        {
-                            Ok(partial_finished_pieces) => {
-                                info!(
-                                    "schedule {} finished {} pieces from parent",
-                                    schedule_count,
-                                    partial_finished_pieces.len()
-                                );
-
-                                partial_finished_pieces
-                            }
-                            Err(err) => {
-                                error!("download from parent error: {:?}", err);
-                                Vec::new()
-                            }
+                        Err(err) => {
+                            error!("download from parent error: {:?}", err);
+                            Vec::new()
                         }
                     };
 
@@ -1017,6 +989,20 @@ impl Task {
         // Get the id of the task.
         let task_id = task.id.as_str();
 
+        // Register the parents for syncing host info.
+        self.parent_selector
+            .register(&parents)
+            .await
+            .inspect_err(|err| {
+                error!("register parents for syncing host info failed: {:?}", err);
+            })?;
+
+        // Clean up the parents in parent selector when the function returns.
+        let parents_clone = parents.clone();
+        let _guard = scopeguard::guard((), |_| {
+            self.parent_selector.unregister(&parents_clone);
+        });
+
         // Initialize the piece collector.
         let piece_collector = piece_collector::PieceCollector::new(
             self.config.clone(),
@@ -1063,7 +1049,7 @@ impl Task {
                 peer_id: String,
                 number: u32,
                 length: u64,
-                parent: piece_collector::CollectedParent,
+                parents: Vec<piece_collector::CollectedParent>,
                 piece_manager: Arc<piece::Piece>,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
                 in_stream_tx: Sender<AnnouncePeerRequest>,
@@ -1072,8 +1058,11 @@ impl Task {
                 is_prefetch: bool,
                 need_piece_content: bool,
                 protocol: String,
+                parent_selector: Arc<ParentSelector>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
+                let parent = parent_selector.select(parents);
+
                 info!(
                     "start to download piece {} from parent {:?}",
                     piece_id,
@@ -1215,6 +1204,7 @@ impl Task {
             let interrupt = interrupt.clone();
             let finished_pieces = finished_pieces.clone();
             let protocol = self.config.download.protocol.clone();
+            let parent_selector = self.parent_selector.clone();
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             join_set.spawn(
                 async move {
@@ -1225,7 +1215,7 @@ impl Task {
                         peer_id,
                         collect_piece.number,
                         collect_piece.length,
-                        collect_piece.parent.clone(),
+                        collect_piece.parents,
                         piece_manager,
                         download_progress_tx,
                         in_stream_tx,
@@ -1234,6 +1224,7 @@ impl Task {
                         is_prefetch,
                         need_piece_content,
                         protocol,
+                        parent_selector,
                     )
                     .await
                 }
@@ -2022,341 +2013,6 @@ impl Task {
                 Err(Error::TaskNotFound(task_id.to_owned()))
             }
         }
-    }
-
-    /// download_partial_with_scheduler_from_parent downloads a partial task with scheduler from a parent.
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
-    async fn download_partial_with_scheduler_from_parent_selector(
-        &self,
-        task: &metadata::Task,
-        host_id: &str,
-        peer_id: &str,
-        parents: Vec<Peer>,
-        interested_pieces: Vec<metadata::Piece>,
-        is_prefetch: bool,
-        need_piece_content: bool,
-        download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
-        in_stream_tx: Sender<AnnouncePeerRequest>,
-    ) -> ClientResult<Vec<metadata::Piece>> {
-        // Get the id of the task.
-        let task_id = task.id.as_str();
-
-        // Convert Peer to CollectedParent
-        let collected_parents: Vec<CollectedParent> = parents
-            .clone()
-            .into_iter()
-            .map(|peer| CollectedParent {
-                id: peer.id,
-                host: peer.host,
-                download_ip: None,
-                download_tcp_port: None,
-                download_quic_port: None,
-            })
-            .collect();
-
-        // Initialize the piece collector.
-        let piece_collector = piece_collector::PieceParentCollector::new(
-            self.config.clone(),
-            host_id,
-            task_id,
-            interested_pieces.clone(),
-            collected_parents.clone(),
-        )
-        .await;
-        let mut piece_collector_rx = piece_collector.run().await;
-        let piece_collector = Arc::new(piece_collector);
-
-        if let Err(err) = self
-            .parent_selector
-            .register_parents(&collected_parents)
-            .await
-        {
-            error!("register parents failed: {:?}", err);
-        }
-
-        // Initialize the interrupt. If download from parent failed with scheduler or download
-        // progress, interrupt the collector and return the finished pieces.
-        let interrupt = Arc::new(AtomicBool::new(false));
-
-        // Initialize the finished pieces.
-        let finished_pieces = Arc::new(Mutex::new(Vec::new()));
-
-        // Initialize the join set.
-        let mut join_set = JoinSet::new();
-        let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
-        ));
-        while let Some(collect_piece) = piece_collector_rx.recv().await {
-            if interrupt.load(Ordering::SeqCst) {
-                // If the interrupt is true, break the collector loop.
-                debug!("interrupt the piece collector");
-                drop(piece_collector_rx);
-                break;
-            }
-
-            async fn download_from_parent(
-                task_id: String,
-                host_id: String,
-                peer_id: String,
-                number: u32,
-                length: u64,
-                parent: piece_collector::CollectedParent,
-                piece_manager: Arc<piece::Piece>,
-                download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
-                in_stream_tx: Sender<AnnouncePeerRequest>,
-                interrupt: Arc<AtomicBool>,
-                finished_pieces: Arc<Mutex<Vec<metadata::Piece>>>,
-                is_prefetch: bool,
-                need_piece_content: bool,
-                piece_collector: Arc<piece_collector::PieceParentCollector>,
-                parent_selector: Arc<ParentSelector>,
-            ) -> ClientResult<metadata::Piece> {
-                let piece_id = piece_manager.id(task_id.as_str(), number);
-
-                let parent = if let Some(parents) = piece_collector.get_candidate_parents(number) {
-                    match parent_selector.select_parent(parents) {
-                        Some(selected_parent) => selected_parent,
-                        None => parent,
-                    }
-                } else {
-                    parent
-                };
-
-                info!(
-                    "start to download piece {} from parent {:?}",
-                    piece_id,
-                    parent.id.clone()
-                );
-
-                let metadata = piece_manager
-                    .download_from_parent(
-                        piece_id.as_str(),
-                        host_id.as_str(),
-                        task_id.as_str(),
-                        number,
-                        length,
-                        parent.clone(),
-                        is_prefetch,
-                    )
-                    .await
-                    .map_err(|err| {
-                        error!(
-                            "download piece {} from parent {:?} error: {:?}",
-                            piece_id,
-                            parent.id.clone(),
-                            err
-                        );
-                        Error::DownloadFromParentFailed(DownloadFromParentFailed {
-                            piece_number: number,
-                            parent_id: parent.id.clone(),
-                        })
-                    })?;
-
-                // Construct the piece.
-                let mut piece = Piece {
-                    number: metadata.number,
-                    parent_id: metadata.parent_id.clone(),
-                    offset: metadata.offset,
-                    length: metadata.length,
-                    digest: metadata.digest.clone(),
-                    content: None,
-                    traffic_type: Some(TrafficType::RemotePeer as i32),
-                    cost: metadata.prost_cost(),
-                    created_at: Some(prost_wkt_types::Timestamp::from(metadata.created_at)),
-                };
-
-                // If need_piece_content is true, read the piece content from the local.
-                if need_piece_content {
-                    let mut reader = piece_manager
-                        .download_from_local_into_async_read(
-                            piece_id.as_str(),
-                            task_id.as_str(),
-                            metadata.length,
-                            None,
-                            true,
-                            false,
-                        )
-                        .await
-                        .inspect_err(|err| {
-                            error!("read piece {} failed: {:?}", piece_id, err);
-                            interrupt.store(true, Ordering::SeqCst);
-                        })?;
-
-                    let mut content = vec![0; metadata.length as usize];
-                    reader.read_exact(&mut content).await.inspect_err(|err| {
-                        error!("read piece {} failed: {:?}", piece_id, err);
-                        interrupt.store(true, Ordering::SeqCst);
-                    })?;
-
-                    piece.content = Some(content);
-                }
-
-                // Send the download piece finished request.
-                in_stream_tx
-                    .send_timeout(
-                        AnnouncePeerRequest {
-                            host_id: host_id.to_string(),
-                            task_id: task_id.to_string(),
-                            peer_id: peer_id.to_string(),
-                            request: Some(
-                                announce_peer_request::Request::DownloadPieceFinishedRequest(
-                                    DownloadPieceFinishedRequest {
-                                        piece: Some(piece.clone()),
-                                    },
-                                ),
-                            ),
-                        },
-                        REQUEST_TIMEOUT,
-                    )
-                    .await
-                    .unwrap_or_else(|err| {
-                        error!(
-                            "send DownloadPieceFinishedRequest for piece {} failed: {:?}",
-                            piece_id, err
-                        );
-                        interrupt.store(true, Ordering::SeqCst);
-                    });
-
-                // Send the download progress.
-                download_progress_tx
-                    .send_timeout(
-                        Ok(DownloadTaskResponse {
-                            host_id: host_id.to_string(),
-                            task_id: task_id.to_string(),
-                            peer_id: peer_id.to_string(),
-                            response: Some(
-                                download_task_response::Response::DownloadPieceFinishedResponse(
-                                    dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(piece.clone()),
-                                    },
-                                ),
-                            ),
-                        }),
-                        REQUEST_TIMEOUT,
-                    )
-                    .await
-                    .unwrap_or_else(|err| {
-                        error!(
-                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
-                            piece_id, err
-                        );
-                        interrupt.store(true, Ordering::SeqCst);
-                    });
-
-                info!(
-                    "finished piece {} from parent {:?}",
-                    piece_id, metadata.parent_id
-                );
-
-                let mut finished_pieces = finished_pieces.lock().unwrap();
-                finished_pieces.push(metadata.clone());
-
-                Ok(metadata)
-            }
-
-            let task_id = task_id.to_string();
-            let host_id = host_id.to_string();
-            let peer_id = peer_id.to_string();
-            let piece_manager = self.piece.clone();
-            let download_progress_tx = download_progress_tx.clone();
-            let in_stream_tx = in_stream_tx.clone();
-            let interrupt = interrupt.clone();
-            let finished_pieces = finished_pieces.clone();
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let piece_collector = piece_collector.clone();
-            let parent_selector = self.parent_selector.clone();
-            join_set.spawn(async move {
-                let _permit = permit;
-                download_from_parent(
-                    task_id,
-                    host_id,
-                    peer_id,
-                    collect_piece.number,
-                    collect_piece.length,
-                    collect_piece.parent.clone(),
-                    piece_manager,
-                    download_progress_tx,
-                    in_stream_tx,
-                    interrupt,
-                    finished_pieces,
-                    is_prefetch,
-                    need_piece_content,
-                    piece_collector,
-                    parent_selector,
-                )
-                .in_current_span()
-                .await
-            });
-        }
-
-        // Wait for the pieces to be downloaded.
-        while let Some(message) = join_set
-            .join_next()
-            .await
-            .transpose()
-            .or_err(ErrorType::AsyncRuntimeError)?
-        {
-            match message {
-                Ok(_) => {}
-                Err(Error::DownloadFromParentFailed(err)) => {
-                    let (piece_number, parent_id) = (err.piece_number, err.parent_id);
-
-                    // Send the download piece failed request.
-                    in_stream_tx
-                        .send_timeout(
-                            AnnouncePeerRequest {
-                                host_id: host_id.to_string(),
-                                task_id: task_id.to_string(),
-                                peer_id: peer_id.to_string(),
-                                request: Some(
-                                    announce_peer_request::Request::DownloadPieceFailedRequest(
-                                        DownloadPieceFailedRequest {
-                                            piece_number: Some(err.piece_number),
-                                            parent_id,
-                                            temporary: true,
-                                        },
-                                    ),
-                                ),
-                            },
-                            REQUEST_TIMEOUT,
-                        )
-                        .await
-                        .unwrap_or_else(|err| {
-                            error!(
-                                "send DownloadPieceFailedRequest for piece {} failed: {:?}",
-                                self.piece.id(task_id, piece_number),
-                                err
-                            )
-                        });
-
-                    // If the download failed from the parent, continue to download the next
-                    // piece and ignore the error.
-                    continue;
-                }
-                Err(Error::SendTimeout) => {
-                    join_set.shutdown().await;
-
-                    // If the send timeout with scheduler or download progress, return the finished pieces.
-                    // It will stop the download from the parent with scheduler
-                    // and download from the source directly from middle.
-                    let finished_pieces = finished_pieces.lock().unwrap().clone();
-                    return Ok(finished_pieces);
-                }
-                Err(err) => {
-                    error!("download from parent error: {:?}", err);
-
-                    // If the unknown error occurred, continue to download the next piece and
-                    // ignore the error.
-                    continue;
-                }
-            }
-        }
-
-        self.parent_selector.unregister_parents(parents);
-
-        let finished_pieces = finished_pieces.lock().unwrap().clone();
-        Ok(finished_pieces)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes significant improvements to the parent selection mechanism for persistent cache tasks in the Dragonfly client. The main changes involve refactoring how parent peers are managed and selected, enhancing configurability, and updating related documentation and code structures. The most important changes are listed below:

### Parent Selector Refactoring and Integration

* Introduced a new `PersistentCacheParentSelector` and integrated it into `PersistentCacheTask`, allowing dynamic registration and unregistration of parent peers for syncing host info. This improves flexibility and maintainability of parent selection logic. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R18) [[2]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R84-R86) [[3]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R102-R124) [[4]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R1031-R1044)
* Updated the download logic to utilize the parent selector for choosing the best parent from a list, rather than selecting a single parent upfront. This enables smarter and more dynamic peer selection during downloads. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1069-R1103) [[2]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R1245) [[3]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1230-R1264)

### Data Structure and Interface Updates

* Changed `CollectedPiece` to store a vector of parents (`parents: Vec<CollectedParent>`) instead of a single parent, reflecting the new multi-parent selection logic throughout the piece collection and download process. [[1]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L61-R62) [[2]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L252-R261) [[3]](diffhunk://#diff-6ea5ff95da7d753fc022fc87083cf177a54d95cfa82a14e2db9aba9f9a7b7824L515-R513)

### Configuration and Documentation Improvements

* Increased the default capacity for parent selector gRPC connections from 20 to 50, supporting more concurrent parent connections. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL91-R91) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL585-R598)
* Improved documentation and comments to clarify the role of parent selector timeouts and the flow of host information and load quality in the system diagrams and docstrings. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL82-R82) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL565-R575) [[3]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL585-R598)

These changes collectively enhance the robustness and scalability of parent selection in persistent cache tasks, paving the way for more efficient and reliable downloads.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3713
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
