### PR TITLE
refactor(resource): add tracing to parent selector methods

### DIFF
--- a/dragonfly-client/src/resource/parent_selector.rs
+++ b/dragonfly-client/src/resource/parent_selector.rs
@@ -148,6 +148,7 @@ impl ParentSelector {
     /// This function performs weighted random selection where parents with higher weights
     /// (better idle bandwidth) have a higher probability of being selected. If weight
     /// calculation fails, falls back to uniform random selection.
+    #[instrument(skip_all)]
     pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
         let weights: Vec<u32> = parents
             .iter()
@@ -195,6 +196,7 @@ impl ParentSelector {
     /// - Creates a new gRPC connection if one doesn't exist.
     /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
     /// - Updates the connection's request counter.
+    #[instrument(skip_all)]
     pub async fn register(&self, parents: &[Peer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
         let mut join_set = JoinSet::new();
@@ -265,6 +267,7 @@ impl ParentSelector {
     /// - Triggers connection shutdown.
     /// - Removes the weight entry.
     /// - Removes the connection from the pool.
+    #[instrument(skip_all)]
     pub fn unregister(&self, parents: &[Peer]) {
         for parent in parents {
             info!("unregister parent {}", parent.id);
@@ -352,6 +355,7 @@ impl ParentSelector {
     }
 
     /// Calculates the idle transmission bandwidth of a host.
+    #[instrument(skip_all)]
     fn get_idle_tx_bandwidth(host: &Host) -> u64 {
         let network = match &host.network {
             Some(network) => network,
@@ -443,6 +447,7 @@ impl PersistentCacheParentSelector {
     /// This function performs weighted random selection where parents with higher weights
     /// (better idle bandwidth) have a higher probability of being selected. If weight
     /// calculation fails, falls back to uniform random selection.
+    #[instrument(skip_all)]
     pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
         let weights: Vec<u32> = parents
             .iter()
@@ -490,6 +495,7 @@ impl PersistentCacheParentSelector {
     /// - Creates a new gRPC connection if one doesn't exist.
     /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
     /// - Updates the connection's request counter.
+    #[instrument(skip_all)]
     pub async fn register(&self, parents: &[PersistentCachePeer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
         let mut join_set = JoinSet::new();
@@ -563,6 +569,7 @@ impl PersistentCacheParentSelector {
     /// - Triggers connection shutdown.
     /// - Removes the weight entry.
     /// - Removes the connection from the pool.
+    #[instrument(skip_all)]
     pub fn unregister(&self, parents: &[PersistentCachePeer]) {
         for parent in parents {
             info!("unregister persistent cache parent {}", parent.id);
@@ -656,6 +663,7 @@ impl PersistentCacheParentSelector {
     }
 
     /// Calculates the idle transmission bandwidth of a host.
+    #[instrument(skip_all)]
     fn get_idle_tx_bandwidth(host: &Host) -> u64 {
         let network = match &host.network {
             Some(network) => network,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds tracing instrumentation to key methods in both the `ParentSelector` and `PersistentCacheParentSelector` implementations in `dragonfly-client/src/resource/parent_selector.rs`. The primary goal is to improve observability and debugging by enabling detailed tracing of method calls without logging their arguments.

Instrumentation for observability:

* Added the `#[instrument(skip_all)]` attribute to the following methods in `ParentSelector`:
  - `select`
  - `register`
  - `unregister`
  - `get_idle_tx_bandwidth`

* Added the `#[instrument(skip_all)]` attribute to the following methods in `PersistentCacheParentSelector`:
  - `select`
  - `register`
  - `unregister`
  - `get_idle_tx_bandwidth`
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
