### PR TITLE
feat(storage): enhance RocksDB sync and compression options

### DIFF
--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -361,6 +361,7 @@ impl Content {
         writer.flush().await.inspect_err(|err| {
             error!("flush {:?} failed: {}", task_path, err);
         })?;
+        debug!("finish to write piece to {:?}", task_path);
 
         if length != expected_length {
             return Err(Error::Unknown(format!(
@@ -590,6 +591,7 @@ impl Content {
         writer.flush().await.inspect_err(|err| {
             error!("flush {:?} failed: {}", task_path, err);
         })?;
+        debug!("finish to write piece to {:?}", task_path);
 
         if length != expected_length {
             return Err(Error::Unknown(format!(

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -361,6 +361,7 @@ impl Content {
         writer.flush().await.inspect_err(|err| {
             error!("flush {:?} failed: {}", task_path, err);
         })?;
+        debug!("finish to write piece to {:?}", task_path);
 
         if length != expected_length {
             return Err(Error::Unknown(format!(
@@ -590,6 +591,7 @@ impl Content {
         writer.flush().await.inspect_err(|err| {
             error!("flush {:?} failed: {}", task_path, err);
         })?;
+        debug!("finish to write piece to {:?}", task_path);
 
         if length != expected_length {
             return Err(Error::Unknown(format!(

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -520,6 +520,7 @@ impl TCPServerHandler {
         writer.flush().await.inspect_err(|err| {
             error!("flush failed: {}", err);
         })?;
+        debug!("finished writing stream to tcp writer");
 
         Ok(())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces improvements to logging and optimizes the RocksDB storage engine configuration. The most significant changes are the addition of debug logs after write operations and adjustments to RocksDB compression and sync settings to improve performance and observability.

**Logging Improvements:**

* Added debug logs after successful piece writes in both `content_linux.rs` and `content_macos.rs` to indicate completion of write operations. [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R364) [[2]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R594)
* Added a debug log in `server/tcp.rs` after flushing the TCP writer to signal stream completion.

**RocksDB Storage Engine Optimization:**

* Introduced a new constant `DEFAULT_BYTES_PER_SYNC` and set RocksDB sync options (`set_use_fsync(false)` and `set_bytes_per_sync`) to optimize disk writes. [[1]](diffhunk://#diff-9851d5766f56f7df703ccd575db532d2a1fc71c4031750e5f1e644af33065592R69-R71) [[2]](diffhunk://#diff-9851d5766f56f7df703ccd575db532d2a1fc71c4031750e5f1e644af33065592R91-R94)
* Changed the bottommost compression type from `Zstd` to `Lz4` for consistency with the main compression type.
* Updated the write operation to use `WriteOptions` with `sync` explicitly set to `false`, potentially improving write performance.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
