### PR TITLE
fix: task ID of image blobs for dragonfly's issue #4418

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -1105,6 +1105,12 @@ impl Default for Rule {
     }
 }
 
+/// default_enable_task_id_based_blob_digest is the default value for enable_task_id_based_blob_digest.
+#[inline]
+fn default_enable_task_id_based_blob_digest() -> bool {
+    true
+}
+
 /// RegistryMirror is the registry mirror configuration.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1120,6 +1126,14 @@ pub struct RegistryMirror {
     /// If registry use self-signed cert, the client should set the
     /// cert for the registry mirror.
     pub cert: Option<PathBuf>,
+
+    /// enable_task_id_based_blob_digest indicates whether to calculate the task ID based on the blob's SHA256 digest
+    /// for OCI registry blob download URLs. When enabled, if the download URL is for an image blob
+    /// (e.g., /v2/<name>/blobs/sha256:<digest>), the task ID will be calculated based on the blob's digest
+    /// instead of the full URL. This allows the same blob from different registries to share the same task ID,
+    /// avoiding redundant downloads and storage.
+    #[serde(default = "default_enable_task_id_based_blob_digest")]
+    pub enable_task_id_based_blob_digest: bool,
 }
 
 /// RegistryMirror implements Default.
@@ -1128,6 +1142,7 @@ impl Default for RegistryMirror {
         Self {
             addr: default_proxy_registry_mirror_addr(),
             cert: None,
+            enable_task_id_based_blob_digest: default_enable_task_id_based_blob_digest(),
         }
     }
 }

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -263,7 +263,33 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             .task
             .id_generator
             .task_id(match download.content_for_calculating_task_id.clone() {
-                Some(content) => TaskIDParameter::Content(content),
+                Some(content) => {
+                    // Check if the content matches OCI digest format: algorithm:encoded
+                    // See: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+                    // Format: algorithm can be [a-z0-9+._-]+, encoded can be [a-zA-Z0-9=_-]+
+                    // If it's a digest, use BlobDigestBased to ensure SHA256 hash is calculated
+                    // from the digest content, regardless of the digest algorithm used.
+                    let is_digest = content.split_once(':').is_some_and(|(alg, enc)| {
+                        // Validate algorithm: [a-z0-9+._-]+
+                        !alg.is_empty()
+                            && alg.chars().all(|c| {
+                                c.is_ascii_lowercase()
+                                    || c.is_ascii_digit()
+                                    || matches!(c, '+' | '.' | '_' | '-')
+                            })
+                            // Validate encoded: [a-zA-Z0-9=_-]+ and minimum length
+                            && enc.len() >= 32
+                            && enc.chars().all(|c| {
+                                c.is_ascii_alphanumeric() || matches!(c, '=' | '_' | '-')
+                            })
+                    });
+
+                    if is_digest {
+                        TaskIDParameter::BlobDigestBased(content)
+                    } else {
+                        TaskIDParameter::Content(content)
+                    }
+                }
                 None => TaskIDParameter::URLBased {
                     url: download.url.clone(),
                     piece_length: download.piece_length,

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -31,6 +31,7 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     http::{hashmap_to_headermap, headermap_to_hashmap},
+    id_generator::extract_blob_digest_from_url,
     shutdown,
     tls::{generate_self_signed_certs_by_ca_cert, generate_simple_self_signed_certs, NoVerifier},
 };
@@ -1121,6 +1122,25 @@ fn make_download_task_request(
         }
     }
 
+    // Determine the content for calculating task ID.
+    // Priority:
+    // 1. Explicit header value (X-Dragonfly-Content-For-Calculating-Task-ID)
+    // 2. Blob digest from URL (if enable_task_id_based_blob_digest is true)
+    // 3. None (will use URL-based calculation)
+    let content_for_calculating_task_id = header::get_content_for_calculating_task_id(&header)
+        .or_else(|| {
+            if config
+                .proxy
+                .registry_mirror
+                .enable_task_id_based_blob_digest
+            {
+                let path = request.uri().path();
+                extract_blob_digest_from_url(path)
+            } else {
+                None
+            }
+        });
+
     Ok(DownloadTaskRequest {
         download: Some(Download {
             url: make_download_url(request.uri(), rule.use_tls, rule.redirect.clone())?,
@@ -1149,7 +1169,7 @@ fn make_download_task_request(
             is_prefetch: false,
             need_piece_content: false,
             force_hard_link: header::get_force_hard_link(&header),
-            content_for_calculating_task_id: header::get_content_for_calculating_task_id(&header),
+            content_for_calculating_task_id,
             remote_ip: Some(remote_ip.to_string()),
             concurrent_piece_count: Some(config.download.concurrent_piece_count),
             overwrite: false,


### PR DESCRIPTION
# Calculate task ID based on blob SHA256 for registry downloads

## Description

This PR implements a feature to calculate task IDs based on the blob's SHA256 digest for OCI registry blob downloads, rather than using the full download URL. This allows identical blobs from different registry domains to share the same task ID, avoiding redundant downloads and storage.

### Key Changes:

1. **Configuration Addition** (`dragonfly-client-config/src/dfdaemon.rs`):
   - Added `enable_blob_based_task_id` field to `RegistryMirror` configuration
   - Defaults to `true` as specified in the issue
   - Allows users to control whether this feature is enabled

2. **Core Implementation** (`dragonfly-client/src/proxy/mod.rs`):
   - Added `extract_blob_digest_from_url()` function to detect and extract SHA256 digest from registry blob URLs (format: `/v2/<name>/blobs/sha256:<digest>`)
   - Modified `make_download_task_request()` to use blob digest for task ID calculation when the feature is enabled
   - Implements a priority system for task ID calculation:
     1. Explicit `X-Dragonfly-Content-For-Calculating-Task-ID` header (highest priority)
     2. Blob SHA256 digest from URL (if `enable_blob_based_task_id` is true)
     3. URL-based calculation (default fallback)

3. **Testing**:
   - Added unit tests for `extract_blob_digest_from_url()` function
   - Tests cover valid blob URLs and invalid/edge cases

### Example:

Before this change:
- `https://registry1.io/v2/nginx/blobs/sha256:abc123...` → Task ID 1
- `https://registry2.io/v2/nginx/blobs/sha256:abc123...` → Task ID 2 (duplicate download)

After this change:
- Both URLs → Same Task ID (based on `sha256:abc123...`)
- No duplicate downloads, shared storage

## Related Issue

Closes https://github.com/dragonflyoss/dragonfly/issues/4418

## Motivation and Context

When pulling container images, different registry mirrors (e.g., Docker Hub, Harbor, custom registries) may serve the same image blobs with identical content but different URLs. Currently, Dragonfly computes task IDs based on the download URL, which leads to:

- **Multiple downloads** of the same blob from different registries
- **Data redundancy** in storage
- **Wasted bandwidth** and slower image pulls

This change solves the problem by:
- Using the blob's SHA256 digest (which is content-addressable) as the basis for task ID calculation
- Ensuring identical blobs share the same task ID regardless of registry domain
- Reducing storage usage and improving download efficiency

The feature is **enabled by default** but can be disabled via configuration if needed for compatibility reasons.

## Screenshots (if appropriate)

N/A - Backend functionality only