### PR TITLE
fix(proxy): ensure none response is sent on empty file

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -807,6 +807,12 @@ async fn proxy_via_dfdaemon(
                     error!("writer shutdown error: {}", err);
                 }
 
+                // Send the none response to the client in case if it is empty file.
+                sender
+                    .send_timeout(None, REQUEST_TIMEOUT)
+                    .await
+                    .unwrap_or_default();
+
                 return;
             };
             let mut need_piece_number = first_piece.number;


### PR DESCRIPTION
This pull request adds a safeguard to the proxy logic in `dragonfly-client/src/proxy/mod.rs` to handle the case where an empty file is encountered. The change ensures that a "none" response is sent to the client, improving reliability and client communication.

Error handling and client response:

* [`dragonfly-client/src/proxy/mod.rs`](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR810-R815): In the `proxy_via_dfdaemon` function, added logic to send a "none" response to the client when an empty file is detected, preventing potential hangs or miscommunication.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
