### PR TITLE
chore(deps): update dragonfly-client dependencies to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -239,7 +239,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -382,7 +382,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -643,7 +643,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1001,7 +1001,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "bincode",
  "bytes",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1334,7 +1334,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1354,7 +1354,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
@@ -2257,7 +2257,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2457,6 +2457,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -3089,20 +3130,20 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.54.1"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
 dependencies = [
  "anyhow",
  "backon",
  "base64 0.22.1",
  "bytes",
- "chrono",
  "crc32c",
  "futures",
  "getrandom 0.2.12",
  "http 1.3.1",
  "http-body 1.0.0",
+ "jiff",
  "log",
  "md-5",
  "percent-encoding",
@@ -3113,6 +3154,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -3139,7 +3181,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3408,7 +3450,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3540,7 +3582,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3591,6 +3633,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3648,7 +3699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3694,14 +3745,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3793,7 +3844,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.111",
  "tempfile",
 ]
 
@@ -3820,7 +3871,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3833,7 +3884,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4045,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4717,7 +4768,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4973,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5017,7 +5068,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5075,7 +5126,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5142,7 +5193,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5153,7 +5204,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5298,7 +5349,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5427,7 +5478,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5553,7 +5604,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5683,7 +5734,7 @@ checksum = "291db8a81af4840c10d636e047cac67664e343be44e24dfdbd1492df9a5d3390"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5960,7 +6011,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -5994,7 +6045,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6208,7 +6259,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6219,7 +6270,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6230,7 +6281,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6241,7 +6292,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6720,7 +6771,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
  "synstructure 0.13.1",
 ]
 
@@ -6741,7 +6792,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6761,7 +6812,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
  "synstructure 0.13.1",
 ]
 
@@ -6790,7 +6841,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.3"
+version = "1.1.4"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.3" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.3" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.3" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.3" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.3" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.3" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.3" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.3" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.4" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.4" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.4" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.4" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.4" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.4" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.4" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.4" }
 dragonfly-api = "=2.1.87"
 thiserror = "2.0"
 futures = "0.3.31"
@@ -85,7 +85,7 @@ humantime = "2.3.0"
 prost-wkt-types = "0.6"
 chrono = { version = "0.4.42", features = ["serde", "clock"] }
 openssl = { version = "0.10", features = ["vendored"] }
-opendal = { version = "0.54.1", features = [
+opendal = { version = "0.55.0", features = [
     "services-s3",
     "services-azblob",
     "services-gcs",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace and dependencies in the `Cargo.toml` file to keep the project up-to-date with the latest releases. The main changes are version bumps for the workspace and several internal dependencies, as well as updating the `opendal` crate to a newer version.

Dependency version updates:

* Bumped the workspace `version` from `1.1.3` to `1.1.4` in `Cargo.toml`.
* Updated all internal workspace dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-metric`, `dragonfly-client-util`, `dragonfly-client-init`) from version `1.1.3` to `1.1.4` in `Cargo.toml`.

Third-party dependency update:

* Upgraded the `opendal` crate from version `0.54.1` to `0.55.0` in `Cargo.toml`, ensuring continued compatibility and access to new features and fixes.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
