### PR TITLE
chore(ci): add .git directory copy to Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     openssl libclang-dev pkg-config protobuf-compiler git \
     && rm -rf /var/lib/apt/lists/*
 
+COPY .git ./.git
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo ./.cargo
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     openssl libclang-dev pkg-config protobuf-compiler git \
     && rm -rf /var/lib/apt/lists/*
 
+COPY .git ./.git
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo ./.cargo
 

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app/client
 
+COPY .git ./.git
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo ./.cargo
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Docker build process for the CI environment by ensuring that the `.git` directory is copied into the Docker images. This change is applied to multiple Dockerfiles to enable build steps that require Git metadata, such as versioning or dependency resolution.

**Docker build process improvements:**

* Added `COPY .git ./.git` to `ci/Dockerfile` to include the Git repository metadata in the build context.
* Added `COPY .git ./.git` to `ci/Dockerfile.debug` for the same purpose in the debug image.
* Added `COPY .git ./.git` to `ci/Dockerfile.dfinit` to ensure Git information is available during the build.
<!--- Describe your changes in detail -->

## Related Issue
Fixed https://github.com/dragonflyoss/client/issues/1459
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
