### PR TITLE
feat: remove gzip, brotli, zstd, deflate from reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,21 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,22 +187,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -413,27 +382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -1030,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1108,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1143,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1173,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1193,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1210,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1225,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -1259,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1732,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",
@@ -4280,7 +4228,6 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -6856,24 +6803,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
-dependencies = [
- "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.4"
+version = "1.1.5"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.4" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.4" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.4" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.4" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.4" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.4" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.4" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.4" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.5" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.5" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.5" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.5" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.5" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.5" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.5" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.5" }
 dragonfly-api = "=2.1.87"
 thiserror = "2.0"
 futures = "0.3.31"
@@ -39,10 +39,6 @@ reqwest = { version = "0.12.4", features = [
     "native-tls",
     "default-tls",
     "rustls-tls",
-    "gzip",
-    "brotli",
-    "zstd",
-    "deflate",
     "blocking",
     "hickory-dns",
 ] }

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -180,10 +180,10 @@ impl ObjectStorage {
     pub fn new(scheme: Scheme) -> ClientResult<ObjectStorage> {
         // Initialize the reqwest client.
         let client = reqwest::Client::builder()
-            .gzip(true)
-            .brotli(true)
-            .zstd(true)
-            .deflate(true)
+            .no_gzip()
+            .no_brotli()
+            .no_zstd()
+            .no_deflate()
             .hickory_dns(true)
             .pool_max_idle_per_host(super::POOL_MAX_IDLE_PER_HOST)
             .tcp_keepalive(super::KEEP_ALIVE_INTERVAL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When gzip, brotli, zstd, or deflate support is enabled in reqwest, OpenDAL fails to correctly get the Content-Length for OSS objects.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/apache/opendal/issues/6857
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
