### PR TITLE
fix(http): correct assignment of response header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.5"
+version = "1.1.6"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.5" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.5" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.5" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.5" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.5" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.5" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.5" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.5" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.6" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.6" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.6" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.6" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.6" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.6" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.6" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.6" }
 dragonfly-api = "=2.1.87"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -319,7 +319,7 @@ impl super::Backend for HTTP {
         Ok(super::HeadResponse {
             success: response_status_code.is_success(),
             content_length: response_content_length,
-            http_header: Some(request_header),
+            http_header: Some(response_header),
             http_status_code: Some(response_status_code),
             error_message: Some(response_status_code.to_string()),
             entries: Vec::new(),


### PR DESCRIPTION
This pull request makes a small but important fix to the HTTP backend implementation in `dragonfly-client-backend/src/http.rs`. The change ensures that the correct HTTP headers are returned in the response.

* The `http_header` field in the `HeadResponse` struct is now set to `response_header` instead of `request_header`, ensuring that the response includes the actual headers received from the server.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
