### PR TITLE
feat(storage): support persistent tasks and pieces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.87"
+version = "2.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef8b4b8e47896501e1903302ef769db26e589d8ccc23256a9b473a8534c50cd"
+checksum = "66bdc5232ecbeffaeaaa6575713a1902705d8d9c289bf21911dd2144b90827f2"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.7
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.7" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.7" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.7" }
-dragonfly-api = "=2.1.87"
+dragonfly-api = "=2.1.89"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.4", features = [

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -33,6 +33,9 @@ pub const DEFAULT_CONTENT_DIR: &str = "content";
 /// DEFAULT_TASK_DIR is the default directory for store task.
 pub const DEFAULT_TASK_DIR: &str = "tasks";
 
+/// DEFAULT_PERSISTENT_TASK_DIR is the default directory for store persistent task.
+pub const DEFAULT_PERSISTENT_TASK_DIR: &str = "persistent-tasks";
+
 /// DEFAULT_PERSISTENT_CACHE_TASK_DIR is the default directory for store persistent cache task.
 pub const DEFAULT_PERSISTENT_CACHE_TASK_DIR: &str = "persistent-cache-tasks";
 
@@ -42,6 +45,15 @@ pub struct WritePieceResponse {
     pub length: u64,
 
     /// hash is the hash of the piece.
+    pub hash: String,
+}
+
+/// WritePersistentTaskResponse is the response of writing a persistent task.
+pub struct WritePersistentTaskResponse {
+    /// length is the length of the persistent task.
+    pub length: u64,
+
+    /// hash is the hash of the persistent task.
     pub hash: String,
 }
 

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -53,6 +53,7 @@ impl Content {
         }
 
         fs::create_dir_all(&dir.join(super::content::DEFAULT_TASK_DIR)).await?;
+        fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_TASK_DIR)).await?;
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_CACHE_TASK_DIR)).await?;
         info!("content initialized directory: {:?}", dir);
         Ok(Content { config, dir })
@@ -102,7 +103,7 @@ impl Content {
         let available_space = self.available_space()?;
         if available_space < content_length {
             warn!(
-                "not enough space to store the persistent cache task: available_space={}, content_length={}",
+                "not enough space to store the task: available_space={}, content_length={}",
                 available_space, content_length
             );
 
@@ -416,6 +417,244 @@ impl Content {
             .join(task_id)
     }
 
+    /// is_same_dev_inode_as_persistent_task checks if the persistent task and target
+    /// are the same device and inode.
+    pub async fn is_same_dev_inode_as_persistent_task(
+        &self,
+        task_id: &str,
+        to: &Path,
+    ) -> Result<bool> {
+        let task_path = self.get_persistent_task_path(task_id);
+        self.is_same_dev_inode(&task_path, to).await
+    }
+
+    /// create_persistent_task creates a new persistent task content.
+    ///
+    /// Behavior of `create_persistent_task`:
+    /// 1. If the persistent task already exists, return the persistent task path.
+    /// 2. If the persistent task does not exist, create the persistent task directory and file.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task(&self, task_id: &str, length: u64) -> Result<PathBuf> {
+        let task_path = self.get_persistent_task_path(task_id);
+        if task_path.exists() {
+            return Ok(task_path);
+        }
+
+        let task_dir = self
+            .dir
+            .join(super::content::DEFAULT_PERSISTENT_TASK_DIR)
+            .join(&task_id[..3]);
+        fs::create_dir_all(&task_dir).await.inspect_err(|err| {
+            error!("create {:?} failed: {}", task_dir, err);
+        })?;
+
+        let f = fs::File::create(task_dir.join(task_id))
+            .await
+            .inspect_err(|err| {
+                error!("create {:?} failed: {}", task_dir, err);
+            })?;
+
+        fallocate(&f, length).await.inspect_err(|err| {
+            error!("fallocate {:?} failed: {}", task_dir, err);
+        })?;
+
+        Ok(task_dir.join(task_id))
+    }
+
+    /// create_persistent_task_dir only creates the directory for the persistent task.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task_dir(&self, task_id: &str) -> Result<PathBuf> {
+        let task_path = self.get_persistent_task_path(task_id);
+        if task_path.exists() {
+            return Ok(task_path);
+        }
+
+        let task_dir = self
+            .dir
+            .join(super::content::DEFAULT_PERSISTENT_TASK_DIR)
+            .join(&task_id[..3]);
+        fs::create_dir_all(&task_dir).await.inspect_err(|err| {
+            error!("create {:?} failed: {}", task_dir, err);
+        })?;
+
+        Ok(task_dir)
+    }
+
+    /// Hard links the persistent task content to the destination.
+    ///
+    /// Behavior of `hard_link_persistent_task`:
+    /// 1. If the destination exists:
+    ///    1.1. If the source and destination share the same device and inode, return immediately.
+    ///    1.2. Otherwise, return an error.
+    /// 2. If the destination does not exist:
+    ///    2.1. If the hard link succeeds, return immediately.
+    ///    2.2. If the hard link fails, copy the persistent task content to the destination once the task is finished, then return immediately.
+    #[instrument(skip_all)]
+    pub async fn hard_link_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
+        let task_path = self.get_persistent_task_path(task_id);
+        if let Err(err) = fs::hard_link(task_path.clone(), to).await {
+            if err.kind() == std::io::ErrorKind::AlreadyExists {
+                if let Ok(true) = self.is_same_dev_inode(&task_path, to).await {
+                    info!("hard already exists, no need to operate");
+                    return Ok(());
+                }
+            }
+
+            warn!("hard link {:?} to {:?} failed: {}", task_path, to, err);
+            return Err(Error::IO(err));
+        }
+
+        info!("hard link {:?} to {:?} success", task_path, to);
+        Ok(())
+    }
+
+    /// Hard links a source file to the persistent task content path.
+    ///
+    /// Behavior:
+    /// 1. If the task path exists:
+    ///    1.1. If source and task share the same inode, return success.
+    ///    1.2. Otherwise, return an error (task content already exists).
+    /// 2. If the task path does not exist:
+    ///    2.1. Create hard link from source to task path.
+    ///    2.2. If hard link fails, return an error.
+    #[instrument(skip_all)]
+    pub async fn hard_link_to_persistent_task(&self, from: &Path, task_id: &str) -> Result<()> {
+        let task_path = self.get_persistent_task_path(task_id);
+        if let Err(err) = fs::hard_link(from, &task_path).await {
+            if err.kind() == std::io::ErrorKind::AlreadyExists {
+                if let Ok(true) = self.is_same_dev_inode(from, &task_path).await {
+                    info!("hard already exists, no need to operate");
+                    return Ok(());
+                }
+            }
+
+            warn!("hard link {:?} to {:?} failed: {}", from, task_path, err);
+            return Err(Error::IO(err));
+        }
+
+        info!("hard link {:?} to {:?} success", from, task_path);
+        Ok(())
+    }
+
+    /// copy_persistent_task copies the persistent task content to the destination.
+    #[instrument(skip_all)]
+    pub async fn copy_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
+        fs::copy(self.get_persistent_task_path(task_id), to).await?;
+        info!("copy to {:?} success", to);
+        Ok(())
+    }
+
+    /// read_persistent_piece reads the persistent piece from the content.
+    #[instrument(skip_all)]
+    pub async fn read_persistent_piece(
+        &self,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        range: Option<Range>,
+    ) -> Result<impl AsyncRead> {
+        let task_path = self.get_persistent_task_path(task_id);
+
+        // Calculate the target offset and length based on the range.
+        let (target_offset, target_length) =
+            super::content::calculate_piece_range(offset, length, range);
+
+        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+            error!("open {:?} failed: {}", task_path, err);
+        })?;
+        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
+
+        f_reader
+            .seek(SeekFrom::Start(target_offset))
+            .await
+            .inspect_err(|err| {
+                error!("seek {:?} failed: {}", task_path, err);
+            })?;
+
+        Ok(f_reader.take(target_length))
+    }
+
+    /// write_persistent_piece writes the persistent piece to the content and
+    /// calculates the hash of the piece by crc32.
+    #[instrument(skip_all)]
+    pub async fn write_persistent_piece<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        task_id: &str,
+        offset: u64,
+        expected_length: u64,
+        reader: &mut R,
+    ) -> Result<super::content::WritePieceResponse> {
+        // Open the file and seek to the offset.
+        let task_path = self.get_persistent_task_path(task_id);
+        let mut f = OpenOptions::new()
+            .truncate(false)
+            .write(true)
+            .open(task_path.as_path())
+            .await
+            .inspect_err(|err| {
+                error!("open {:?} failed: {}", task_path, err);
+            })?;
+
+        f.seek(SeekFrom::Start(offset)).await.inspect_err(|err| {
+            error!("seek {:?} failed: {}", task_path, err);
+        })?;
+
+        let reader = reader.take(expected_length);
+        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
+        let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
+
+        // Copy the piece to the file while updating the CRC32 value.
+        let mut hasher = crc32fast::Hasher::new();
+        let mut tee = InspectReader::new(reader, |bytes| {
+            hasher.update(bytes);
+        });
+
+        debug!("start to write piece to {:?}", task_path);
+        let length = io::copy(&mut tee, &mut writer).await.inspect_err(|err| {
+            error!("copy {:?} failed: {}", task_path, err);
+        })?;
+
+        writer.flush().await.inspect_err(|err| {
+            error!("flush {:?} failed: {}", task_path, err);
+        })?;
+        debug!("finish to write piece to {:?}", task_path);
+
+        if length != expected_length {
+            return Err(Error::Unknown(format!(
+                "expected length {} but got {}",
+                expected_length, length
+            )));
+        }
+
+        // Calculate the hash of the piece.
+        Ok(super::content::WritePieceResponse {
+            length,
+            hash: hasher.finalize().to_string(),
+        })
+    }
+
+    /// delete_task deletes the persistent task content.
+    pub async fn delete_persistent_task(&self, task_id: &str) -> Result<()> {
+        info!("delete persistent task content: {}", task_id);
+        let persistent_task_path = self.get_persistent_task_path(task_id);
+        fs::remove_file(persistent_task_path.as_path())
+            .await
+            .inspect_err(|err| {
+                error!("remove {:?} failed: {}", persistent_task_path, err);
+            })?;
+        Ok(())
+    }
+
+    /// get_persistent_task_path returns the persistent task path by task id.
+    fn get_persistent_task_path(&self, task_id: &str) -> PathBuf {
+        // The persistent task needs split by the first 3 characters of task id(sha256) to
+        // avoid too many files in one directory.
+        self.dir
+            .join(super::content::DEFAULT_PERSISTENT_TASK_DIR)
+            .join(&task_id[..3])
+            .join(task_id)
+    }
+
     /// is_same_dev_inode_as_persistent_cache_task checks if the persistent cache task and target
     /// are the same device and inode.
     pub async fn is_same_dev_inode_as_persistent_cache_task(
@@ -579,52 +818,6 @@ impl Content {
             })?;
 
         Ok(f_reader.take(target_length))
-    }
-
-    /// read_persistent_cache_piece_with_dual_read return two readers, one is the range reader, and the other is the
-    /// full reader of the persistent cache piece. It is used for cache the piece content to the proxy cache.
-    #[instrument(skip_all)]
-    pub async fn read_persistent_cache_piece_with_dual_read(
-        &self,
-        task_id: &str,
-        offset: u64,
-        length: u64,
-        range: Option<Range>,
-    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
-        let task_path = self.get_persistent_cache_task_path(task_id);
-
-        // Calculate the target offset and length based on the range.
-        let (target_offset, target_length) =
-            super::content::calculate_piece_range(offset, length, range);
-
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_range_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_range_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let range_reader = f_range_reader.take(target_length);
-
-        // Create full reader of the piece.
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_reader
-            .seek(SeekFrom::Start(offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let reader = f_reader.take(length);
-
-        Ok((range_reader, reader))
     }
 
     /// write_persistent_cache_piece writes the persistent cache piece to the content and
@@ -838,6 +1031,135 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "c4f108ab1d2b8cfdffe89ea9676af35123fa02e3c25167d62538f630d5d44745";
+        let task_path = content.create_persistent_task(task_id, 0).await.unwrap();
+        assert!(task_path.exists());
+        assert_eq!(task_path, temp_dir.path().join("content/persistent-tasks/c4f/c4f108ab1d2b8cfdffe89ea9676af35123fa02e3c25167d62538f630d5d44745"));
+
+        let task_path_exists = content.create_persistent_task(task_id, 0).await.unwrap();
+        assert_eq!(task_path, task_path_exists);
+    }
+
+    #[tokio::test]
+    async fn test_hard_link_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "5e81970eb2b048910cc84cab026b951f2ceac0a09c72c0717193bb6e466e11cd";
+        content.create_persistent_task(task_id, 0).await.unwrap();
+
+        let to = temp_dir
+            .path()
+            .join("5e81970eb2b048910cc84cab026b951f2ceac0a09c72c0717193bb6e466e11cd");
+        content
+            .hard_link_persistent_task(task_id, &to)
+            .await
+            .unwrap();
+        assert!(to.exists());
+
+        content
+            .hard_link_persistent_task(task_id, &to)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_copy_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "194b9c2018429689fb4e596a506c7e9db564c187b9709b55b33b96881dfb6dd5";
+        content.create_persistent_task(task_id, 64).await.unwrap();
+
+        let to = temp_dir
+            .path()
+            .join("194b9c2018429689fb4e596a506c7e9db564c187b9709b55b33b96881dfb6dd5");
+        content.copy_persistent_task(task_id, &to).await.unwrap();
+        assert!(to.exists());
+    }
+
+    #[tokio::test]
+    async fn test_delete_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "17430ba545c3ce82790e9c9f77e64dca44bb6d6a0c9e18be175037c16c73713d";
+        let task_path = content.create_persistent_task(task_id, 0).await.unwrap();
+        assert!(task_path.exists());
+
+        content.delete_persistent_task(task_id).await.unwrap();
+        assert!(!task_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_read_persistent_piece() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "9cb27a4af09aee4eb9f904170217659683f4a0ea7cd55e1a9fbcb99ddced659a";
+        content.create_persistent_task(task_id, 13).await.unwrap();
+
+        let data = b"hello, world!";
+        let mut reader = Cursor::new(data);
+        content
+            .write_persistent_piece(task_id, 0, 13, &mut reader)
+            .await
+            .unwrap();
+
+        let mut reader = content
+            .read_persistent_piece(task_id, 0, 13, None)
+            .await
+            .unwrap();
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, data);
+
+        let mut reader = content
+            .read_persistent_piece(
+                task_id,
+                0,
+                13,
+                Some(Range {
+                    start: 0,
+                    length: 5,
+                }),
+            )
+            .await
+            .unwrap();
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_write_persistent_piece() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "ca1afaf856e8a667fbd48093ca3ca1b8eeb4bf735912fbe551676bc5817a720a";
+        content.create_persistent_task(task_id, 4).await.unwrap();
+
+        let data = b"test";
+        let mut reader = Cursor::new(data);
+        let response = content
+            .write_persistent_piece(task_id, 0, 4, &mut reader)
+            .await
+            .unwrap();
+        assert_eq!(response.length, 4);
+        assert!(!response.hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_create_persistent_cache_task() {
         let temp_dir = tempdir().unwrap();
         let config = Arc::new(Config::default());
         let content = Content::new(config, temp_dir.path()).await.unwrap();

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -203,6 +203,171 @@ impl Storage {
         });
     }
 
+    /// hard_link_persistent_task hard links the persistent task content to the destination.
+    #[instrument(skip_all)]
+    pub async fn hard_link_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
+        self.content.hard_link_persistent_task(task_id, to).await
+    }
+
+    /// hard_link_to_persistent_task hard links the source file to the persistent task content.
+    #[instrument(skip_all)]
+    pub async fn hard_link_to_persistent_task(&self, from: &Path, task_id: &str) -> Result<()> {
+        self.content
+            .hard_link_to_persistent_task(from, task_id)
+            .await
+    }
+
+    /// copy_taskcopy_persistent_taskcopies the persistent task content to the destination.
+    #[instrument(skip_all)]
+    pub async fn copy_persistent_task(&self, id: &str, to: &Path) -> Result<()> {
+        self.content.copy_persistent_task(id, to).await
+    }
+
+    /// is_same_dev_inode_as_persistent_task checks if the persistent task content is on the same device inode as the
+    /// destination.
+    pub async fn is_same_dev_inode_as_persistent_task(&self, id: &str, to: &Path) -> Result<bool> {
+        self.content
+            .is_same_dev_inode_as_persistent_task(id, to)
+            .await
+    }
+
+    /// create_persistent_task_started prepares the metadata of the persistent task
+    /// and create directory for the persistent task.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task_started(
+        &self,
+        id: &str,
+        ttl: Duration,
+        piece_length: u64,
+        content_length: u64,
+    ) -> Result<metadata::PersistentTask> {
+        let metadata =
+            self.metadata
+                .create_persistent_task_started(id, ttl, piece_length, content_length)?;
+
+        self.content.create_persistent_task_dir(id).await?;
+        return Ok(metadata);
+    }
+
+    /// create_persistent_task creates and fallocates the persistent task content.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task(&self, id: &str, content_length: u64) -> Result<()> {
+        self.content
+            .create_persistent_task(id, content_length)
+            .await
+            .map(|_| ())
+    }
+
+    /// create_persistent_task_finished updates the metadata of the persistent task
+    /// when the persistent task creates finished.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task_finished(
+        &self,
+        id: &str,
+    ) -> Result<metadata::PersistentTask> {
+        self.metadata.create_persistent_task_finished(id)
+    }
+
+    /// create_persistent_task_failed deletes the persistent task when
+    /// the persistent task creates failed.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_task_failed(&self, id: &str) {
+        self.delete_persistent_task(id).await;
+    }
+
+    /// download_persistent_task_started updates the metadata of the persistent task
+    /// and creates the persistent task content when the persistent task downloads started.
+    #[instrument(skip_all)]
+    pub async fn download_persistent_task_started(
+        &self,
+        id: &str,
+        ttl: Duration,
+        persistent: bool,
+        piece_length: u64,
+        content_length: u64,
+        created_at: NaiveDateTime,
+    ) -> Result<metadata::PersistentTask> {
+        let metadata = self.metadata.download_persistent_task_started(
+            id,
+            ttl,
+            persistent,
+            piece_length,
+            content_length,
+            created_at,
+        )?;
+
+        self.content
+            .create_persistent_task(id, content_length)
+            .await?;
+        Ok(metadata)
+    }
+
+    /// download_persistent_task_finished updates the metadata of the persistent task when the persistent task downloads finished.
+    #[instrument(skip_all)]
+    pub fn download_persistent_task_finished(&self, id: &str) -> Result<metadata::PersistentTask> {
+        self.metadata.download_persistent_task_finished(id)
+    }
+
+    /// download_persistent_task_failed updates the metadata of the persistent task when the persistent task downloads failed.
+    #[instrument(skip_all)]
+    pub async fn download_persistent_task_failed(
+        &self,
+        id: &str,
+    ) -> Result<metadata::PersistentTask> {
+        self.metadata.download_persistent_task_failed(id)
+    }
+
+    /// upload_persistent_task_finished updates the metadata of the cahce task when persistent task uploads finished.
+    #[instrument(skip_all)]
+    pub fn upload_persistent_task_finished(&self, id: &str) -> Result<metadata::PersistentTask> {
+        self.metadata.upload_persistent_task_finished(id)
+    }
+
+    /// get_persistent_task returns the persistent task metadata.
+    #[instrument(skip_all)]
+    pub fn get_persistent_task(&self, id: &str) -> Result<Option<metadata::PersistentTask>> {
+        self.metadata.get_persistent_task(id)
+    }
+
+    /// persist_persistent_task persists the persistent task metadata.
+    #[instrument(skip_all)]
+    pub fn persist_persistent_task(&self, id: &str) -> Result<metadata::PersistentTask> {
+        self.metadata.persist_persistent_task(id)
+    }
+
+    /// is_persistent_task_exists returns whether the persistent task exists.
+    #[instrument(skip_all)]
+    pub fn is_persistent_task_exists(&self, id: &str) -> Result<bool> {
+        self.metadata.is_persistent_task_exists(id)
+    }
+
+    /// get_tasks returns the task metadatas.
+    #[instrument(skip_all)]
+    pub fn get_persistent_tasks(&self) -> Result<Vec<metadata::PersistentTask>> {
+        self.metadata.get_persistent_tasks()
+    }
+
+    /// delete_persistent_task deletes the persistent task metadatas, persistent task content and piece metadatas.
+    #[instrument(skip_all)]
+    pub async fn delete_persistent_task(&self, id: &str) {
+        self.metadata
+            .delete_persistent_task(id)
+            .unwrap_or_else(|err| {
+                error!("delete persistent task metadata failed: {}", err);
+            });
+
+        self.metadata.delete_pieces(id).unwrap_or_else(|err| {
+            error!("delete persistent piece metadatas failed: {}", err);
+        });
+
+        self.content
+            .delete_persistent_task(id)
+            .await
+            .unwrap_or_else(|err| {
+                error!("delete persistent task content failed: {}", err);
+            });
+    }
+
     /// hard_link_persistent_cache_task hard links the persistent cache task content to the destination.
     #[instrument(skip_all)]
     pub async fn hard_link_persistent_cache_task(&self, task_id: &str, to: &Path) -> Result<()> {
@@ -470,6 +635,53 @@ impl Storage {
         cache.delete_task(id).await.unwrap_or_else(|err| {
             info!("delete cache task from cache failed: {}", err);
         });
+    }
+
+    /// create_persistent_piece creates a new persistent piece.
+    #[instrument(skip_all)]
+    pub async fn create_persistent_piece<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        number: u32,
+        offset: u64,
+        length: u64,
+        reader: &mut R,
+    ) -> Result<metadata::Piece> {
+        let response = self
+            .content
+            .write_persistent_piece(task_id, offset, length, reader)
+            .await?;
+        let digest = Digest::new(Algorithm::Crc32, response.hash);
+
+        self.metadata.create_persistent_piece(
+            piece_id,
+            number,
+            offset,
+            length,
+            digest.to_string().as_str(),
+        )
+    }
+
+    /// register_persistent_piece registers a persistent piece without calculating its digest.
+    /// Used when creating a hardlink from persistent to storage. Since the piece
+    /// content is accessed via hardlink, digest calculation is deferred until another
+    /// peer downloads the piece.
+    #[instrument(skip_all)]
+    pub fn register_persistent_piece(
+        &self,
+        piece_id: &str,
+        number: u32,
+        offset: u64,
+        length: u64,
+    ) -> Result<metadata::Piece> {
+        self.metadata.create_persistent_piece(
+            piece_id,
+            number,
+            offset,
+            length,
+            "".to_string().as_str(),
+        )
     }
 
     /// create_persistent_cache_piece creates a new persistent cache piece.
@@ -744,6 +956,142 @@ impl Storage {
         self.metadata.piece_id(task_id, number)
     }
 
+    /// download_persistent_piece_started updates the metadata of the persistent piece and writes
+    /// the data of piece to file when the persistent piece downloads started.
+    #[instrument(skip_all)]
+    pub async fn download_persistent_piece_started(
+        &self,
+        piece_id: &str,
+        number: u32,
+    ) -> Result<metadata::Piece> {
+        // Wait for the piece to be finished.
+        match self.wait_for_persistent_piece_finished(piece_id).await {
+            Ok(piece) => Ok(piece),
+            // If piece is not found or wait timeout, create piece metadata.
+            Err(_) => self.metadata.download_piece_started(piece_id, number),
+        }
+    }
+
+    /// download_persistent_piece_from_parent_finished is used for downloading persistent piece from parent.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    pub async fn download_persistent_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        offset: u64,
+        length: u64,
+        expected_digest: &str,
+        parent_id: &str,
+        reader: &mut R,
+    ) -> Result<metadata::Piece> {
+        let response = self
+            .content
+            .write_persistent_piece(task_id, offset, length, reader)
+            .await?;
+
+        let length = response.length;
+        let digest = Digest::new(Algorithm::Crc32, response.hash);
+
+        // Check the digest of the piece.
+        if expected_digest.is_empty() {
+            warn!(
+                "expected digest is empty for piece {} downloaded from parent {}",
+                piece_id, parent_id
+            );
+        } else if expected_digest != digest.to_string() {
+            return Err(Error::DigestMismatch(
+                expected_digest.to_string(),
+                digest.to_string(),
+            ));
+        }
+
+        self.metadata.download_piece_finished(
+            piece_id,
+            offset,
+            length,
+            digest.to_string().as_str(),
+            Some(parent_id.to_string()),
+        )
+    }
+
+    /// download_persistent_piece_failed updates the metadata of the persistent piece when the persistent piece downloads failed.
+    #[instrument(skip_all)]
+    pub fn download_persistent_piece_failed(&self, piece_id: &str) -> Result<()> {
+        self.metadata.download_piece_failed(piece_id)
+    }
+
+    /// upload_persistent_piece updates the metadata of the piece and_then
+    /// returns the data of the piece.
+    #[instrument(skip_all)]
+    pub async fn upload_persistent_piece(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        range: Option<Range>,
+    ) -> Result<impl AsyncRead> {
+        // Wait for the persistent piece to be finished.
+        self.wait_for_persistent_piece_finished(piece_id).await?;
+
+        // Start uploading the persistent task.
+        self.metadata.upload_persistent_task_started(task_id)?;
+
+        // Get the persistent piece metadata and return the content of the persistent piece.
+        match self.metadata.get_piece(piece_id) {
+            Ok(Some(piece)) => {
+                match self
+                    .content
+                    .read_persistent_piece(task_id, piece.offset, piece.length, range)
+                    .await
+                {
+                    Ok(reader) => {
+                        // Finish uploading the persistent task.
+                        self.metadata.upload_persistent_task_finished(task_id)?;
+                        Ok(reader)
+                    }
+                    Err(err) => {
+                        // Failed uploading the persistent task.
+                        self.metadata.upload_persistent_task_failed(task_id)?;
+                        Err(err)
+                    }
+                }
+            }
+            Ok(None) => {
+                // Failed uploading the persistent task.
+                self.metadata.upload_persistent_task_failed(task_id)?;
+                Err(Error::PieceNotFound(piece_id.to_string()))
+            }
+            Err(err) => {
+                // Failed uploading the persistent task.
+                self.metadata.upload_persistent_task_failed(task_id)?;
+                Err(err)
+            }
+        }
+    }
+
+    /// get_persistent_piece returns the persistent piece metadata.
+    #[instrument(skip_all)]
+    pub fn get_persistent_piece(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
+        self.metadata.get_piece(piece_id)
+    }
+
+    /// is_persistent_piece_exists returns whether the persistent piece exists.
+    #[instrument(skip_all)]
+    pub fn is_persistent_piece_exists(&self, piece_id: &str) -> Result<bool> {
+        self.metadata.is_piece_exists(piece_id)
+    }
+
+    /// get_persistent_pieces returns the persistent piece metadatas.
+    pub fn get_persistent_pieces(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
+        self.metadata.get_pieces(task_id)
+    }
+
+    /// persistent_piece_id returns the persistent piece id.
+    #[inline]
+    pub fn persistent_piece_id(&self, task_id: &str, number: u32) -> String {
+        self.metadata.piece_id(task_id, number)
+    }
+
     /// download_persistent_cache_piece_started updates the metadata of the persistent cache piece and writes
     /// the data of piece to file when the persistent cache piece downloads started.
     #[instrument(skip_all)]
@@ -903,6 +1251,37 @@ impl Storage {
                 _ = interval.tick() => {
                     let piece = self
                         .get_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    // If the piece is finished, return.
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+                }
+                _ = &mut wait_timeout => {
+                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                }
+            }
+        }
+    }
+
+    /// wait_for_persistent_piece_finished waits for the persistent piece to be finished.
+    #[instrument(skip_all)]
+    async fn wait_for_persistent_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
+        // Total timeout for downloading a piece, combining the download time and the time to write to storage.
+        let wait_timeout = tokio::time::sleep(
+            self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
+        );
+        tokio::pin!(wait_timeout);
+
+        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let piece = self
+                        .get_persistent_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
                     // If the piece is finished, return.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add persistent-tasks directory and related create/read/write/hard-link/copy/delete operations (Linux/macOS)
- Extend Storage with persistent task lifecycle APIs: create/download/upload/delete, query, persist flag, hard-link and copy
- Introduce PersistentTask metadata model with full CRUD and state transitions
- Add persistent piece support: create/register (for hard-link), download/upload with digest check, and wait-for-finish helper
- Bump dragonfly-api dependency to 2.1.89
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
