### PR TITLE
refactor(metadata): change uploading_count type to u64

### DIFF
--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -45,7 +45,7 @@ pub struct Task {
     pub response_header: HashMap<String, String>,
 
     /// uploading_count is the count of the task being uploaded by other peers.
-    pub uploading_count: i64,
+    pub uploading_count: u64,
 
     /// uploaded_count is the count of the task has been uploaded by other peers.
     pub uploaded_count: u64,
@@ -345,7 +345,7 @@ pub struct CacheTask {
     pub response_header: HashMap<String, String>,
 
     /// uploading_count is the count of the task being uploaded by other peers.
-    pub uploading_count: i64,
+    pub uploading_count: u64,
 
     /// uploaded_count is the count of the task has been uploaded by other peers.
     pub uploaded_count: u64,
@@ -450,7 +450,7 @@ pub struct Piece {
     pub parent_id: Option<String>,
 
     /// DEPRECATED: uploading_count is the count of the piece being uploaded by other peers.
-    pub uploading_count: i64,
+    pub uploading_count: u64,
 
     /// DEPRECATED: uploaded_count is the count of the piece has been uploaded by other peers.
     pub uploaded_count: u64,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the type of the `uploading_count` field from `i64` to `u64` in several structs within `dragonfly-client-storage/src/metadata.rs`. This change ensures that upload counts, which should never be negative, are now represented as unsigned integers.

Type consistency and correctness:

* Changed the `uploading_count` field from `i64` to `u64` in the `Task` struct to prevent negative upload counts.
* Changed the `uploading_count` field from `i64` to `u64` in the `CacheTask` struct for the same reason.
* Changed the (deprecated) `uploading_count` field from `i64` to `u64` in the `Piece` struct.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
