### PR TITLE
build(ci): pin pprof version in Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM public.ecr.aws/docker/library/golang:1.24.0-alpine3.20 AS pprof
 
-RUN go install github.com/google/pprof@latest
+RUN go install github.com/google/pprof@v0.0.0-20251114195745-4902fdda35c8
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -64,7 +64,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 
 FROM public.ecr.aws/docker/library/golang:1.24.0-alpine3.20 AS pprof
 
-RUN go install github.com/google/pprof@latest
+RUN go install github.com/google/pprof@v0.0.0-20251114195745-4902fdda35c8
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 FROM public.ecr.aws/debian/debian:bookworm-slim


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the version of the `pprof` tool installed in our Docker build files to use a specific commit instead of always installing the latest version. This change ensures more consistent and reproducible builds.

Dependency version pinning:

* Updated the installation of `github.com/google/pprof` in both `ci/Dockerfile` and `ci/Dockerfile.debug` to use a specific commit hash (`v0.0.0-20251114195745-4902fdda35c8`) instead of `@latest`. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL65-R65) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L67-R67)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
