### PR TITLE
feat(backend): add stat request and response types

### DIFF
--- a/dragonfly-client-backend/examples/plugin/src/lib.rs
+++ b/dragonfly-client-backend/examples/plugin/src/lib.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use dragonfly_client_backend::{Backend, Body, GetRequest, GetResponse, HeadRequest, HeadResponse};
+use dragonfly_client_backend::{Backend, Body, GetRequest, GetResponse, StatRequest, StatResponse};
 use dragonfly_client_core::{Error, Result};
 
 /// Hdfs is a struct that implements the Backend trait
@@ -35,13 +35,13 @@ impl Backend for Hdfs {
         "hdfs".to_string()
     }
 
-    /// head is an async function that takes a HeadRequest and returns a HeadResponse.
-    async fn head(&self, request: HeadRequest) -> Result<HeadResponse> {
-        println!("HDFS head url: {}", request.url);
+    /// stat gets the metadata from the backend.
+    async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
+        println!("HDFS stat url: {}", request.url);
         Err(Error::Unimplemented)
     }
 
-    /// get is an async function that takes a GetRequest and returns a GetResponse.
+    /// get gets the content from the backend.
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
         println!("HDFS get url: {}", request.url);
         Err(Error::Unimplemented)

--- a/dragonfly-client-backend/src/hdfs.rs
+++ b/dragonfly-client-backend/src/hdfs.rs
@@ -87,11 +87,11 @@ impl super::Backend for Hdfs {
         self.scheme.clone()
     }
 
-    /// head gets the header of the request.
+    /// stat gets the metadata from the backend.
     #[instrument(skip_all)]
-    async fn head(&self, request: super::HeadRequest) -> ClientResult<super::HeadResponse> {
+    async fn stat(&self, request: super::StatRequest) -> ClientResult<super::StatResponse> {
         debug!(
-            "head request {} {}: {:?}",
+            "stat request {} {}: {:?}",
             request.task_id, request.url, request.http_header
         );
 
@@ -155,13 +155,13 @@ impl super::Backend for Hdfs {
             })?;
 
         debug!(
-            "head response {} {}: {}",
+            "stat response {} {}: {}",
             request.task_id,
             request.url,
             response.content_length()
         );
 
-        Ok(super::HeadResponse {
+        Ok(super::StatResponse {
             success: true,
             content_length: Some(response.content_length()),
             http_header: None,
@@ -171,7 +171,7 @@ impl super::Backend for Hdfs {
         })
     }
 
-    /// get returns content of requested file.
+    /// get gets the content from the backend.
     #[instrument(skip_all)]
     async fn get(
         &self,

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -65,8 +65,8 @@ pub const NAME: &str = "backend";
 /// Body is the body of the response.
 pub type Body = Box<dyn AsyncRead + Send + Unpin>;
 
-/// HeadRequest is the head request for backend.
-pub struct HeadRequest {
+/// StatRequest is the stat request for backend.
+pub struct StatRequest {
     /// task_id is the id of the task.
     pub task_id: String,
 
@@ -89,9 +89,9 @@ pub struct HeadRequest {
     pub hdfs: Option<Hdfs>,
 }
 
-/// HeadResponse is the head response for backend.
+/// StatResponse is the stat response for backend.
 #[derive(Debug)]
-pub struct HeadResponse {
+pub struct StatResponse {
     /// success is the success of the response.
     pub success: bool,
 
@@ -196,10 +196,10 @@ pub trait Backend {
     /// scheme returns the scheme of the backend.
     fn scheme(&self) -> String;
 
-    /// head gets the header of the request.
-    async fn head(&self, request: HeadRequest) -> Result<HeadResponse>;
+    /// stat gets the metadata from the backend.
+    async fn stat(&self, request: StatRequest) -> Result<StatResponse>;
 
-    /// get gets the content of the request.
+    /// get gets the content from the backend.
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>>;
 }
 

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -498,11 +498,11 @@ impl crate::Backend for ObjectStorage {
         self.scheme.to_string()
     }
 
-    /// head gets the header of the request.
+    /// stat gets the metadata from the backend.
     #[instrument(skip_all)]
-    async fn head(&self, request: super::HeadRequest) -> ClientResult<super::HeadResponse> {
+    async fn stat(&self, request: super::StatRequest) -> ClientResult<super::StatResponse> {
         debug!(
-            "head request {} {}: {:?}",
+            "stat request {} {}: {:?}",
             request.task_id, request.url, request.http_header
         );
 
@@ -513,7 +513,7 @@ impl crate::Backend for ObjectStorage {
             .map_err(|_| ClientError::InvalidURI(request.url.clone()))?;
         let parsed_url: super::object_storage::ParsedURL = url.try_into().inspect_err(|err| {
             error!(
-                "parse head request url failed {} {}: {}",
+                "parse stat request url failed {} {}: {}",
                 request.task_id, request.url, err
             );
         })?;
@@ -566,13 +566,13 @@ impl crate::Backend for ObjectStorage {
         })?;
 
         debug!(
-            "head response {} {}: {}",
+            "stat response {} {}: {}",
             request.task_id,
             request.url,
             response.content_length()
         );
 
-        Ok(super::HeadResponse {
+        Ok(super::StatResponse {
             success: true,
             content_length: Some(response.content_length()),
             http_header: None,
@@ -582,7 +582,7 @@ impl crate::Backend for ObjectStorage {
         })
     }
 
-    /// get returns content of requested file.
+    /// get gets the content from the backend.
     #[instrument(skip_all)]
     async fn get(
         &self,

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -33,7 +33,7 @@ use dragonfly_api::dfdaemon::v2::{
 };
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_api::scheduler::v2::DeleteHostRequest as SchedulerDeleteHostRequest;
-use dragonfly_client_backend::HeadRequest;
+use dragonfly_client_backend::StatRequest;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -785,7 +785,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
 
         // Head the task entries.
         let response = backend
-            .head(HeadRequest {
+            .stat(StatRequest {
                 task_id: request.task_id.clone(),
                 url: request.url.clone(),
                 http_header: Some(hashmap_to_headermap(&request.request_header).map_err(

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -37,7 +37,7 @@ use dragonfly_api::dfdaemon::v2::{
     SyncPiecesResponse, UpdatePersistentCacheTaskRequest, UpdatePersistentTaskRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
-use dragonfly_client_backend::HeadRequest;
+use dragonfly_client_backend::StatRequest;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -763,7 +763,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
         // Head the task entries.
         let response = backend
-            .head(HeadRequest {
+            .stat(StatRequest {
                 task_id: request.task_id.clone(),
                 url: request.url.clone(),
                 http_header: Some(hashmap_to_headermap(&request.request_header).map_err(

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -34,7 +34,7 @@ use dragonfly_api::scheduler::v2::{
     DownloadPieceFailedRequest, DownloadPieceFinishedRequest, RegisterPeerRequest,
     ReschedulePeerRequest, StatTaskRequest,
 };
-use dragonfly_client_backend::{BackendFactory, HeadRequest};
+use dragonfly_client_backend::{BackendFactory, StatRequest};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{BackendError, DownloadFromParentFailed, ErrorType, OrErr},
@@ -197,7 +197,7 @@ impl Task {
             http::Method::HEAD.as_str(),
         );
         let response = backend
-            .head(HeadRequest {
+            .stat(StatRequest {
                 task_id: id.to_string(),
                 url: request.url,
                 http_header: Some(request_header),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the backend API by renaming the "head" operation to "stat" across the codebase. The change is made to better reflect the purpose of the operation, which is to retrieve metadata (not just headers) from various storage backends. All related request and response types, trait methods, implementations, comments, and tests have been updated accordingly.

Key changes:

**API and Type Renaming:**

- Renamed `HeadRequest` and `HeadResponse` structs to `StatRequest` and `StatResponse` in `dragonfly-client-backend/src/lib.rs`, updating all associated documentation comments and usages. [[1]](diffhunk://#diff-6acac939bcda338ef32b3d844b2a6dad132f231935dd23bb8eead046b3effe94L68-R69) [[2]](diffhunk://#diff-6acac939bcda338ef32b3d844b2a6dad132f231935dd23bb8eead046b3effe94L92-R94)
- Changed the `Backend` trait method from `head` to `stat`, updating the signature and documentation to reflect the new naming and semantics.

**Backend Implementations:**

- Updated all backend implementations (`HTTP`, `Hdfs`, and `ObjectStorage`) to use the new `stat` method and types, including logging messages and error handling. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL330-R334) [[2]](diffhunk://#diff-cd1d5e18ab53a872f52409d8f57a522927798574e1bd8a3d6b9523ba20b9c661L90-R94) [[3]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L501-R505)
- Adjusted response construction and debug messages to use `StatResponse` and "stat" terminology. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL387-R391) [[2]](diffhunk://#diff-cd1d5e18ab53a872f52409d8f57a522927798574e1bd8a3d6b9523ba20b9c661L158-R164) [[3]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L569-R575)

**Tests and Example Plugins:**

- Modified tests and example plugin code to use `StatRequest` and the `stat` method instead of `HeadRequest` and `head`. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL554-R554) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL728-R728) [[3]](diffhunk://#diff-2922b9846b9b2dcd86c87b123fe3739c24d3d2984dfe6a2755baeaa452579cf1L17-R17) [[4]](diffhunk://#diff-2922b9846b9b2dcd86c87b123fe3739c24d3d2984dfe6a2755baeaa452579cf1L38-R44)

**Client Usage:**

- Updated all client-side usages and gRPC handlers to call `stat` with `StatRequest` instead of `head` with `HeadRequest`. [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL36-R36) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL788-R788) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L40-R40) [[4]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L766-R766) [[5]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L37-R37) [[6]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L200-R200)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
