### PR TITLE
feat(grpc): add stat_local_task functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.89"
+version = "2.1.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bdc5232ecbeffaeaaa6575713a1902705d8d9c289bf21911dd2144b90827f2"
+checksum = "a4efa4db9b3f3d2493720990bc1f8d7abe577fc3573d11625ff4caf763fbe9d0"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.7
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.7" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.7" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.7" }
-dragonfly-api = "=2.1.89"
+dragonfly-api = "=2.1.94"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.25", features = [

--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -212,6 +212,20 @@ lazy_static! {
             &["type"]
         ).expect("metric can be created");
 
+    /// STAT_TASK_COUNT is used to count the number of stat tasks.
+    pub static ref STAT_LOCAL_TASK_COUNT: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new("stat_local_task_total", "Counter of the number of the stat local task.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
+            &["type"]
+        ).expect("metric can be created");
+
+    /// STAT_TASK_FAILURE_COUNT is used to count the failed number of stat tasks.
+    pub static ref STAT_LOCAL_TASK_FAILURE_COUNT: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new("stat_local_task_failure_total", "Counter of the number of failed of the stat local task.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
+            &["type"]
+        ).expect("metric can be created");
+
     /// LIST_TASK_ENTRIES_COUNT is used to count the number of list task entries.
     pub static ref LIST_TASK_ENTRIES_COUNT: IntCounterVec =
         IntCounterVec::new(
@@ -768,6 +782,20 @@ pub fn collect_stat_task_started_metrics(typ: i32) {
 /// collect_stat_task_failure_metrics collects the stat task failure metrics.
 pub fn collect_stat_task_failure_metrics(typ: i32) {
     STAT_TASK_FAILURE_COUNT
+        .with_label_values(&[typ.to_string().as_str()])
+        .inc();
+}
+
+/// collect_stat_task_started_metrics collects the stat task started metrics.
+pub fn collect_local_stat_task_started_metrics(typ: i32) {
+    STAT_LOCAL_TASK_COUNT
+        .with_label_values(&[typ.to_string().as_str()])
+        .inc();
+}
+
+/// collect_stat_task_failure_metrics collects the stat task failure metrics.
+pub fn collect_local_stat_task_failure_metrics(typ: i32) {
+    STAT_LOCAL_TASK_FAILURE_COUNT
         .with_label_values(&[typ.to_string().as_str()])
         .inc();
 }

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -27,7 +27,8 @@ use dragonfly_api::dfdaemon::v2::{
     DownloadPersistentCacheTaskRequest, DownloadPersistentCacheTaskResponse,
     DownloadPersistentTaskRequest, DownloadPersistentTaskResponse, DownloadTaskRequest,
     DownloadTaskResponse, Entry, ListTaskEntriesRequest, ListTaskEntriesResponse,
-    StatCacheTaskRequest as DfdaemonStatCacheTaskRequest, StatPersistentCacheTaskRequest,
+    StatCacheTaskRequest as DfdaemonStatCacheTaskRequest, StatLocalTaskRequest,
+    StatLocalTaskResponse, StatPersistentCacheTaskRequest,
     StatTaskRequest as DfdaemonStatTaskRequest, UploadPersistentCacheTaskRequest,
     UploadPersistentTaskRequest,
 };
@@ -44,7 +45,8 @@ use dragonfly_client_metric::{
     collect_delete_task_failure_metrics, collect_delete_task_started_metrics,
     collect_download_task_failure_metrics, collect_download_task_finished_metrics,
     collect_download_task_started_metrics, collect_list_task_entries_failure_metrics,
-    collect_list_task_entries_started_metrics, collect_stat_task_failure_metrics,
+    collect_list_task_entries_started_metrics, collect_local_stat_task_failure_metrics,
+    collect_local_stat_task_started_metrics, collect_stat_task_failure_metrics,
     collect_stat_task_started_metrics, collect_upload_task_failure_metrics,
     collect_upload_task_finished_metrics, collect_upload_task_started_metrics,
 };
@@ -737,6 +739,54 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 Err(match err {
                     ClientError::TaskNotFound(id) => {
                         Status::not_found(format!("task not found: {}", id))
+                    }
+                    _ => Status::internal(err.to_string()),
+                })
+            }
+        }
+    }
+
+    /// stat_local_task stats the local task.
+    #[instrument(skip_all, fields(task_id, remote_ip))]
+    async fn stat_local_task(
+        &self,
+        request: Request<StatLocalTaskRequest>,
+    ) -> Result<Response<StatLocalTaskResponse>, Status> {
+        // If the parent context is set, use it as the parent context for the span.
+        if let Some(parent_ctx) = request.extensions().get::<Context>() {
+            Span::current().set_parent(parent_ctx.clone());
+        };
+
+        // Clone the request.
+        let request = request.into_inner();
+
+        // Get the task id from the request.
+        let task_id = request.task_id;
+
+        // Span record the task id.
+        Span::current().record("task_id", task_id.as_str());
+        Span::current().record(
+            "remote_ip",
+            request.remote_ip.clone().unwrap_or_default().as_str(),
+        );
+        info!("stat local task in upload server");
+
+        // Collect the local stat task metrics.
+        collect_local_stat_task_started_metrics(TaskType::Standard as i32);
+
+        match self.task.local_stat(task_id.as_str()).await {
+            Ok(response) => Ok(Response::new(response)),
+            Err(err) => {
+                // Collect the local stat task failure metrics.
+                collect_local_stat_task_failure_metrics(TaskType::Standard as i32);
+
+                // Log the error with detailed context.
+                error!("stat local task failed: {}", err);
+
+                // Map the error to an appropriate gRPC status.
+                Err(match err {
+                    ClientError::TaskNotFound(id) => {
+                        Status::not_found(format!("local task not found: {}", id))
                     }
                     _ => Status::internal(err.to_string()),
                 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

support stat task from local client, to get status of task on specific peer node

## Related Issue

https://github.com/dragonflyoss/client/issues/1544

## Motivation and Context

dragonfly scheduler statImage/statFile return the finished or failed status of each task, to get preheat status

