### PR TITLE
refactor: rename and simplify stat task methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.1.94"
+version = "2.1.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4efa4db9b3f3d2493720990bc1f8d7abe577fc3573d11625ff4caf763fbe9d0"
+checksum = "23320c2abc12035f6c33df860a869d7a1b2f774b057b3505065a7d8a01f0c7c6"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.7
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.7" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.7" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.7" }
-dragonfly-api = "=2.1.94"
+dragonfly-api = "=2.1.97"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.25", features = [

--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -786,15 +786,15 @@ pub fn collect_stat_task_failure_metrics(typ: i32) {
         .inc();
 }
 
-/// collect_stat_task_started_metrics collects the stat task started metrics.
-pub fn collect_local_stat_task_started_metrics(typ: i32) {
+/// collect_stat_local_task_started_metrics collects the stat local task started metrics.
+pub fn collect_stat_local_task_started_metrics(typ: i32) {
     STAT_LOCAL_TASK_COUNT
         .with_label_values(&[typ.to_string().as_str()])
         .inc();
 }
 
-/// collect_stat_task_failure_metrics collects the stat task failure metrics.
-pub fn collect_local_stat_task_failure_metrics(typ: i32) {
+/// collect_stat_local_task_failure_metrics collects the stat local task failure metrics.
+pub fn collect_stat_local_task_failure_metrics(typ: i32) {
     STAT_LOCAL_TASK_FAILURE_COUNT
         .with_label_values(&[typ.to_string().as_str()])
         .inc();

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -45,8 +45,8 @@ use dragonfly_client_metric::{
     collect_delete_task_failure_metrics, collect_delete_task_started_metrics,
     collect_download_task_failure_metrics, collect_download_task_finished_metrics,
     collect_download_task_started_metrics, collect_list_task_entries_failure_metrics,
-    collect_list_task_entries_started_metrics, collect_local_stat_task_failure_metrics,
-    collect_local_stat_task_started_metrics, collect_stat_task_failure_metrics,
+    collect_list_task_entries_started_metrics, collect_stat_local_task_failure_metrics,
+    collect_stat_local_task_started_metrics, collect_stat_task_failure_metrics,
     collect_stat_task_started_metrics, collect_upload_task_failure_metrics,
     collect_upload_task_finished_metrics, collect_upload_task_started_metrics,
 };
@@ -687,7 +687,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
     }
 
     /// stat_task gets the status of the task.
-    #[instrument(skip_all, fields(host_id, task_id, remote_ip, local_only))]
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn stat_task(
         &self,
         request: Request<DfdaemonStatTaskRequest>,
@@ -706,9 +706,6 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // Get the task id from the request.
         let task_id = request.task_id;
 
-        // Get the local_only flag from the request, default to false.
-        let local_only = request.local_only;
-
         // Span record the host id and task id.
         Span::current().record("host_id", host_id.as_str());
         Span::current().record("task_id", task_id.as_str());
@@ -716,17 +713,11 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             "remote_ip",
             request.remote_ip.clone().unwrap_or_default().as_str(),
         );
-        Span::current().record("local_only", local_only.to_string().as_str());
         info!("stat task in download server");
 
         // Collect the stat task metrics.
         collect_stat_task_started_metrics(TaskType::Standard as i32);
-
-        match self
-            .task
-            .stat(task_id.as_str(), host_id.as_str(), local_only)
-            .await
-        {
+        match self.task.stat(task_id.as_str(), host_id.as_str()).await {
             Ok(task) => Ok(Response::new(task)),
             Err(err) => {
                 // Collect the stat task failure metrics.
@@ -772,13 +763,13 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         info!("stat local task in upload server");
 
         // Collect the local stat task metrics.
-        collect_local_stat_task_started_metrics(TaskType::Standard as i32);
+        collect_stat_local_task_started_metrics(TaskType::Standard as i32);
 
-        match self.task.local_stat(task_id.as_str()).await {
+        match self.task.stat_local(task_id.as_str()).await {
             Ok(response) => Ok(Response::new(response)),
             Err(err) => {
                 // Collect the local stat task failure metrics.
-                collect_local_stat_task_failure_metrics(TaskType::Standard as i32);
+                collect_stat_local_task_failure_metrics(TaskType::Standard as i32);
 
                 // Log the error with detailed context.
                 error!("stat local task failed: {}", err);
@@ -1406,7 +1397,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
     }
 
     /// stat_cache_task gets the status of the cache task.
-    #[instrument(skip_all, fields(host_id, task_id, remote_pi, local_only))]
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn stat_cache_task(
         &self,
         _request: Request<DfdaemonStatCacheTaskRequest>,

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -48,8 +48,8 @@ use dragonfly_client_metric::{
     collect_delete_task_failure_metrics, collect_delete_task_started_metrics,
     collect_download_task_failure_metrics, collect_download_task_finished_metrics,
     collect_download_task_started_metrics, collect_list_task_entries_failure_metrics,
-    collect_list_task_entries_started_metrics, collect_local_stat_task_failure_metrics,
-    collect_local_stat_task_started_metrics, collect_stat_task_failure_metrics,
+    collect_list_task_entries_started_metrics, collect_stat_local_task_failure_metrics,
+    collect_stat_local_task_started_metrics, collect_stat_task_failure_metrics,
     collect_stat_task_started_metrics, collect_update_task_failure_metrics,
     collect_update_task_started_metrics, collect_upload_piece_failure_metrics,
     collect_upload_piece_finished_metrics, collect_upload_piece_started_metrics,
@@ -668,7 +668,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
     }
 
     /// stat_task stats the task.
-    #[instrument(skip_all, fields(host_id, task_id, remote_ip, local_only))]
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn stat_task(&self, request: Request<StatTaskRequest>) -> Result<Response<Task>, Status> {
         // If the parent context is set, use it as the parent context for the span.
         if let Some(parent_ctx) = request.extensions().get::<Context>() {
@@ -684,9 +684,6 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         // Get the task id from the request.
         let task_id = request.task_id;
 
-        // Get the local_only flag from the request, default to false.
-        let local_only = request.local_only;
-
         // Span record the host id and task id.
         Span::current().record("host_id", host_id.as_str());
         Span::current().record("task_id", task_id.as_str());
@@ -694,17 +691,11 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             "remote_ip",
             request.remote_ip.clone().unwrap_or_default().as_str(),
         );
-        Span::current().record("local_only", local_only.to_string().as_str());
         info!("stat task in upload server");
 
         // Collect the stat task metrics.
         collect_stat_task_started_metrics(TaskType::Standard as i32);
-
-        match self
-            .task
-            .stat(task_id.as_str(), host_id.as_str(), local_only)
-            .await
-        {
+        match self.task.stat(task_id.as_str(), host_id.as_str()).await {
             Ok(task) => Ok(Response::new(task)),
             Err(err) => {
                 // Collect the stat task failure metrics.
@@ -750,13 +741,12 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         info!("stat local task in upload server");
 
         // Collect the local stat task metrics.
-        collect_local_stat_task_started_metrics(TaskType::Standard as i32);
-
-        match self.task.local_stat(task_id.as_str()).await {
+        collect_stat_local_task_started_metrics(TaskType::Standard as i32);
+        match self.task.stat_local(task_id.as_str()).await {
             Ok(response) => Ok(Response::new(response)),
             Err(err) => {
                 // Collect the local stat task failure metrics.
-                collect_local_stat_task_failure_metrics(TaskType::Standard as i32);
+                collect_stat_local_task_failure_metrics(TaskType::Standard as i32);
 
                 // Log the error with detailed context.
                 error!("stat local task failed: {}", err);
@@ -2383,7 +2373,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
     }
 
     /// stat_cache_task stats the cache task.
-    #[instrument(skip_all, fields(host_id, task_id, remote_ip, local_only))]
+    #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn stat_cache_task(
         &self,
         _request: Request<StatCacheTaskRequest>,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Rename `local_stat` to `stat_local` for consistency
- Rename metric functions: `collect_local_stat_task_*` to `collect_stat_local_task_*`
- Remove `local_only` parameter from `stat_task` methods
- Simplify `stat` method to always query scheduler instead of local storage
- Clean up `stat_local` implementation using `Into` trait for timestamp conversions
- Update instrument fields in `stat_task` and `stat_cache_task` (remove `local_only`)
- Remove unused imports (`HashMap`, `SizeScope`)
- Update dragonfly-api version from 2.1.94 to 2.1.97
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
