### PR TITLE
feat(progress): add option to disable progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.7"
+version = "1.1.8"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.7" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.7" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.7" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.7" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.7" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.7" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.7" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.7" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.8" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.8" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.8" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.8" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.8" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.8" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.8" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.8" }
 dragonfly-api = "=2.1.97"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -109,6 +109,13 @@ pub struct ExportCommand {
     endpoint: PathBuf,
 
     #[arg(
+        long,
+        default_value_t = false,
+        help = "Specify whether to disable the progress bar display"
+    )]
+    no_progress: bool,
+
+    #[arg(
         short = 'l',
         long,
         default_value = "info",
@@ -495,7 +502,12 @@ impl ExportCommand {
         };
 
         // Initialize progress bar.
-        let progress_bar = ProgressBar::new(0);
+        let progress_bar = if self.no_progress {
+            ProgressBar::hidden()
+        } else {
+            ProgressBar::new(0)
+        };
+
         progress_bar.set_style(
             ProgressStyle::with_template(
                 "[{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -101,6 +101,13 @@ pub struct ImportCommand {
     endpoint: PathBuf,
 
     #[arg(
+        long,
+        default_value_t = false,
+        help = "Specify whether to disable the progress bar display"
+    )]
+    no_progress: bool,
+
+    #[arg(
         short = 'l',
         long,
         default_value = "info",
@@ -317,7 +324,12 @@ impl ImportCommand {
         let absolute_path = Path::new(&self.path).absolutize()?;
         info!("import file: {}", absolute_path.to_string_lossy());
 
-        let progress_bar = ProgressBar::new_spinner();
+        let progress_bar = if self.no_progress {
+            ProgressBar::hidden()
+        } else {
+            ProgressBar::new_spinner()
+        };
+
         progress_bar.enable_steady_tick(DEFAULT_PROGRESS_BAR_STEADY_TICK_INTERVAL);
         progress_bar.set_style(
             ProgressStyle::with_template("{spinner:.blue} {msg}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the project version and synchronizes the versions of all workspace dependencies to `1.1.8` in the `Cargo.toml` file.

Version updates:

* Bumped the workspace package version from `1.1.7` to `1.1.8`.
* Updated all internal workspace dependencies (`dragonfly-client`, `dragonfly-client-core`, `dragonfly-client-config`, `dragonfly-client-storage`, `dragonfly-client-backend`, `dragonfly-client-metric`, `dragonfly-client-util`, `dragonfly-client-init`) to version `1.1.8` for consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
