### PR TITLE
feat(storage): add download persistent piece methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.10"
+version = "1.1.11"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.10" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.10" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.10" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.10" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.10" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.10" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.10" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.10" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.11" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.11" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.11" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.11" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.11" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.11" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.11" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.11" }
 dragonfly-api = "=2.2.7"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -772,7 +772,7 @@ impl crate::Backend for ObjectStorage {
             success: true,
             http_header: None,
             http_status_code: Some(reqwest::StatusCode::OK),
-            content_length: None,
+            content_length: Some(content_length),
             error_message: None,
         })
     }

--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -581,9 +581,8 @@ pub fn collect_upload_task_finished_metrics(
     // Collect the slow upload Level1 task for analysis.
     if task_size == TaskSize::Level1 && cost > UPLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
         warn!(
-            "upload task cost is too long: {}ms {}bytes",
-            cost.as_millis(),
-            content_length,
+            "upload task, cost: {:?}, size: {} bytes",
+            cost, content_length,
         );
     }
 
@@ -645,11 +644,7 @@ pub fn collect_download_task_finished_metrics(
     // Nydus will request the small range of the file, so the download task duration
     // should be short. Collect the slow download Level1 task for analysis.
     if task_size == TaskSize::Level1 && cost > DOWNLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
-        warn!(
-            "download task cost is too long: {}ms {}bytes",
-            cost.as_millis(),
-            size,
-        );
+        warn!("download task, cost: {:?}, size: {} bytes", cost, size,);
     }
 
     let typ = typ.to_string();

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -1558,6 +1558,7 @@ impl Metadata<RocksdbStorageEngine> {
             &[
                 Task::NAMESPACE,
                 Piece::NAMESPACE,
+                PersistentTask::NAMESPACE,
                 PersistentCacheTask::NAMESPACE,
                 CacheTask::NAMESPACE,
             ],

--- a/dragonfly-client/src/bin/dfstore/import.rs
+++ b/dragonfly-client/src/bin/dfstore/import.rs
@@ -361,7 +361,7 @@ impl ImportCommand {
         );
         progress_bar.set_message("Importing...");
 
-        let persistent_task = dfdaemon_download_client
+        dfdaemon_download_client
             .upload_persistent_task(UploadPersistentTaskRequest {
                 url: self.url.to_string(),
                 object_storage: Some(ObjectStorage {
@@ -387,7 +387,7 @@ impl ImportCommand {
             })
             .await?;
 
-        progress_bar.finish_with_message(format!("Done: {}", persistent_task.id));
+        progress_bar.finish_with_message(format!("Done: {}", self.url));
         Ok(())
     }
 

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -913,7 +913,11 @@ impl Piece {
 
         // Clean up residual piece metadata if error occurred.
         let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self.storage.download_piece_failed(piece_id).err() {
+            if let Some(err) = self
+                .storage
+                .download_persistent_piece_failed(piece_id)
+                .err()
+            {
                 error!("set piece metadata failed: {}", err)
             };
         });
@@ -921,7 +925,7 @@ impl Piece {
         // Record the start of downloading piece.
         let piece = self
             .storage
-            .download_piece_started(piece_id, number)
+            .download_persistent_piece_started(piece_id, number)
             .await?;
 
         // If the piece is downloaded by the other thread,
@@ -1010,7 +1014,7 @@ impl Piece {
         // Record the finish of downloading piece.
         match self
             .storage
-            .download_piece_from_source_finished(
+            .download_persistent_piece_from_source_finished(
                 piece_id,
                 task_id,
                 offset,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces several improvements and refactorings to the persistent piece download/upload workflow, logging, and metrics collection in the Dragonfly client. The changes focus on enhancing observability, clarifying code intent, and improving the handling of persistent tasks and pieces. The most significant updates include new methods for persistent piece handling, improved logging for uploads, and updates to metrics reporting.

**Persistent Piece Handling and Metadata**

* Added new methods to `Storage` for handling the completion of persistent piece downloads from the source (`download_persistent_piece_from_source_finished` and its helper), and updated related calls in the `Piece` resource to use these new persistent-specific methods. [[1]](diffhunk://#diff-09bca31ba146d9bc116819606a37c3f4073946a1e2af40382b3c41e440869e6eR1006-R1052) [[2]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L916-R928) [[3]](diffhunk://#diff-475bfaadbebd4a013fc563ecdf5dc59fc9f5258738fc46ff30b0ac3cea0ad515L1013-R1017)
* Updated metadata initialization to include the `PersistentTask` namespace, ensuring correct tracking of persistent tasks.

**Logging and Observability**

* Enhanced logging in `PersistentTask` methods to provide detailed timing and size information for uploads to both local and source storage, and added `#[instrument(skip_all)]` for better tracing. [[1]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R325) [[2]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R348-R358) [[3]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R446-R450) [[4]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R544-R568) [[5]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R616-R620)
* Improved warning messages in metrics collection for upload and download tasks to include more precise cost and size details. [[1]](diffhunk://#diff-e0465731b8631d47250b40554f866a41fbb6e2d1cf95e0a9acec327b3ad0e9afL584-R585) [[2]](diffhunk://#diff-e0465731b8631d47250b40554f866a41fbb6e2d1cf95e0a9acec327b3ad0e9afL648-R647)

**Bug Fixes and Minor Improvements**

* Fixed the response to always report `content_length` in the object storage backend, ensuring the value is set correctly on success.
* Removed a redundant log message after uploading persistent task content, reducing log noise.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
