### PR TITLE
chore(deps): update dependencies to version 1.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.2.7"
+version = "2.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c668a9a422732d69cc38dc4fe47afbf9fa9a6281b48c5283b810b64ba5ef6a3d"
+checksum = "0313125f2240495343ebfd697e35ed736f63e77a4ddd89279341459676121e04"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.14.1",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "headers 0.4.1",
  "http 1.3.1",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.13"
+version = "1.1.14"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,15 +23,15 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.13" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.13" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.13" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.13" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.13" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.13" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.13" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.13" }
-dragonfly-api = "=2.2.7"
+dragonfly-client = { path = "dragonfly-client", version = "1.1.14" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.14" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.14" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.14" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.14" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.14" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.14" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.14" }
+dragonfly-api = "=2.2.8"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.26", features = [

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -1061,6 +1061,7 @@ impl PersistentTask {
                                     self.config.download.concurrent_piece_count,
                                 ),
                                 piece_count: task.piece_count(),
+                                need_back_to_source: false,
                             },
                         ),
                     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes a minor version bump and dependency updates across the workspace, along with a small bugfix in the `PersistentTask` resource implementation.

Dependency and version updates:

* Bumped the workspace version to `1.1.14` in `Cargo.toml` and updated all internal `dragonfly-client-*` dependencies to version `1.1.14`. Also updated the `dragonfly-api` dependency from `2.2.7` to `2.2.8`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R34)

Bugfix:

* Set the `need_back_to_source` field to `false` when constructing the `PersistentTask` resource in `dragonfly-client/src/resource/persistent_task.rs`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
