### PR TITLE
refactor(gc): rename dist_* variables to disk_* for clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.14"
+version = "1.1.15"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.14" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.14" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.14" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.14" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.14" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.14" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.14" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.14" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.15" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.15" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.15" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.15" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.15" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.15" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.15" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.15" }
 dragonfly-api = "=2.2.8"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -280,21 +280,21 @@ fn default_gc_policy_persistent_cache_task_ttl() -> Duration {
     Duration::from_secs(86_400)
 }
 
-/// default_gc_policy_dist_threshold is the default threshold of the disk usage to do gc.
+/// default_gc_policy_disk_threshold is the default threshold of the disk usage to do gc.
 #[inline]
-fn default_gc_policy_dist_threshold() -> ByteSize {
+fn default_gc_policy_disk_threshold() -> ByteSize {
     ByteSize::default()
 }
 
-/// default_gc_policy_dist_high_threshold_percent is the default high threshold percent of the disk usage.
+/// default_gc_policy_disk_high_threshold_percent is the default high threshold percent of the disk usage.
 #[inline]
-fn default_gc_policy_dist_high_threshold_percent() -> u8 {
+fn default_gc_policy_disk_high_threshold_percent() -> u8 {
     80
 }
 
-/// default_gc_policy_dist_low_threshold_percent is the default low threshold percent of the disk usage.
+/// default_gc_policy_disk_low_threshold_percent is the default low threshold percent of the disk usage.
 #[inline]
-fn default_gc_policy_dist_low_threshold_percent() -> u8 {
+fn default_gc_policy_disk_low_threshold_percent() -> u8 {
     60
 }
 
@@ -990,42 +990,52 @@ pub struct Policy {
     )]
     pub persistent_cache_task_ttl: Duration,
 
-    /// Dist threshold optionally defines a specific disk capacity to be used as the base for
-    /// calculating GC trigger points with `dist_high_threshold_percent` and `dist_low_threshold_percent`.
+    /// Disk threshold optionally defines a specific disk capacity to be used as the base for
+    /// calculating GC trigger points with `disk_high_threshold_percent` and `disk_low_threshold_percent`.
     ///
-    /// - If a value is provided (e.g., "500GB"), the percentage-based thresholds (`dist_high_threshold_percent`,
-    ///   `dist_low_threshold_percent`) are applied relative to this specified capacity.
+    /// - If a value is provided (e.g., "500GB"), the percentage-based thresholds (`disk_high_threshold_percent`,
+    ///   `disk_low_threshold_percent`) are applied relative to this specified capacity.
     /// - If not provided or set to 0 (the default behavior), these percentage-based thresholds are applied
     ///   relative to the total actual disk space.
     ///
     /// This allows dfdaemon to effectively manage a logical portion of the disk for its cache,
     /// rather than always considering the entire disk volume.
-    #[serde(with = "bytesize_serde", default = "default_gc_policy_dist_threshold")]
-    pub dist_threshold: ByteSize,
+    #[serde(
+        with = "bytesize_serde",
+        default = "default_gc_policy_disk_threshold",
+        alias = "distThreshold"
+    )]
+    pub disk_threshold: ByteSize,
 
-    /// Dist high threshold percent is the high threshold percent of the disk usage.
+    /// Disk high threshold percent is the high threshold percent of the disk usage.
     /// If the disk usage is greater than the threshold, dfdaemon will do gc.
-    #[serde(default = "default_gc_policy_dist_high_threshold_percent")]
+    #[serde(
+        default = "default_gc_policy_disk_high_threshold_percent",
+        alias = "distHighThresholdPercent"
+    )]
     #[validate(range(min = 1, max = 99))]
-    pub dist_high_threshold_percent: u8,
+    pub disk_high_threshold_percent: u8,
 
-    /// Dist low threshold percent is the low threshold percent of the disk usage.
+    /// Disk low threshold percent is the low threshold percent of the disk usage.
     /// If the disk usage is less than the threshold, dfdaemon will stop gc.
-    #[serde(default = "default_gc_policy_dist_low_threshold_percent")]
+    #[serde(
+        default = "default_gc_policy_disk_low_threshold_percent",
+        alias = "distLowThresholdPercent"
+    )]
     #[validate(range(min = 1, max = 99))]
-    pub dist_low_threshold_percent: u8,
+    pub disk_low_threshold_percent: u8,
 }
 
 /// Policy implements Default.
 impl Default for Policy {
     fn default() -> Self {
         Policy {
-            dist_threshold: default_gc_policy_dist_threshold(),
+            disk_threshold: default_gc_policy_disk_threshold(),
             task_ttl: default_gc_policy_task_ttl(),
             persistent_task_ttl: default_gc_policy_persistent_task_ttl(),
             persistent_cache_task_ttl: default_gc_policy_persistent_cache_task_ttl(),
-            dist_high_threshold_percent: default_gc_policy_dist_high_threshold_percent(),
-            dist_low_threshold_percent: default_gc_policy_dist_low_threshold_percent(),
+            disk_high_threshold_percent: default_gc_policy_disk_high_threshold_percent(),
+            disk_low_threshold_percent: default_gc_policy_disk_low_threshold_percent(),
         }
     }
 }
@@ -2036,9 +2046,9 @@ key: /etc/ssl/private/client.pem
             task_ttl: Duration::from_secs(12 * 3600),
             persistent_task_ttl: Duration::from_secs(24 * 3600),
             persistent_cache_task_ttl: Duration::from_secs(48 * 3600),
-            dist_threshold: ByteSize::mb(100),
-            dist_high_threshold_percent: 90,
-            dist_low_threshold_percent: 70,
+            disk_threshold: ByteSize::mb(100),
+            disk_high_threshold_percent: 90,
+            disk_low_threshold_percent: 70,
         };
         assert!(valid_policy.validate().is_ok());
 
@@ -2046,9 +2056,9 @@ key: /etc/ssl/private/client.pem
             task_ttl: Duration::from_secs(12 * 3600),
             persistent_task_ttl: Duration::from_secs(24 * 3600),
             persistent_cache_task_ttl: Duration::from_secs(48 * 3600),
-            dist_threshold: ByteSize::mb(100),
-            dist_high_threshold_percent: 100,
-            dist_low_threshold_percent: 70,
+            disk_threshold: ByteSize::mb(100),
+            disk_high_threshold_percent: 100,
+            disk_low_threshold_percent: 70,
         };
         assert!(invalid_policy.validate().is_err());
     }
@@ -2078,8 +2088,8 @@ key: /etc/ssl/private/client.pem
             gc.policy.persistent_cache_task_ttl,
             Duration::from_secs(48 * 3600)
         );
-        assert_eq!(gc.policy.dist_high_threshold_percent, 90);
-        assert_eq!(gc.policy.dist_low_threshold_percent, 70);
+        assert_eq!(gc.policy.disk_high_threshold_percent, 90);
+        assert_eq!(gc.policy.disk_low_threshold_percent, 70);
     }
 
     #[test]

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -61,8 +61,8 @@ impl Content {
 
     /// available_space returns the available space of the disk.
     pub fn available_space(&self) -> Result<u64> {
-        let dist_threshold = self.config.gc.policy.dist_threshold;
-        if dist_threshold != ByteSize::default() {
+        let disk_threshold = self.config.gc.policy.disk_threshold;
+        if disk_threshold != ByteSize::default() {
             let usage_space = WalkDir::new(&self.dir)
                 .into_iter()
                 .filter_map(|entry| entry.ok())
@@ -70,16 +70,16 @@ impl Content {
                 .filter(|metadata| metadata.is_file())
                 .fold(0, |acc, m| acc + m.len());
 
-            if usage_space >= dist_threshold.as_u64() {
+            if usage_space >= disk_threshold.as_u64() {
                 warn!(
-                    "usage space {} is greater than dist threshold {}, no need to calculate available space",
-                    usage_space, dist_threshold
+                    "usage space {} is greater than disk threshold {}, no need to calculate available space",
+                    usage_space, disk_threshold
                 );
 
                 return Ok(0);
             }
 
-            return Ok(dist_threshold.as_u64() - usage_space);
+            return Ok(disk_threshold.as_u64() - usage_space);
         }
 
         let stat = fs2::statvfs(&self.dir)?;
@@ -88,10 +88,10 @@ impl Content {
 
     /// total_space returns the total space of the disk.
     pub fn total_space(&self) -> Result<u64> {
-        // If the dist_threshold is set, return it directly.
-        let dist_threshold = self.config.gc.policy.dist_threshold;
-        if dist_threshold != ByteSize::default() {
-            return Ok(dist_threshold.as_u64());
+        // If the disk_threshold is set, return it directly.
+        let disk_threshold = self.config.gc.policy.disk_threshold;
+        if disk_threshold != ByteSize::default() {
+            return Ok(disk_threshold.as_u64());
         }
 
         let stat = fs2::statvfs(&self.dir)?;
@@ -1324,7 +1324,7 @@ mod tests {
         assert!(!has_space);
 
         let mut config = Config::default();
-        config.gc.policy.dist_threshold = ByteSize::mib(10);
+        config.gc.policy.disk_threshold = ByteSize::mib(10);
         let config = Arc::new(config);
         let content = Content::new(config, temp_dir.path()).await.unwrap();
 

--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -147,15 +147,15 @@ impl GC {
 
         // Calculate the usage percent.
         let usage_percent = (100 - available_space * 100 / total_space) as u8;
-        if usage_percent >= self.config.gc.policy.dist_high_threshold_percent {
+        if usage_percent >= self.config.gc.policy.disk_high_threshold_percent {
             info!(
                 "start to evict task by disk usage, disk usage {}% is higher than high threshold {}%",
-                usage_percent, self.config.gc.policy.dist_high_threshold_percent
+                usage_percent, self.config.gc.policy.disk_high_threshold_percent
             );
 
             // Calculate the need evict space.
             let need_evict_space = total_space as f64
-                * ((usage_percent - self.config.gc.policy.dist_low_threshold_percent) as f64
+                * ((usage_percent - self.config.gc.policy.disk_low_threshold_percent) as f64
                     / 100.0);
 
             // Evict the task by the need evict space.
@@ -264,15 +264,15 @@ impl GC {
 
         // Calculate the usage percent.
         let usage_percent = (100 - available_space * 100 / total_space) as u8;
-        if usage_percent >= self.config.gc.policy.dist_high_threshold_percent {
+        if usage_percent >= self.config.gc.policy.disk_high_threshold_percent {
             info!(
                 "start to evict persistent task by disk usage, disk usage {}% is higher than high threshold {}%",
-                usage_percent, self.config.gc.policy.dist_high_threshold_percent
+                usage_percent, self.config.gc.policy.disk_high_threshold_percent
             );
 
             // Calculate the need evict space.
             let need_evict_space = total_space as f64
-                * ((usage_percent - self.config.gc.policy.dist_low_threshold_percent) as f64
+                * ((usage_percent - self.config.gc.policy.disk_low_threshold_percent) as f64
                     / 100.0);
 
             // Evict the persistent task by the need evict space.
@@ -313,15 +313,15 @@ impl GC {
 
         // Calculate the usage percent.
         let usage_percent = (100 - available_space * 100 / total_space) as u8;
-        if usage_percent >= self.config.gc.policy.dist_high_threshold_percent {
+        if usage_percent >= self.config.gc.policy.disk_high_threshold_percent {
             info!(
                 "start to evict persistent cache task by disk usage, disk usage {}% is higher than high threshold {}%",
-                usage_percent, self.config.gc.policy.dist_high_threshold_percent
+                usage_percent, self.config.gc.policy.disk_high_threshold_percent
             );
 
             // Calculate the need evict space.
             let need_evict_space = total_space as f64
-                * ((usage_percent - self.config.gc.policy.dist_low_threshold_percent) as f64
+                * ((usage_percent - self.config.gc.policy.disk_low_threshold_percent) as f64
                     / 100.0);
 
             // Evict the persistent cache task by the need evict space.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request refactors the disk usage GC (garbage collection) policy configuration by renaming the related fields from `dist_*` to `disk_*` for clarity and consistency across the codebase. It updates the struct definitions, default value functions, serialization aliases, and all usages throughout the code, including tests and logic for disk space calculations and GC triggers.

**GC Policy Configuration Refactor:**

* Renamed all GC policy disk usage fields in the `Policy` struct from `dist_threshold`, `dist_high_threshold_percent`, and `dist_low_threshold_percent` to `disk_threshold`, `disk_high_threshold_percent`, and `disk_low_threshold_percent`, respectively. Updated serde aliases and documentation for clarity.
* Updated default value functions and their usages to match the new naming convention (`default_gc_policy_disk_threshold`, etc.), replacing previous `dist_*` names.

**Disk Space Calculation Updates:**

* Refactored disk space calculation logic in `content_linux.rs` and `content_macos.rs` to use the new `disk_threshold` field instead of `dist_threshold`, including all related logging and calculations. [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L64-R82) [[2]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L91-R94) [[3]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL64-R82) [[4]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL91-R94)

**GC Trigger Logic Updates:**

* Updated GC logic in `gc/mod.rs` to use `disk_high_threshold_percent` and `disk_low_threshold_percent` instead of the old `dist_*` fields when determining whether to trigger eviction based on disk usage. [[1]](diffhunk://#diff-cfa731d3c9a1cae126b87183eb862b9c4149ab3f19300d94c55580e53797a2ccL150-R158) [[2]](diffhunk://#diff-cfa731d3c9a1cae126b87183eb862b9c4149ab3f19300d94c55580e53797a2ccL267-R275) [[3]](diffhunk://#diff-cfa731d3c9a1cae126b87183eb862b9c4149ab3f19300d94c55580e53797a2ccL316-R324)

**Test Updates:**

* Updated all related tests in both `dfdaemon.rs` and platform-specific content modules to use the new `disk_*` field names, ensuring consistency and correctness in validation and assertions. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL2039-R2061) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL2081-R2092) [[3]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L1299-R1299) [[4]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL1327-R1327)
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/dragonflyoss/client/issues/1527

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
