### PR TITLE
fix: sync piece stream to check if task is finished before waiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.15"
+version = "1.1.16"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.15" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.15" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.15" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.15" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.15" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.15" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.15" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.15" }
+dragonfly-client = { path = "dragonfly-client", version = "1.1.16" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.16" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.16" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.16" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.16" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.16" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.16" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.16" }
 dragonfly-api = "=2.2.8"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -938,7 +938,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let (out_stream_tx, out_stream_rx) = mpsc::channel(128);
         tokio::spawn(
             async move {
-                match task_manager.get(task_id.as_str()) {
+                let task = match task_manager.get(task_id.as_str()) {
                     Ok(Some(task)) => {
                         if task.is_failed() {
                             error!("get task {} failed", task_id);
@@ -954,6 +954,8 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                             return;
                         }
+
+                        task
                     }
                     Ok(None) => {
                         error!("get task {} not found", task_id);
@@ -983,7 +985,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                         return;
                     }
-                }
+                };
 
                 loop {
                     let mut finished_piece_numbers = Vec::new();
@@ -1050,13 +1052,20 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                         }
                     }
 
+                    // If task is finished, no need to wait for downloads piece.
+                    if task.is_finished() {
+                        info!("all existing pieces have been sent");
+                        drop(out_stream_tx);
+                        return;
+                    }
+
                     // Remove the finished piece numbers from the interested piece numbers.
                     interested_piece_numbers
                         .retain(|number| !finished_piece_numbers.contains(number));
 
                     // If all the interested pieces are finished, return.
                     if interested_piece_numbers.is_empty() {
-                        info!("all the interested pieces are finished");
+                        info!("all interested pieces have been finished");
                         drop(out_stream_tx);
                         return;
                     }
@@ -1777,7 +1786,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let (out_stream_tx, out_stream_rx) = mpsc::channel(128);
         tokio::spawn(
             async move {
-                match persistent_task_manager.get(task_id.as_str()) {
+                let task = match persistent_task_manager.get(task_id.as_str()) {
                     Ok(Some(task)) => {
                         if task.is_failed() {
                             error!("get persistent task {} failed", task_id);
@@ -1799,6 +1808,8 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                             return;
                         }
+
+                        task
                     }
                     Ok(None) => {
                         error!("get persistent task {} not found", task_id);
@@ -1834,7 +1845,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                         return;
                     }
-                }
+                };
 
                 loop {
                     let mut finished_piece_numbers = Vec::new();
@@ -1909,13 +1920,20 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                         }
                     }
 
+                    // If task is finished, no need to wait for downloads piece.
+                    if task.is_finished() {
+                        info!("all existing pieces have been sent");
+                        drop(out_stream_tx);
+                        return;
+                    }
+
                     // Remove the finished piece numbers from the interested piece numbers.
                     interested_piece_numbers
                         .retain(|number| !finished_piece_numbers.contains(number));
 
                     // If all the interested pieces are finished, return.
                     if interested_piece_numbers.is_empty() {
-                        info!("all the interested persistent pieces are finished");
+                        info!("all interested pieces have been finished");
                         drop(out_stream_tx);
                         return;
                     }
@@ -2463,7 +2481,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let (out_stream_tx, out_stream_rx) = mpsc::channel(128);
         tokio::spawn(
             async move {
-                match persistent_cache_task_manager.get(task_id.as_str()) {
+                let task = match persistent_cache_task_manager.get(task_id.as_str()) {
                     Ok(Some(task)) => {
                         if task.is_failed() {
                             error!("get persistent cache task {} failed", task_id);
@@ -2479,6 +2497,8 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                             return;
                         }
+
+                        task
                     }
                     Ok(None) => {
                         error!("get persistent cache task {} not found", task_id);
@@ -2508,7 +2528,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                         return;
                     }
-                }
+                };
 
                 loop {
                     let mut finished_piece_numbers = Vec::new();
@@ -2574,13 +2594,20 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                         }
                     }
 
+                    // If task is finished, no need to wait for downloads piece.
+                    if task.is_finished() {
+                        info!("all existing pieces have been sent");
+                        drop(out_stream_tx);
+                        return;
+                    }
+
                     // Remove the finished piece numbers from the interested piece numbers.
                     interested_piece_numbers
                         .retain(|number| !finished_piece_numbers.contains(number));
 
                     // If all the interested pieces are finished, return.
                     if interested_piece_numbers.is_empty() {
-                        info!("all the interested persistent cache pieces are finished");
+                        info!("all interested pieces have been finished");
                         drop(out_stream_tx);
                         return;
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace versioning and refactors the upload server handler logic for improved clarity and correctness in the handling of task completion. The main changes include a version bump across all workspace packages and significant refactoring of how task retrieval and completion are handled in the `DfdaemonUploadServerHandler` implementation.

**Versioning Updates:**
- Updated the workspace version and all local dependency versions from `1.1.15` to `1.1.16` in `Cargo.toml` to keep the workspace and its components in sync. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)

**Refactoring and Logic Improvements in Task Handling:**
- Refactored the retrieval of tasks in `dfdaemon_upload.rs` by assigning the result of the `get` call to a variable, improving readability and ensuring the task object is available for subsequent checks. This pattern is now consistently used for normal, persistent, and persistent cache tasks. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L941-R941) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1780-R1789) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L2466-R2484)
- Ensured that the task object is always available after retrieval by moving the assignment outside of the match arms, and returning early if the task is not found or has failed. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R957-R958) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1811-R1812) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R2500-R2501)
- Improved the loop structure by ensuring the task variable is always in scope, and replaced the match statement with a let-binding followed by a semicolon. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L986-R988) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1837-R1848) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L2511-R2531)
- Added an explicit check for task completion (`task.is_finished()`) before waiting for additional pieces, allowing the upload stream to close immediately when the task is done, and logging accordingly. This prevents unnecessary waiting and resource usage. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1055-R1068) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1923-R1936) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R2597-R2610)
- Standardized log messages to improve clarity and consistency when all interested pieces have been finished. [[1]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1055-R1068) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R1923-R1936) [[3]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R2597-R2610)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
