### PR TITLE
refactor(grpc): simplify download task success handling

### DIFF
--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -483,15 +483,15 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
 
                         // Download task succeeded.
                         info!("download task succeeded");
-                        if download_clone.range.is_none() {
-                            if let Err(err) =
-                                task_manager_clone.download_finished(task_clone.id.as_str())
-                            {
-                                error!("download task finished: {}", err);
-                                handle_error(&out_stream_tx, err).await;
-                                return;
-                            }
+                        if let Err(err) =
+                            task_manager_clone.download_finished(task_clone.id.as_str())
+                        {
+                            error!("download task finished: {}", err);
+                            handle_error(&out_stream_tx, err).await;
+                            return;
+                        }
 
+                        if download_clone.range.is_none() {
                             if let Some(output_path) = &download_clone.output_path {
                                 if !download_clone.force_hard_link {
                                     let output_path = Path::new(output_path.as_str());

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -480,15 +480,15 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
                         // Download task succeeded.
                         info!("download task succeeded");
-                        if download_clone.range.is_none() {
-                            if let Err(err) =
-                                task_manager_clone.download_finished(task_clone.id.as_str())
-                            {
-                                error!("download task finished: {}", err);
-                                handle_error(&out_stream_tx, err).await;
-                                return;
-                            }
+                        if let Err(err) =
+                            task_manager_clone.download_finished(task_clone.id.as_str())
+                        {
+                            error!("download task finished: {}", err);
+                            handle_error(&out_stream_tx, err).await;
+                            return;
+                        }
 
+                        if download_clone.range.is_none() {
                             if let Some(output_path) = &download_clone.output_path {
                                 if !download_clone.force_hard_link {
                                     let output_path = Path::new(output_path.as_str());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the logic in both the download and upload gRPC server handlers to improve the order in which certain operations are performed after a download task succeeds. The main change is to ensure that the `download_finished` method is always called before checking for output path handling when the download is not a ranged request.

Key changes:

**Refactoring task completion flow:**
- The call to `task_manager_clone.download_finished` is now always executed immediately after a successful download, regardless of whether the download is ranged or not, in both `DfdaemonDownloadServerHandler` and `DfdaemonUploadServerHandler` implementations (`dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`). [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL486) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L483)

**Conditional output path handling:**
- The check for `download_clone.range.is_none()` and the subsequent output path handling logic have been moved to occur after the `download_finished` call, ensuring proper task completion notification before any file system operations (`dragonfly-client/src/grpc/dfdaemon_download.rs`, `dragonfly-client/src/grpc/dfdaemon_upload.rs`). [[1]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dR494) [[2]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1R491)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
