### PR TITLE
chore(dependencies): update client dependencies to 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.18"
+version = "1.2.0"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.1.18" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.1.18" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.1.18" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.1.18" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.1.18" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.1.18" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.1.18" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.1.18" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.0" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.0" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.0" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.0" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.0" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.0" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.0" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.0" }
 dragonfly-api = "=2.2.8"
 thiserror = "2.0"
 futures = "0.3.31"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the workspace versioning for the project and its internal dependencies to 1.2.0. This ensures consistency across the codebase and prepares for a new release.

Version updates:

* Bumped the overall workspace package version from 1.1.18 to 1.2.0 in `Cargo.toml`.
* Updated all internal workspace dependencies (such as `dragonfly-client`, `dragonfly-client-core`, etc.) to version 1.2.0 in `Cargo.toml`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
