### PR TITLE
chore: bump version to 1.2.1 and update vnodes config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.2.0" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.0" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.0" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.0" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.0" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.0" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.0" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.0" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.1" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.1" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.1" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.1" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.1" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.1" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.1" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.1" }
 dragonfly-api = "=2.2.8"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -44,7 +44,7 @@ pub trait Selector: Send + Sync {
 const SEED_PEERS_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// DEFAULT_VNODES_PER_HOST is the default number of virtual nodes per host.
-const DEFAULT_VNODES_PER_HOST: usize = 3;
+const DEFAULT_VNODES_PER_HOST: usize = 256;
 
 /// SeedPeers holds the data of seed peers.
 struct SeedPeers {


### PR DESCRIPTION
This pull request updates the workspace version and dependency versions in `Cargo.toml` to `1.2.1`, and increases the default number of virtual nodes per host in the request selector utility. These changes help ensure consistency across the project and may improve load balancing or distribution logic.

Version updates:

* Updated the workspace version to `1.2.1` in `Cargo.toml`.
* Updated all internal workspace dependencies to version `1.2.1` in `Cargo.toml` to maintain compatibility.

Configuration improvement:

* Increased the `DEFAULT_VNODES_PER_HOST` constant from `3` to `256` in `dragonfly-client-util/src/request/selector.rs`, which may improve host distribution and scalability.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
