### PR TITLE
feat(announcer): add pod namespace and name to host name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,12 +961,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.2.8"
+version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0313125f2240495343ebfd697e35ed736f63e77a4ddd89279341459676121e04"
+checksum = "895a75ffd8d60e922b10df7d4086c631c74490c979dd883ae8d66c59078c725c"
 dependencies = [
  "prost 0.13.5",
- "prost-types 0.14.1",
+ "prost-types 0.14.3",
  "prost-wkt-types",
  "serde",
  "tokio",
@@ -1103,6 +1103,7 @@ dependencies = [
  "http-serde",
  "humantime",
  "humantime-serde",
+ "lazy_static",
  "local-ip-address",
  "rcgen",
  "regex",
@@ -3721,12 +3722,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -3778,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3800,11 +3801,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.1",
+ "prost 0.14.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.1
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.1" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.1" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.1" }
-dragonfly-api = "=2.2.8"
+dragonfly-api = "=2.2.9"
 thiserror = "2.0"
 futures = "0.3.31"
 reqwest = { version = "0.12.28", features = [

--- a/dragonfly-client-config/Cargo.toml
+++ b/dragonfly-client-config/Cargo.toml
@@ -31,6 +31,7 @@ rustls-pki-types.workspace = true
 rcgen.workspace = true
 reqwest.workspace = true
 hostname.workspace = true
+lazy_static.workspace = true
 home = "0.5.11"
 humantime-serde = "1.1.1"
 serde_regex = "1.1.0"

--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -15,6 +15,7 @@
  */
 
 use clap::{Arg, Command};
+use lazy_static::lazy_static;
 use std::path::PathBuf;
 
 pub mod dfcache;
@@ -38,7 +39,7 @@ pub const CARGO_PKG_RUSTC_VERSION: &str = env!("CARGO_PKG_RUST_VERSION");
 /// BUILD_PLATFORM is the platform of the build.
 pub const BUILD_PLATFORM: &str = env!("BUILD_PLATFORM");
 
-// BUILD_TIMESTAMP is the timestamp of the build.
+/// BUILD_TIMESTAMP is the timestamp of the build.
 pub const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
 
 /// GIT_COMMIT_SHORT_HASH is the short git commit hash of the package.
@@ -56,6 +57,15 @@ pub const GIT_COMMIT_DATE: &str = {
         None => "unknown",
     }
 };
+
+lazy_static! {
+    /// INSTANCE_NAME is the name of the instance, formatted as pod_namespace-pod_name.
+    pub static ref INSTANCE_NAME: dragonfly_client_core::Result<String> = {
+        let namespace = std::env::var("POD_NAMESPACE")?;
+        let name = std::env::var("POD_NAME")?;
+        Ok(format!("{}-{}", namespace, name))
+    };
+}
 
 /// default_root_dir is the default root directory for client.
 pub fn default_root_dir() -> PathBuf {

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -30,6 +30,10 @@ pub enum DFError {
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
+    /// VarError is the error for environment variable.
+    #[error(transparent)]
+    VarError(#[from] std::env::VarError),
+
     /// MpscSend is the error for send.
     #[error("mpsc send: {0}")]
     MpscSend(String),

--- a/dragonfly-client/src/announcer/mod.rs
+++ b/dragonfly-client/src/announcer/mod.rs
@@ -19,9 +19,9 @@ use dragonfly_api::common::v2::{Build, Cpu, Disk, Host, Memory, Network};
 use dragonfly_api::scheduler::v2::{AnnounceHostRequest, DeleteHostRequest};
 use dragonfly_client_config::{
     dfdaemon::{Config, HostType},
-    CARGO_PKG_RUSTC_VERSION, CARGO_PKG_VERSION, GIT_COMMIT_SHORT_HASH,
+    CARGO_PKG_RUSTC_VERSION, CARGO_PKG_VERSION, GIT_COMMIT_SHORT_HASH, INSTANCE_NAME,
 };
-use dragonfly_client_core::error::{ErrorType, OrErr};
+use dragonfly_client_core::error::{ErrorType, ExternalError, OrErr};
 use dragonfly_client_core::Result;
 use dragonfly_client_util::{net::Interface, shutdown};
 use std::env;
@@ -236,6 +236,13 @@ impl SchedulerAnnouncer {
             scheduler_cluster_id: self.config.host.scheduler_cluster_id.unwrap_or_default(),
             disable_shared: self.config.upload.disable_shared,
             proxy_port: self.config.proxy.server.port as i32,
+            name: INSTANCE_NAME
+                .as_ref()
+                .map_err(|e| {
+                    ExternalError::new(ErrorType::ConfigError)
+                        .with_context(format!("failed to get instance name: {}", e))
+                })?
+                .clone(),
         };
 
         Ok(AnnounceHostRequest {


### PR DESCRIPTION
This pull request updates the `dragonfly-client` to improve Kubernetes integration and error handling, and bumps a dependency version. The main changes focus on extracting pod metadata from environment variables and including it in host announcements.

**Kubernetes integration and host identification:**

* The announcer now reads the `POD_NAMESPACE` and `POD_NAME` environment variables, returning a configuration error if either is missing. These values are used to help uniquely identify the host in a Kubernetes environment.
* The host's `name` field is now set to a combination of the pod namespace and pod name, improving traceability of hosts within Kubernetes clusters.

**Error handling improvements:**

* The announcer uses the `ExternalError` type to provide clearer error context when required environment variables are missing, enhancing debuggability. [[1]](diffhunk://#diff-2f5fa9773cd3fe93b2f904e42003a63c6e6b085bc1c7a2143adfe195cc98e939L24-R24) [[2]](diffhunk://#diff-2f5fa9773cd3fe93b2f904e42003a63c6e6b085bc1c7a2143adfe195cc98e939R218-R227)

**Dependency updates:**

* The `dragonfly-api` dependency is updated from version `2.2.8` to `2.2.9`.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
