### PR TITLE
refactor(config): improve INSTANCE_NAME generation logic

### DIFF
--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -59,11 +59,19 @@ pub const GIT_COMMIT_DATE: &str = {
 };
 
 lazy_static! {
-    /// INSTANCE_NAME is the name of the instance, formatted as pod_namespace-pod_name.
-    pub static ref INSTANCE_NAME: dragonfly_client_core::Result<String> = {
-        let namespace = std::env::var("POD_NAMESPACE")?;
-        let name = std::env::var("POD_NAME")?;
-        Ok(format!("{}-{}", namespace, name))
+    /// INSTANCE_NAME is the name of the instance, formatted as {POD_NAMESPACE}-{POD_NAME}.
+    pub static ref INSTANCE_NAME: String = {
+        if let (Some(pod_namespace), Some(pod_name)) = (
+            option_env!("POD_NAMESPACE"),
+            option_env!("POD_NAME")
+        ) {
+            format!("{}-{}", pod_namespace, pod_name)
+        } else {
+            hostname::get()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        }
     };
 }
 

--- a/dragonfly-client/src/announcer/mod.rs
+++ b/dragonfly-client/src/announcer/mod.rs
@@ -21,7 +21,7 @@ use dragonfly_client_config::{
     dfdaemon::{Config, HostType},
     CARGO_PKG_RUSTC_VERSION, CARGO_PKG_VERSION, GIT_COMMIT_SHORT_HASH, INSTANCE_NAME,
 };
-use dragonfly_client_core::error::{ErrorType, ExternalError, OrErr};
+use dragonfly_client_core::error::{ErrorType, OrErr};
 use dragonfly_client_core::Result;
 use dragonfly_client_util::{net::Interface, shutdown};
 use std::env;
@@ -236,13 +236,7 @@ impl SchedulerAnnouncer {
             scheduler_cluster_id: self.config.host.scheduler_cluster_id.unwrap_or_default(),
             disable_shared: self.config.upload.disable_shared,
             proxy_port: self.config.proxy.server.port as i32,
-            name: INSTANCE_NAME
-                .as_ref()
-                .map_err(|e| {
-                    ExternalError::new(ErrorType::ConfigError)
-                        .with_context(format!("failed to get instance name: {}", e))
-                })?
-                .clone(),
+            name: INSTANCE_NAME.clone(),
         };
 
         Ok(AnnounceHostRequest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates how the `INSTANCE_NAME` is determined and simplifies its usage throughout the codebase. The main change is switching from reading the instance name from environment variables at runtime (with error handling) to using compile-time environment variables if available, and falling back to the system hostname otherwise. This also removes the need for error handling when accessing `INSTANCE_NAME`.

**Configuration and environment variable handling:**

* Refactored `INSTANCE_NAME` in `dragonfly-client-config/src/lib.rs` to use `option_env!` for `POD_NAMESPACE` and `POD_NAME`, falling back to the system hostname if those are not set, and changed its type from `Result<String>` to `String`.

**Code simplification:**

* Updated usage of `INSTANCE_NAME` in `dragonfly-client/src/announcer/mod.rs` to remove error handling and simply clone the `String`, since it can no longer fail.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
