### PR TITLE
refactor(hashring): change VNode to use String instead of SocketAddr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
+      labels: [oracle-vm-32cpu-128gb-x86-64]
     timeout-minutes: 480
     strategy:
       matrix:
@@ -61,7 +63,7 @@ jobs:
         uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b
         with:
           tool: cargo-generate-rpm
-          
+
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -109,8 +111,8 @@ jobs:
           name: release-${{ matrix.target }}
           path: |
             ${{ env.CLIENT_RPM_ASSET }}
-            ${{ env.CLIENT_DEB_ASSET }}            
-            ${{ env.CLIENT_TAR_ASSET }}          
+            ${{ env.CLIENT_DEB_ASSET }}
+            ${{ env.CLIENT_TAR_ASSET }}
 
   release-github:
     runs-on: ubuntu-latest
@@ -148,7 +150,7 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-            
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -18,12 +18,8 @@ use crate::hashring::VNodeHashRing;
 use crate::shutdown;
 use dragonfly_api::common::v2::Host;
 use dragonfly_api::scheduler::v2::{scheduler_client::SchedulerClient, ListHostsRequest};
-use dragonfly_client_core::{
-    error::{ErrorType, OrErr},
-    Error, Result,
-};
+use dragonfly_client_core::{Error, Result};
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinSet;
@@ -44,7 +40,7 @@ pub trait Selector: Send + Sync {
 const SEED_PEERS_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// DEFAULT_VNODES_PER_HOST is the default number of virtual nodes per host.
-const DEFAULT_VNODES_PER_HOST: usize = 256;
+const DEFAULT_VNODES_PER_HOST: usize = 512;
 
 /// SeedPeers holds the data of seed peers.
 struct SeedPeers {
@@ -143,12 +139,9 @@ impl SeedPeerSelector {
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(Ok(peer)) => {
-                    let addr: SocketAddr = format!("{}:{}", peer.ip, peer.port)
-                        .parse()
-                        .or_err(ErrorType::ParseError)?;
-
-                    hashring.add(addr);
-                    hosts.insert(addr.to_string(), peer);
+                    let name = peer.name.to_string();
+                    hashring.add(name.clone());
+                    hosts.insert(name, peer);
                 }
                 Ok(Err(err)) => error!("health check failed: {}", err),
                 Err(err) => error!("task join error: {}", err),
@@ -215,7 +208,7 @@ impl Selector for SeedPeerSelector {
             .filter_map(|vnode| {
                 seed_peers
                     .hosts
-                    .get(vnode.addr().to_string().as_str())
+                    .get(vnode.name().to_string().as_str())
                     .cloned()
             })
             .collect();


### PR DESCRIPTION
This pull request updates the consistent hash ring implementation in `dragonfly-client-util` to use a `String` identifier for physical nodes instead of `SocketAddr`. It also increases the default number of virtual nodes per host, updates all related methods and tests, and bumps the workspace and dependency versions to 1.2.2.

**Consistent Hash Ring Refactor:**

* Refactored the `VNode` struct in `hashring/mod.rs` to use a `String` (`name`) instead of a `SocketAddr` (`addr`) for identifying physical nodes, updating all methods, trait implementations, and test cases accordingly. [[1]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L20-R53) [[2]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L80-R81) [[3]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L114-R123) [[4]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L149-R140) [[5]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L172-R162) [[6]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L199-R192) [[7]](diffhunk://#diff-e6509a6eecc66efa6ab5ce5e1ec46d4c5aa091862100e39a870add084c680096L237-R209)
* Updated the `SeedPeerSelector` in `request/selector.rs` to use node names as `String` throughout, including hash ring operations and host lookups. [[1]](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL146-R144) [[2]](diffhunk://#diff-6322522f00d2c05acee4db2a9c5cea00a02a8afe4ee9b3b188d2b11887bd188cL218-R211)

**Configuration and Defaults:**

* Increased the default number of virtual nodes per host from 256 to 512 for improved key distribution.

**Version Bumps:**

* Bumped the workspace package version and all internal dependency versions from 1.2.1 to 1.2.2 in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)

**Code Cleanup:**

* Removed unused imports related to `SocketAddr` and error handling in `request/selector.rs` as they are no longer needed after the refactor.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
