### PR TITLE
docs: standardize function comments to start with verbs

### DIFF
--- a/dragonfly-client-backend/examples/plugin/src/lib.rs
+++ b/dragonfly-client-backend/examples/plugin/src/lib.rs
@@ -33,18 +33,18 @@ impl Hdfs {
 /// Implement the Backend trait for Hdfs.
 #[tonic::async_trait]
 impl Backend for Hdfs {
-    /// scheme returns the scheme of the backend.
+    /// Returns the scheme of the backend.
     fn scheme(&self) -> String {
         "hdfs".to_string()
     }
 
-    /// stat gets the metadata from the backend.
+    /// Gets the metadata from the backend.
     async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
         println!("HDFS stat url: {}", request.url);
         Err(Error::Unimplemented)
     }
 
-    /// get gets the content from the backend.
+    /// Gets the content from the backend.
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
         println!("HDFS get url: {}", request.url);
         Err(Error::Unimplemented)
@@ -56,7 +56,7 @@ impl Backend for Hdfs {
         Err(Error::Unimplemented)
     }
 
-    /// exists checks if the object exists in the backend.
+    /// Checks if the object exists in the backend.
     async fn exists(&self, request: ExistsRequest) -> Result<bool> {
         println!("HDFS exists url: {}", request.url);
         Err(Error::Unimplemented)

--- a/dragonfly-client-backend/src/hdfs.rs
+++ b/dragonfly-client-backend/src/hdfs.rs
@@ -39,7 +39,7 @@ pub struct Hdfs {
 
 /// Hdfs implements the Backend trait.
 impl Hdfs {
-    /// new returns a new HDFS backend.
+    /// Creates a new HDFS backend.
     pub fn new() -> Self {
         Self {
             scheme: HDFS_SCHEME.to_string(),
@@ -82,12 +82,12 @@ impl Hdfs {
 /// Implement the Backend trait for Hdfs.
 #[tonic::async_trait]
 impl super::Backend for Hdfs {
-    /// scheme returns the scheme of the HDFS backend.
+    /// Returns the scheme of the HDFS backend.
     fn scheme(&self) -> String {
         self.scheme.clone()
     }
 
-    /// stat gets the metadata from the backend.
+    /// Gets the metadata from the backend.
     #[instrument(skip_all)]
     async fn stat(&self, request: super::StatRequest) -> ClientResult<super::StatResponse> {
         debug!(
@@ -170,7 +170,7 @@ impl super::Backend for Hdfs {
         })
     }
 
-    /// get gets the content from the backend.
+    /// Gets the content from the backend.
     #[instrument(skip_all)]
     async fn get(
         &self,
@@ -251,7 +251,7 @@ impl super::Backend for Hdfs {
         unimplemented!()
     }
 
-    /// exists checks whether the file exists in the backend.
+    /// Checks whether the file exists in the backend.
     #[instrument(skip_all)]
     async fn exists(&self, request: super::ExistsRequest) -> ClientResult<bool> {
         debug!(

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -90,7 +90,7 @@ impl HTTP {
     /// DEFAULT_CACHE_TEMPORARY_REDIRECT_CAPACITY is the default capacity for temporary redirect cache.
     const DEFAULT_CACHE_TEMPORARY_REDIRECT_CAPACITY: usize = 1000;
 
-    /// new returns a new HTTP.
+    /// Creates a new HTTP.
     pub fn new(
         scheme: &str,
         request_header: Option<HashMap<String, String>>,
@@ -172,7 +172,7 @@ impl HTTP {
         })
     }
 
-    /// client returns a new reqwest client.
+    /// Returns a new reqwest client.
     fn client(
         &self,
         client_cert: Option<Vec<CertificateDer<'static>>>,
@@ -276,7 +276,7 @@ impl HTTP {
         Ok(())
     }
 
-    /// get_temporary_redirect_url gets the cached temporary redirect URL if exists
+    /// Gets the cached temporary redirect URL if exists
     /// and not expired.
     async fn get_temporary_redirect_url(&self, url: &str) -> String {
         let mut temporary_redirects = self.temporary_redirects.lock().await;
@@ -322,12 +322,12 @@ impl HTTP {
 /// Backend implements the Backend trait.
 #[tonic::async_trait]
 impl super::Backend for HTTP {
-    /// scheme returns the scheme of the HTTP backend.
+    /// Returns the scheme of the HTTP backend.
     fn scheme(&self) -> String {
         self.scheme.clone()
     }
 
-    /// stat gets the metadata from the backend.
+    /// Gets the metadata from the backend.
     #[instrument(skip_all)]
     async fn stat(&self, request: super::StatRequest) -> Result<super::StatResponse> {
         debug!(
@@ -491,7 +491,7 @@ impl super::Backend for HTTP {
         })
     }
 
-    /// get gets the content from the backend.
+    /// Gets the content from the backend.
     #[instrument(skip_all)]
     async fn get(&self, request: super::GetRequest) -> Result<super::GetResponse<super::Body>> {
         debug!(
@@ -601,7 +601,7 @@ impl super::Backend for HTTP {
         unimplemented!()
     }
 
-    /// exists checks whether the file exists in the backend.
+    /// Checks whether the file exists in the backend.
     #[instrument(skip_all)]
     async fn exists(&self, request: super::ExistsRequest) -> Result<bool> {
         debug!(

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -318,7 +318,7 @@ pub struct BackendFactory {
 /// The backend plugin implementation can refer to
 /// https://github.com/dragonflyoss/client/tree/main/dragonfly-client-backend/examples/plugin/.
 impl BackendFactory {
-    /// new returns a new BackendFactory.
+    /// Creates a new BackendFactory.
     pub fn new(config: Arc<Config>, plugin_dir: Option<&Path>) -> Result<Self> {
         let mut backend_factory = Self {
             config: config.clone(),
@@ -340,12 +340,12 @@ impl BackendFactory {
         Ok(backend_factory)
     }
 
-    /// unsupported_download_directory returns whether the scheme does not support directory download.
+    /// Returns whether the scheme does not support directory download.
     pub fn unsupported_download_directory(scheme: &str) -> bool {
         scheme == http::HTTP_SCHEME || scheme == http::HTTPS_SCHEME
     }
 
-    /// build returns the backend by the scheme of the url.
+    /// Returns the backend by the scheme of the url.
     pub fn build(&self, url: &str) -> Result<&(dyn Backend + Send + Sync)> {
         let url = Url::parse(url).or_err(ErrorType::ParseError)?;
         let scheme = url.scheme();
@@ -358,7 +358,7 @@ impl BackendFactory {
             })
     }
 
-    /// load_builtin_backends loads the builtin backends.
+    /// Loads the builtin backends.
     fn load_builtin_backends(
         &mut self,
         enable_cache_temporary_redirect: bool,
@@ -447,7 +447,7 @@ impl BackendFactory {
         Ok(())
     }
 
-    /// load_plugin_backends loads the plugin backends.
+    /// Loads the plugin backends.
     fn load_plugin_backends(&mut self, plugin_dir: &Path) -> Result<()> {
         let backend_plugin_dir = plugin_dir.join(NAME);
         if !backend_plugin_dir.exists() {

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -102,7 +102,7 @@ pub struct ParsedURL {
 
 /// ParsedURL implements the ParsedURL trait.
 impl ParsedURL {
-    /// is_dir returns true if the URL path ends with a slash.
+    /// Returns true if the URL path ends with a slash.
     pub fn is_dir(&self) -> bool {
         self.url.path().ends_with('/')
     }
@@ -502,12 +502,12 @@ impl ObjectStorage {
 /// Backend implements the Backend trait.
 #[tonic::async_trait]
 impl crate::Backend for ObjectStorage {
-    /// scheme returns the scheme of the object storage.
+    /// Returns the scheme of the object storage.
     fn scheme(&self) -> String {
         self.scheme.to_string()
     }
 
-    /// stat gets the metadata from the backend.
+    /// Gets the metadata from the backend.
     #[instrument(skip_all)]
     async fn stat(&self, request: super::StatRequest) -> ClientResult<super::StatResponse> {
         debug!(
@@ -594,7 +594,7 @@ impl crate::Backend for ObjectStorage {
         })
     }
 
-    /// get gets the content from the backend.
+    /// Gets the content from the backend.
     #[instrument(skip_all)]
     async fn get(
         &self,
@@ -777,7 +777,7 @@ impl crate::Backend for ObjectStorage {
         })
     }
 
-    /// exists checks whether the file exists in the backend.
+    /// Checks whether the file exists in the backend.
     #[instrument(skip_all)]
     async fn exists(&self, request: super::ExistsRequest) -> ClientResult<bool> {
         debug!(

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -44,273 +44,273 @@ use validator::Validate;
 /// NAME is the name of dfdaemon.
 pub const NAME: &str = "dfdaemon";
 
-/// default_dfdaemon_config_path is the default config path for dfdaemon.
+/// Returns the default config path for dfdaemon.
 #[inline]
 pub fn default_dfdaemon_config_path() -> PathBuf {
     crate::default_config_dir().join("dfdaemon.yaml")
 }
 
-/// default_dfdaemon_log_dir is the default log directory for dfdaemon.
+/// Returns the default log directory for dfdaemon.
 #[inline]
 pub fn default_dfdaemon_log_dir() -> PathBuf {
     crate::default_log_dir().join(NAME)
 }
 
-/// default_download_unix_socket_path is the default unix socket path for download gRPC service.
+/// Returns the default unix socket path for download gRPC service.
 pub fn default_download_unix_socket_path() -> PathBuf {
     crate::default_root_dir().join("dfdaemon.sock")
 }
 
-/// default_download_protocol is the default protocol of downloading.
+/// Returns the default protocol of downloading.
 #[inline]
 fn default_download_protocol() -> String {
     "tcp".to_string()
 }
 
-/// default_download_request_rate_limit is the default rate limit of the download request in the
+/// Returns the default rate limit of the download request in the
 /// download grpc server, default is 5000 req/s.
 pub fn default_download_request_rate_limit() -> u64 {
     5000
 }
 
-/// default_host_hostname is the default hostname of the host.
+/// Returns the default hostname of the host.
 #[inline]
 fn default_host_hostname() -> String {
     hostname::get().unwrap().to_string_lossy().to_string()
 }
 
-/// default_dfdaemon_plugin_dir is the default plugin directory for dfdaemon.
+/// Returns the default plugin directory for dfdaemon.
 #[inline]
 fn default_dfdaemon_plugin_dir() -> PathBuf {
     crate::default_plugin_dir().join(NAME)
 }
 
-/// default_dfdaemon_cache_dir is the default cache directory for dfdaemon.
+/// Returns the default cache directory for dfdaemon.
 #[inline]
 fn default_dfdaemon_cache_dir() -> PathBuf {
     crate::default_cache_dir().join(NAME)
 }
 
-/// default_upload_grpc_server_port is the default port of the upload gRPC server.
+/// Returns the default port of the upload gRPC server.
 #[inline]
 fn default_upload_grpc_server_port() -> u16 {
     4000
 }
 
-/// default_upload_request_rate_limit is the default rate limit of the upload request in the
+/// Returns the default rate limit of the upload request in the
 /// upload grpc server, default is 5000 req/s.
 pub fn default_upload_request_rate_limit() -> u64 {
     5000
 }
 
-/// default_upload_rate_limit is the default rate limit of the upload speed in GiB/Mib/Kib per second.
+/// Returnsupload_rate_limit is the default rate limit of the upload speed in GiB/Mib/Kib per second.
 #[inline]
 fn default_upload_rate_limit() -> ByteSize {
     // Default rate limit is 10GiB/s.
     ByteSize::gib(10)
 }
 
-/// default_health_server_port is the default port of the health server.
+/// Returnshealth_server_port is the default port of the health server.
 #[inline]
 fn default_health_server_port() -> u16 {
     4003
 }
 
-/// default_metrics_server_port is the default port of the metrics server.
+/// Returnsmetrics_server_port is the default port of the metrics server.
 #[inline]
 fn default_metrics_server_port() -> u16 {
     4002
 }
 
-/// default_stats_server_port is the default port of the stats server.
+/// Returnsstats_server_port is the default port of the stats server.
 #[inline]
 fn default_stats_server_port() -> u16 {
     4004
 }
 
-/// default_download_rate_limit is the default rate limit of the download speed in GiB/Mib/Kib per second.
+/// Returnsdownload_rate_limit is the default rate limit of the download speed in GiB/Mib/Kib per second.
 #[inline]
 fn default_download_rate_limit() -> ByteSize {
     // Default rate limit is 10GiB/s.
     ByteSize::gib(10)
 }
 
-/// default_download_piece_timeout is the default timeout for downloading a piece from source.
+/// Returnsdownload_piece_timeout is the default timeout for downloading a piece from source.
 #[inline]
 fn default_download_piece_timeout() -> Duration {
     Duration::from_secs(360)
 }
 
-/// default_collected_download_piece_timeout is the default timeout for collecting one piece from the parent in the stream.
+/// Returnscollected_download_piece_timeout is the default timeout for collecting one piece from the parent in the stream.
 #[inline]
 fn default_collected_download_piece_timeout() -> Duration {
     Duration::from_secs(360)
 }
 
-/// default_download_concurrent_piece_count is the default number of concurrent pieces to download.
+/// Returnsdownload_concurrent_piece_count is the default number of concurrent pieces to download.
 #[inline]
 fn default_download_concurrent_piece_count() -> u32 {
     8
 }
 
-/// default_backend_enable_cache_temporary_redirect is the default value for caching temporary redirects.
+/// Returnsbackend_enable_cache_temporary_redirect is the default value for caching temporary redirects.
 #[inline]
 fn default_backend_enable_cache_temporary_redirect() -> bool {
     true
 }
 
-/// default_backend_cache_temporary_redirect_ttl is the default TTL for cached 307 redirects, default is 10 minutes.
+/// Returnsbackend_cache_temporary_redirect_ttl is the default TTL for cached 307 redirects, default is 10 minutes.
 #[inline]
 fn default_backend_cache_temporary_redirect_ttl() -> Duration {
     Duration::from_secs(600)
 }
 
-/// default_backend_put_concurrent_chunk_count is the default number of concurrent chunks to upload.
+/// Returnsbackend_put_concurrent_chunk_count is the default number of concurrent chunks to upload.
 #[inline]
 fn default_backend_put_concurrent_chunk_count() -> u32 {
     16
 }
 
-/// default_backend_put_chunk_size is the default chunk size for uploading, default is 8MiB.
+/// Returnsbackend_put_chunk_size is the default chunk size for uploading, default is 8MiB.
 fn default_backend_put_chunk_size() -> ByteSize {
     ByteSize::mib(8)
 }
 
-/// default_backend_put_timeout is the default timeout for uploading a file to backend, default is
+/// Returnsbackend_put_timeout is the default timeout for uploading a file to backend, default is
 /// 15 minutes.
 fn default_backend_put_timeout() -> Duration {
     Duration::from_secs(900)
 }
 
-/// default_download_max_schedule_count is the default max count of schedule.
+/// Returnsdownload_max_schedule_count is the default max count of schedule.
 #[inline]
 fn default_download_max_schedule_count() -> u32 {
     5
 }
 
-/// default_tracing_path is the default tracing path for dfdaemon.
+/// Returnstracing_path is the default tracing path for dfdaemon.
 #[inline]
 fn default_tracing_path() -> Option<PathBuf> {
     Some(PathBuf::from("/v1/traces"))
 }
 
-/// default_scheduler_announce_interval is the default interval to announce peer to the scheduler.
+/// Returnsscheduler_announce_interval is the default interval to announce peer to the scheduler.
 #[inline]
 fn default_scheduler_announce_interval() -> Duration {
     Duration::from_secs(300)
 }
 
-/// default_scheduler_schedule_timeout is the default timeout for scheduling.
+/// Returnsscheduler_schedule_timeout is the default timeout for scheduling.
 #[inline]
 fn default_scheduler_schedule_timeout() -> Duration {
     Duration::from_secs(3 * 60 * 60)
 }
 
-/// default_dynconfig_refresh_interval is the default interval to refresh dynamic configuration from manager.
+/// Returnsdynconfig_refresh_interval is the default interval to refresh dynamic configuration from manager.
 #[inline]
 fn default_dynconfig_refresh_interval() -> Duration {
     Duration::from_secs(300)
 }
 
-/// default_storage_server_tcp_port is the default port of the storage tcp server.
+/// Returnsstorage_server_tcp_port is the default port of the storage tcp server.
 #[inline]
 fn default_storage_server_tcp_port() -> u16 {
     4005
 }
 
-/// default_storage_server_quic_port is the default port of the storage quic server.
+/// Returnsstorage_server_quic_port is the default port of the storage quic server.
 #[inline]
 fn default_storage_server_quic_port() -> u16 {
     4006
 }
 
-/// default_storage_keep is the default keep of the task's metadata and content when the dfdaemon restarts.
+/// Returnsstorage_keep is the default keep of the task's metadata and content when the dfdaemon restarts.
 #[inline]
 fn default_storage_keep() -> bool {
     false
 }
 
-/// default_storage_write_piece_timeout is the default timeout for writing a piece to storage(e.g., disk
+/// Returnsstorage_write_piece_timeout is the default timeout for writing a piece to storage(e.g., disk
 /// or cache).
 #[inline]
 fn default_storage_write_piece_timeout() -> Duration {
     Duration::from_secs(360)
 }
 
-/// default_storage_write_buffer_size is the default buffer size for writing piece to disk, default is 4MB.
+/// Returnsstorage_write_buffer_size is the default buffer size for writing piece to disk, default is 4MB.
 #[inline]
 fn default_storage_write_buffer_size() -> usize {
     4 * 1024 * 1024
 }
 
-/// default_storage_read_buffer_size is the default buffer size for reading piece from disk, default is 4MB.
+/// Returnsstorage_read_buffer_size is the default buffer size for reading piece from disk, default is 4MB.
 #[inline]
 fn default_storage_read_buffer_size() -> usize {
     4 * 1024 * 1024
 }
 
-/// default_storage_cache_capacity is the default cache capacity for the storage server, default is
+/// Returnsstorage_cache_capacity is the default cache capacity for the storage server, default is
 /// 64MiB.
 #[inline]
 fn default_storage_cache_capacity() -> ByteSize {
     ByteSize::mib(64)
 }
 
-/// default_gc_interval is the default interval to do gc.
+/// Returnsgc_interval is the default interval to do gc.
 #[inline]
 fn default_gc_interval() -> Duration {
     Duration::from_secs(900)
 }
 
-/// default_gc_policy_task_ttl is the default ttl of the task, default is 30 day.
+/// Returnsgc_policy_task_ttl is the default ttl of the task, default is 30 day.
 #[inline]
 fn default_gc_policy_task_ttl() -> Duration {
     Duration::from_secs(2_592_000)
 }
 
-/// default_gc_policy_task_ttl is the default ttl of the task, default is 1 day.
+/// Returnsgc_policy_task_ttl is the default ttl of the task, default is 1 day.
 #[inline]
 fn default_gc_policy_persistent_task_ttl() -> Duration {
     Duration::from_secs(86_400)
 }
 
-/// default_gc_policy_task_ttl is the default ttl of the task, default is 1 day.
+/// Returnsgc_policy_task_ttl is the default ttl of the task, default is 1 day.
 #[inline]
 fn default_gc_policy_persistent_cache_task_ttl() -> Duration {
     Duration::from_secs(86_400)
 }
 
-/// default_gc_policy_disk_threshold is the default threshold of the disk usage to do gc.
+/// Returnsgc_policy_disk_threshold is the default threshold of the disk usage to do gc.
 #[inline]
 fn default_gc_policy_disk_threshold() -> ByteSize {
     ByteSize::default()
 }
 
-/// default_gc_policy_disk_high_threshold_percent is the default high threshold percent of the disk usage.
+/// Returnsgc_policy_disk_high_threshold_percent is the default high threshold percent of the disk usage.
 #[inline]
 fn default_gc_policy_disk_high_threshold_percent() -> u8 {
     80
 }
 
-/// default_gc_policy_disk_low_threshold_percent is the default low threshold percent of the disk usage.
+/// Returnsgc_policy_disk_low_threshold_percent is the default low threshold percent of the disk usage.
 #[inline]
 fn default_gc_policy_disk_low_threshold_percent() -> u8 {
     60
 }
 
-/// default_proxy_server_port is the default port of the proxy server.
+/// Returnsproxy_server_port is the default port of the proxy server.
 #[inline]
 pub fn default_proxy_server_port() -> u16 {
     4001
 }
 
-/// default_proxy_read_buffer_size is the default buffer size for reading piece, default is 4MB.
+/// Returnsproxy_read_buffer_size is the default buffer size for reading piece, default is 4MB.
 #[inline]
 pub fn default_proxy_read_buffer_size() -> usize {
     4 * 1024 * 1024
 }
 
-/// default_prefetch_rate_limit is the default rate limit of the prefetch speed in GiB/Mib/Kib per second. The prefetch request
+/// Returnsprefetch_rate_limit is the default rate limit of the prefetch speed in GiB/Mib/Kib per second. The prefetch request
 /// has lower priority so limit the rate to avoid occupying the bandwidth impact other download tasks.
 #[inline]
 fn default_prefetch_rate_limit() -> ByteSize {
@@ -318,13 +318,13 @@ fn default_prefetch_rate_limit() -> ByteSize {
     ByteSize::gib(2)
 }
 
-/// default_proxy_registry_mirror_addr is the default registry mirror address.
+/// Returnsproxy_registry_mirror_addr is the default registry mirror address.
 #[inline]
 fn default_proxy_registry_mirror_addr() -> String {
     "https://index.docker.io".to_string()
 }
 
-/// default_enable_task_id_based_blob_digest is the default value for enable_task_id_based_blob_digest.
+/// Returnsenable_task_id_based_blob_digest is the default value for enable_task_id_based_blob_digest.
 /// It indicates whether to calculate the task ID based on the blob's SHA256 digest for OCI registry
 /// blob download URLs.
 #[inline]

--- a/dragonfly-client-config/src/dfinit.rs
+++ b/dragonfly-client-config/src/dfinit.rs
@@ -27,37 +27,37 @@ use validator::Validate;
 /// NAME is the name of dfinit.
 pub const NAME: &str = "dfinit";
 
-/// default_dfinit_config_path is the default config path for dfinit.
+/// Returns the default config path for dfinit.
 #[inline]
 pub fn default_dfinit_config_path() -> PathBuf {
     crate::default_config_dir().join("dfinit.yaml")
 }
 
-/// default_container_runtime_containerd_config_path is the default containerd configuration path.
+/// Returns the default containerd configuration path.
 #[inline]
 fn default_container_runtime_containerd_config_path() -> PathBuf {
     PathBuf::from("/etc/containerd/config.toml")
 }
 
-/// default_container_runtime_docker_config_path is the default docker configuration path.
+/// Returns the default docker configuration path.
 #[inline]
 fn default_container_runtime_docker_config_path() -> PathBuf {
     PathBuf::from("/etc/docker/daemon.json")
 }
 
-/// default_container_runtime_crio_config_path is the default cri-o configuration path.
+/// Returns the default cri-o configuration path.
 #[inline]
 fn default_container_runtime_crio_config_path() -> PathBuf {
     PathBuf::from("/etc/containers/registries.conf")
 }
 
-/// default_container_runtime_podman_config_path is the default podman configuration path.
+/// Returns the default podman configuration path.
 #[inline]
 fn default_container_runtime_podman_config_path() -> PathBuf {
     PathBuf::from("/etc/containers/registries.conf")
 }
 
-/// default_container_runtime_crio_unqualified_search_registries is the default unqualified search registries of cri-o,
+/// Returns the default unqualified search registries of cri-o,
 /// refer to https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#global-settings.
 #[inline]
 fn default_container_runtime_crio_unqualified_search_registries() -> Vec<String> {
@@ -68,7 +68,7 @@ fn default_container_runtime_crio_unqualified_search_registries() -> Vec<String>
     ]
 }
 
-/// default_container_runtime_podman_unqualified_search_registries is the default unqualified search registries of cri-o,
+/// Returns the default unqualified search registries of podman,
 /// refer to https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#global-settings.
 #[inline]
 fn default_container_runtime_podman_unqualified_search_registries() -> Vec<String> {
@@ -79,7 +79,7 @@ fn default_container_runtime_podman_unqualified_search_registries() -> Vec<Strin
     ]
 }
 
-/// default_proxy_addr is the default proxy address of dfdaemon.
+/// Returns the default proxy address of dfdaemon.
 #[inline]
 fn default_proxy_addr() -> String {
     format!(
@@ -89,8 +89,7 @@ fn default_proxy_addr() -> String {
     )
 }
 
-/// default_container_runtime_containerd_registry_host_capabilities is the default
-/// capabilities of the containerd registry.
+/// Returns the default capabilities of the containerd registry.
 #[inline]
 fn default_container_runtime_containerd_registry_capabilities() -> Vec<String> {
     vec!["pull".to_string(), "resolve".to_string()]
@@ -330,7 +329,7 @@ pub struct Config {
 
 /// Config implements the config operation of dfinit.
 impl Config {
-    /// load loads configuration from file.
+    /// Loads configuration from file.
     #[instrument(skip_all)]
     pub fn load(path: &PathBuf) -> Result<Config> {
         // Load configuration from file.

--- a/dragonfly-client-storage/src/cache/lru_cache.rs
+++ b/dragonfly-client-storage/src/cache/lru_cache.rs
@@ -135,7 +135,7 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         }
     }
 
-    /// get gets the value of the key.
+    /// Gets the value of the key.
     pub fn get<'a, Q>(&'a mut self, k: &Q) -> Option<&'a V>
     where
         K: Borrow<Q>,

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -66,13 +66,12 @@ pub struct WritePersistentCacheTaskResponse {
     pub hash: String,
 }
 
-/// new_content creates a new Content instance to support linux and macos.
+/// Creates a new Content instance to support linux and macos.
 pub async fn new_content(config: Arc<Config>, dir: &Path) -> Result<Content> {
     Content::new(config, dir).await
 }
 
-/// calculate_piece_range calculates the target offset and length based on the piece range and
-/// request range.
+/// Calculates the target offset and length based on the piece range and request range.
 pub fn calculate_piece_range(offset: u64, length: u64, range: Option<Range>) -> (u64, u64) {
     if let Some(range) = range {
         let target_offset = max(offset, range.start);

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -41,7 +41,7 @@ pub struct Content {
 
 /// Content implements the content storage.
 impl Content {
-    /// new returns a new content.
+    /// Creates a new Content instance.
     pub async fn new(config: Arc<Config>, dir: &Path) -> Result<Content> {
         let dir = dir.join(super::content::DEFAULT_CONTENT_DIR);
 
@@ -59,7 +59,7 @@ impl Content {
         Ok(Content { config, dir })
     }
 
-    /// available_space returns the available space of the disk.
+    /// Returns the available space of the disk.
     pub fn available_space(&self) -> Result<u64> {
         let disk_threshold = self.config.gc.policy.disk_threshold;
         if disk_threshold != ByteSize::default() {
@@ -86,7 +86,7 @@ impl Content {
         Ok(stat.available_space())
     }
 
-    /// total_space returns the total space of the disk.
+    /// Returns the total space of the disk.
     pub fn total_space(&self) -> Result<u64> {
         // If the disk_threshold is set, return it directly.
         let disk_threshold = self.config.gc.policy.disk_threshold;
@@ -98,7 +98,7 @@ impl Content {
         Ok(stat.total_space())
     }
 
-    /// has_enough_space checks if the storage has enough space to store the content.
+    /// Checks if the storage has enough space to store the content.
     pub fn has_enough_space(&self, content_length: u64) -> Result<bool> {
         let available_space = self.available_space()?;
         if available_space < content_length {
@@ -113,7 +113,7 @@ impl Content {
         Ok(true)
     }
 
-    /// is_same_dev_inode checks if the source and target are the same device and inode.
+    /// Checks if the source and target are the same device and inode.
     async fn is_same_dev_inode<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
         source: P,
@@ -126,13 +126,13 @@ impl Content {
             && source_metadata.ino() == target_metadata.ino())
     }
 
-    /// is_same_dev_inode_as_task checks if the task and target are the same device and inode.
+    /// Checks if the task and target are the same device and inode.
     pub async fn is_same_dev_inode_as_task(&self, task_id: &str, to: &Path) -> Result<bool> {
         let task_path = self.get_task_path(task_id);
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_task creates a new task content.
+    /// Creates a new task content.
     ///
     /// Behavior of `create_task`:
     /// 1. If the task already exists, return the task path.
@@ -378,7 +378,7 @@ impl Content {
         })
     }
 
-    /// get_task_path returns the task path by task id.
+    /// Returns the task path by task id.
     fn get_task_path(&self, task_id: &str) -> PathBuf {
         // The task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.
@@ -389,7 +389,7 @@ impl Content {
             .join(task_id)
     }
 
-    /// is_same_dev_inode_as_persistent_task checks if the persistent task and target
+    /// Checks if the persistent task and target
     /// are the same device and inode.
     pub async fn is_same_dev_inode_as_persistent_task(
         &self,
@@ -400,7 +400,7 @@ impl Content {
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_persistent_task creates a new persistent task content.
+    /// Creates a new persistent task content.
     ///
     /// Behavior of `create_persistent_task`:
     /// 1. If the persistent task already exists, return the persistent task path.
@@ -617,7 +617,7 @@ impl Content {
         Ok(())
     }
 
-    /// get_persistent_task_path returns the persistent task path by task id.
+    /// Returns the persistent task path by task id.
     fn get_persistent_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.
@@ -627,7 +627,7 @@ impl Content {
             .join(task_id)
     }
 
-    /// is_same_dev_inode_as_persistent_cache_task checks if the persistent cache task and target
+    /// Checks if the persistent cache task and target
     /// are the same device and inode.
     pub async fn is_same_dev_inode_as_persistent_cache_task(
         &self,
@@ -638,7 +638,7 @@ impl Content {
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_persistent_cache_task creates a new persistent cache task content.
+    /// Creates a new persistent cache task content.
     ///
     /// Behavior of `create_persistent_cache_task`:
     /// 1. If the persistent cache task already exists, return the persistent cache task path.
@@ -863,7 +863,7 @@ impl Content {
         Ok(())
     }
 
-    /// get_persistent_cache_task_path returns the persistent cache task path by task id.
+    /// Returns the persistent cache task path by task id.
     fn get_persistent_cache_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent cache task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -41,7 +41,7 @@ pub struct Content {
 
 /// Content implements the content storage.
 impl Content {
-    /// new returns a new content.
+    /// Creates a new Content instance.
     pub async fn new(config: Arc<Config>, dir: &Path) -> Result<Content> {
         let dir = dir.join(super::content::DEFAULT_CONTENT_DIR);
 
@@ -59,7 +59,7 @@ impl Content {
         Ok(Content { config, dir })
     }
 
-    /// available_space returns the available space of the disk.
+    /// Returns the available space of the disk.
     pub fn available_space(&self) -> Result<u64> {
         let disk_threshold = self.config.gc.policy.disk_threshold;
         if disk_threshold != ByteSize::default() {
@@ -86,7 +86,7 @@ impl Content {
         Ok(stat.available_space())
     }
 
-    /// total_space returns the total space of the disk.
+    /// Returns the total space of the disk.
     pub fn total_space(&self) -> Result<u64> {
         // If the disk_threshold is set, return it directly.
         let disk_threshold = self.config.gc.policy.disk_threshold;
@@ -98,7 +98,7 @@ impl Content {
         Ok(stat.total_space())
     }
 
-    /// has_enough_space checks if the storage has enough space to store the content.
+    /// Checks if the storage has enough space to store the content.
     pub fn has_enough_space(&self, content_length: u64) -> Result<bool> {
         let available_space = self.available_space()?;
         if available_space < content_length {
@@ -113,7 +113,7 @@ impl Content {
         Ok(true)
     }
 
-    /// is_same_dev_inode checks if the source and target are the same device and inode.
+    /// Checks if the source and target are the same device and inode.
     async fn is_same_dev_inode<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
         source: P,
@@ -126,13 +126,13 @@ impl Content {
             && source_metadata.ino() == target_metadata.ino())
     }
 
-    /// is_same_dev_inode_as_task checks if the task and target are the same device and inode.
+    /// Checks if the task and target are the same device and inode.
     pub async fn is_same_dev_inode_as_task(&self, task_id: &str, to: &Path) -> Result<bool> {
         let task_path = self.get_task_path(task_id);
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_task creates a new task content.
+    /// Creates a new task content.
     ///
     /// Behavior of `create_task`:
     /// 1. If the task already exists, return the task path.
@@ -406,7 +406,7 @@ impl Content {
         })
     }
 
-    /// get_task_path returns the task path by task id.
+    /// Returns the task path by task id.
     fn get_task_path(&self, task_id: &str) -> PathBuf {
         // The task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.
@@ -417,7 +417,7 @@ impl Content {
             .join(task_id)
     }
 
-    /// is_same_dev_inode_as_persistent_task checks if the persistent task and target
+    /// Checks if the persistent task and target
     /// are the same device and inode.
     pub async fn is_same_dev_inode_as_persistent_task(
         &self,
@@ -428,7 +428,7 @@ impl Content {
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_persistent_task creates a new persistent task content.
+    /// Creates a new persistent task content.
     ///
     /// Behavior of `create_persistent_task`:
     /// 1. If the persistent task already exists, return the persistent task path.
@@ -645,7 +645,7 @@ impl Content {
         Ok(())
     }
 
-    /// get_persistent_task_path returns the persistent task path by task id.
+    /// Returns the persistent task path by task id.
     fn get_persistent_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.
@@ -655,7 +655,7 @@ impl Content {
             .join(task_id)
     }
 
-    /// is_same_dev_inode_as_persistent_cache_task checks if the persistent cache task and target
+    /// Checks if the persistent cache task and target
     /// are the same device and inode.
     pub async fn is_same_dev_inode_as_persistent_cache_task(
         &self,
@@ -666,7 +666,7 @@ impl Content {
         self.is_same_dev_inode(&task_path, to).await
     }
 
-    /// create_persistent_cache_task creates a new persistent cache task content.
+    /// Creates a new persistent cache task content.
     ///
     /// Behavior of `create_persistent_cache_task`:
     /// 1. If the persistent cache task already exists, return the persistent cache task path.
@@ -891,7 +891,7 @@ impl Content {
         Ok(())
     }
 
-    /// get_persistent_cache_task_path returns the persistent cache task path by task id.
+    /// Returns the persistent cache task path by task id.
     fn get_persistent_cache_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent cache task needs split by the first 3 characters of task id(sha256) to
         // avoid too many files in one directory.

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Storage {
 
 /// Storage implements the storage.
 impl Storage {
-    /// new returns a new storage.
+    /// Creates a new storage.
     pub async fn new(config: Arc<Config>, dir: &Path, log_dir: PathBuf) -> Result<Self> {
         let metadata = metadata::Metadata::new(config.clone(), dir, &log_dir)?;
         let content = content::new_content(config.clone(), dir).await?;
@@ -79,17 +79,17 @@ impl Storage {
         })
     }
 
-    /// total_space returns the total space of the disk.
+    /// Returns the total space of the disk.
     pub fn total_space(&self) -> Result<u64> {
         self.content.total_space()
     }
 
-    /// available_space returns the available space of the disk.
+    /// Returns the available space of the disk.
     pub fn available_space(&self) -> Result<u64> {
         self.content.available_space()
     }
 
-    /// has_enough_space checks if the storage has enough space to store the content.
+    /// Checks if the storage has enough space to store the content.
     pub fn has_enough_space(&self, content_length: u64) -> Result<bool> {
         self.content.has_enough_space(content_length)
     }
@@ -106,7 +106,7 @@ impl Storage {
         self.content.copy_task(id, to).await
     }
 
-    /// is_same_dev_inode_as_task checks if the task content is on the same device inode as the
+    /// Checks if the task content is on the same device inode as the
     /// destination.
     pub async fn is_same_dev_inode_as_task(&self, id: &str, to: &Path) -> Result<bool> {
         self.content.is_same_dev_inode_as_task(id, to).await
@@ -164,19 +164,19 @@ impl Storage {
         self.metadata.upload_task_finished(id)
     }
 
-    /// get_task returns the task metadata.
+    /// Returns the task metadata.
     #[instrument(skip_all)]
     pub fn get_task(&self, id: &str) -> Result<Option<metadata::Task>> {
         self.metadata.get_task(id)
     }
 
-    /// is_task_exists returns whether the task exists.
+    /// Returns whether the task exists.
     #[instrument(skip_all)]
     pub fn is_task_exists(&self, id: &str) -> Result<bool> {
         self.metadata.is_task_exists(id)
     }
 
-    /// get_tasks returns the task metadatas.
+    /// Returns the task metadatas.
     #[instrument(skip_all)]
     pub fn get_tasks(&self) -> Result<Vec<metadata::Task>> {
         self.metadata.get_tasks()
@@ -223,7 +223,7 @@ impl Storage {
         self.content.copy_persistent_task(id, to).await
     }
 
-    /// is_same_dev_inode_as_persistent_task checks if the persistent task content is on the same device inode as the
+    /// Checks if the persistent task content is on the same device inode as the
     /// destination.
     pub async fn is_same_dev_inode_as_persistent_task(&self, id: &str, to: &Path) -> Result<bool> {
         self.content
@@ -323,7 +323,7 @@ impl Storage {
         self.metadata.upload_persistent_task_finished(id)
     }
 
-    /// get_persistent_task returns the persistent task metadata.
+    /// Returns the persistent task metadata.
     #[instrument(skip_all)]
     pub fn get_persistent_task(&self, id: &str) -> Result<Option<metadata::PersistentTask>> {
         self.metadata.get_persistent_task(id)
@@ -335,13 +335,13 @@ impl Storage {
         self.metadata.persist_persistent_task(id)
     }
 
-    /// is_persistent_task_exists returns whether the persistent task exists.
+    /// Returns whether the persistent task exists.
     #[instrument(skip_all)]
     pub fn is_persistent_task_exists(&self, id: &str) -> Result<bool> {
         self.metadata.is_persistent_task_exists(id)
     }
 
-    /// get_tasks returns the task metadatas.
+    /// Returns the task metadatas.
     #[instrument(skip_all)]
     pub fn get_persistent_tasks(&self) -> Result<Vec<metadata::PersistentTask>> {
         self.metadata.get_persistent_tasks()
@@ -394,7 +394,7 @@ impl Storage {
         self.content.copy_persistent_cache_task(id, to).await
     }
 
-    /// is_same_dev_inode_as_persistent_cache_task checks if the persistent cache task content is on the same device inode as the
+    /// Checks if the persistent cache task content is on the same device inode as the
     /// destination.
     pub async fn is_same_dev_inode_as_persistent_cache_task(
         &self,
@@ -507,7 +507,7 @@ impl Storage {
         self.metadata.upload_persistent_cache_task_finished(id)
     }
 
-    /// get_persistent_cache_task returns the persistent cache task metadata.
+    /// Returns the persistent cache task metadata.
     #[instrument(skip_all)]
     pub fn get_persistent_cache_task(
         &self,
@@ -522,13 +522,13 @@ impl Storage {
         self.metadata.persist_persistent_cache_task(id)
     }
 
-    /// is_persistent_cache_task_exists returns whether the persistent cache task exists.
+    /// Returns whether the persistent cache task exists.
     #[instrument(skip_all)]
     pub fn is_persistent_cache_task_exists(&self, id: &str) -> Result<bool> {
         self.metadata.is_persistent_cache_task_exists(id)
     }
 
-    /// get_tasks returns the task metadatas.
+    /// Returns the task metadatas.
     #[instrument(skip_all)]
     pub fn get_persistent_cache_tasks(&self) -> Result<Vec<metadata::PersistentCacheTask>> {
         self.metadata.get_persistent_cache_tasks()
@@ -590,13 +590,13 @@ impl Storage {
         self.metadata.upload_cache_task_finished(id)
     }
 
-    /// get_cache_task returns the cache task metadata.
+    /// Returns the cache task metadata.
     #[instrument(skip_all)]
     pub fn get_cache_task(&self, id: &str) -> Result<Option<metadata::CacheTask>> {
         self.metadata.get_cache_task(id)
     }
 
-    /// is_cache_task_exists returns whether the cache task exists.
+    /// Returns whether the cache task exists.
     #[instrument(skip_all)]
     pub fn is_cache_task_exists(&self, id: &str) -> Result<bool> {
         self.metadata.is_cache_task_exists(id)

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -728,19 +728,19 @@ impl<E: StorageEngineOwned> Metadata<E> {
         Ok(task)
     }
 
-    /// get_task gets the task metadata.
+    /// Gets the task metadata.
     #[instrument(skip_all)]
     pub fn get_task(&self, id: &str) -> Result<Option<Task>> {
         self.db.get(id.as_bytes())
     }
 
-    /// is_task_exists checks if the task exists.
+    /// Checks if the task exists.
     #[instrument(skip_all)]
     pub fn is_task_exists(&self, id: &str) -> Result<bool> {
         self.db.exists::<Task>(id.as_bytes())
     }
 
-    /// get_tasks gets the task metadatas.
+    /// Gets the task metadatas.
     #[instrument(skip_all)]
     pub fn get_tasks(&self) -> Result<Vec<Task>> {
         let tasks = self
@@ -960,13 +960,13 @@ impl<E: StorageEngineOwned> Metadata<E> {
         self.db.get(id.as_bytes())
     }
 
-    /// is_persistent_task_exists checks if the persistent task exists.
+    /// Checks if the persistent task exists.
     #[instrument(skip_all)]
     pub fn is_persistent_task_exists(&self, id: &str) -> Result<bool> {
         self.db.exists::<PersistentTask>(id.as_bytes())
     }
 
-    /// get_persistent_tasks gets the persistent task metadatas.
+    /// Gets the persistent task metadatas.
     #[instrument(skip_all)]
     pub fn get_persistent_tasks(&self) -> Result<Vec<PersistentTask>> {
         let iter = self.db.iter::<PersistentTask>()?;
@@ -1175,13 +1175,13 @@ impl<E: StorageEngineOwned> Metadata<E> {
         self.db.get(id.as_bytes())
     }
 
-    /// is_persistent_cache_task_exists checks if the persistent cache task exists.
+    /// Checks if the persistent cache task exists.
     #[instrument(skip_all)]
     pub fn is_persistent_cache_task_exists(&self, id: &str) -> Result<bool> {
         self.db.exists::<PersistentCacheTask>(id.as_bytes())
     }
 
-    /// get_persistent_cache_tasks gets the persistent cache task metadatas.
+    /// Gets the persistent cache task metadatas.
     #[instrument(skip_all)]
     pub fn get_persistent_cache_tasks(&self) -> Result<Vec<PersistentCacheTask>> {
         let iter = self.db.iter::<PersistentCacheTask>()?;
@@ -1323,13 +1323,13 @@ impl<E: StorageEngineOwned> Metadata<E> {
         self.db.get(id.as_bytes())
     }
 
-    /// is_cache_task_exists checks if the cache task exists.
+    /// Checks if the cache task exists.
     #[instrument(skip_all)]
     pub fn is_cache_task_exists(&self, id: &str) -> Result<bool> {
         self.db.exists::<CacheTask>(id.as_bytes())
     }
 
-    /// get_cache_tasks gets the cache task metadatas.
+    /// Gets the cache task metadatas.
     #[instrument(skip_all)]
     pub fn get_cache_tasks(&self) -> Result<Vec<CacheTask>> {
         let tasks = self

--- a/dragonfly-client-util/src/digest/mod.rs
+++ b/dragonfly-client-util/src/digest/mod.rs
@@ -32,7 +32,7 @@ lazy_static! {
     static ref BLOB_URL_REGEX: Regex = Regex::new(r"^(.*)://(.*)/v2/(.*)/blobs/([^?]+)(?:\?.*)?$").unwrap();
 }
 
-/// is_blob_url checks if the url is an oci blob url.
+/// Checks if the URL is an OCI blob URL.
 pub fn is_blob_url(url: &str) -> bool {
     BLOB_URL_REGEX.is_match(url)
 }
@@ -88,7 +88,7 @@ pub struct Digest {
 
 /// Digest implements the Digest.
 impl Digest {
-    /// new returns a new Digest.
+    /// Creates a new Digest.
     pub fn new(algorithm: Algorithm, encoded: String) -> Self {
         Self { algorithm, encoded }
     }
@@ -103,7 +103,7 @@ impl Digest {
             .ok()
     }
 
-    /// algorithm returns the algorithm of the digest.
+    /// Returns the algorithm of the digest.
     pub fn algorithm(&self) -> Algorithm {
         self.algorithm
     }
@@ -171,7 +171,7 @@ impl FromStr for Digest {
     }
 }
 
-/// calculate_file_digest calculates the digest of a file.
+/// Calculates the digest of a file.
 #[instrument(skip_all)]
 pub fn calculate_file_digest(algorithm: Algorithm, path: &Path) -> ClientResult<Digest> {
     let f = std::fs::File::open(path)?;

--- a/dragonfly-client-util/src/http/basic_auth.rs
+++ b/dragonfly-client-util/src/http/basic_auth.rs
@@ -32,7 +32,7 @@ pub struct Credentials {
 
 /// Credentials is the basic auth.
 impl Credentials {
-    /// new returns a new Credentials.
+    /// Creates a new Credentials.
     pub fn new(username: &str, password: &str) -> Credentials {
         Self {
             username: username.to_string(),

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -86,7 +86,7 @@ pub struct IDGenerator {
 
 /// IDGenerator implements the IDGenerator.
 impl IDGenerator {
-    /// new creates a new IDGenerator.
+    /// Creates a new IDGenerator.
     pub fn new(ip: String, hostname: String, is_seed_peer: bool) -> Self {
         IDGenerator {
             ip,

--- a/dragonfly-client-util/src/net/mod.rs
+++ b/dragonfly-client-util/src/net/mod.rs
@@ -61,7 +61,7 @@ impl Interface {
     /// DEFAULT_NETWORKS_REFRESH_INTERVAL is the default interval for refreshing network data.
     const DEFAULT_NETWORKS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
-    /// new creates a new Interface instance based on the provided IP address and rate limit.
+    /// Creates a new Interface instance based on the provided IP address and rate limit.
     pub fn new(ip: IpAddr, rate_limit: ByteSize) -> Interface {
         let rate_limit = Self::byte_size_to_bits(rate_limit); // convert to bps
         let Some(interface) = Self::get_network_interface_by_ip(ip) else {
@@ -146,7 +146,7 @@ impl Interface {
         }
     }
 
-    /// get_speed returns the speed of the network interface in Mbps.
+    /// Returns the speed of the network interface in Mbps.
     pub fn get_speed(name: &str) -> Option<u64> {
         #[cfg(target_os = "linux")]
         {
@@ -163,8 +163,7 @@ impl Interface {
         }
     }
 
-    /// get_network_interface_by_ip returns the network interface that has the specified
-    /// IP address.
+    /// Returns the network interface that has the specified IP address.
     pub fn get_network_interface_by_ip(ip: IpAddr) -> Option<NetworkInterface> {
         datalink::interfaces()
             .into_iter()

--- a/dragonfly-client-util/src/pool/mod.rs
+++ b/dragonfly-client-util/src/pool/mod.rs
@@ -36,7 +36,7 @@ pub struct RequestGuard {
 
 /// RequestGuard implements the request guard pattern.
 impl RequestGuard {
-    /// Create a new request guard.
+    /// Creates a new request guard.
     fn new(active_requests: Arc<AtomicUsize>) -> Self {
         active_requests.fetch_add(1, Ordering::SeqCst);
         Self { active_requests }
@@ -66,7 +66,7 @@ pub struct Entry<T> {
 
 /// Entry methods for managing client state.
 impl<T> Entry<T> {
-    /// Create a new entry with the given client.
+    /// Creates a new entry with the given client.
     fn new(client: T) -> Self {
         Self {
             client,
@@ -144,7 +144,7 @@ where
     T: Clone,
     F: Factory<A, T>,
 {
-    /// Create a new client pool builder.
+    /// Creates a new client pool builder.
     pub fn new(factory: F) -> Self {
         Self {
             factory,

--- a/dragonfly-client-util/src/request/mod.rs
+++ b/dragonfly-client-util/src/request/mod.rs
@@ -194,7 +194,7 @@ pub struct Builder {
 
 /// Builder implements Default trait.
 impl Default for Builder {
-    /// default returns a default Builder.
+    /// Returns a default Builder.
     fn default() -> Self {
         Self {
             scheduler_endpoint: "".to_string(),

--- a/dragonfly-client-util/src/request/selector.rs
+++ b/dragonfly-client-util/src/request/selector.rs
@@ -72,7 +72,7 @@ pub struct SeedPeerSelector {
 
 /// SeedPeerSelector implements a selector that selects seed peers from the scheduler service.
 impl SeedPeerSelector {
-    /// new creates a new seed peer selector.
+    /// Creates a new seed peer selector.
     pub async fn new(
         scheduler_client: SchedulerClient<Channel>,
         health_check_interval: Duration,

--- a/dragonfly-client-util/src/shutdown/mod.rs
+++ b/dragonfly-client-util/src/shutdown/mod.rs
@@ -33,7 +33,7 @@ pub struct Shutdown {
 
 /// Shutdown implements the shutdown signal.
 impl Shutdown {
-    /// new creates a new Shutdown.
+    /// Creates a new Shutdown.
     pub fn new() -> Shutdown {
         let (sender, receiver) = broadcast::channel(1);
         Self {
@@ -43,7 +43,7 @@ impl Shutdown {
         }
     }
 
-    /// is_shutdown returns true if the shutdown signal has been received.
+    /// Returns true if the shutdown signal has been received.
     pub fn is_shutdown(&self) -> bool {
         self.is_shutdown
     }
@@ -70,7 +70,7 @@ impl Shutdown {
 
 // Default implements the Default trait.
 impl Default for Shutdown {
-    // default returns a new default Shutdown.
+    // Returns a new default Shutdown.
     fn default() -> Self {
         Self::new()
     }
@@ -78,7 +78,7 @@ impl Default for Shutdown {
 
 /// Clone implements the Clone trait.
 impl Clone for Shutdown {
-    /// clone returns a new Shutdown.
+    /// Returns a new Shutdown.
     fn clone(&self) -> Self {
         let sender = self.sender.clone();
         let receiver = self.sender.subscribe();

--- a/dragonfly-client-util/src/tls/mod.rs
+++ b/dragonfly-client-util/src/tls/mod.rs
@@ -52,7 +52,7 @@ pub struct NoVerifier(Arc<rustls::crypto::CryptoProvider>);
 
 /// Implement the NoVerifier.
 impl NoVerifier {
-    /// new creates a new NoVerifier.
+    /// Creates a new NoVerifier.
     pub fn new() -> Arc<Self> {
         Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
     }

--- a/dragonfly-client/src/announcer/mod.rs
+++ b/dragonfly-client/src/announcer/mod.rs
@@ -54,7 +54,7 @@ pub struct SchedulerAnnouncer {
 
 /// SchedulerAnnouncer implements the scheduler announcer of the dfdaemon.
 impl SchedulerAnnouncer {
-    /// new creates a new scheduler announcer.
+    /// Creates a new scheduler announcer.
     pub async fn new(
         config: Arc<Config>,
         host_id: String,

--- a/dragonfly-client/src/dynconfig/mod.rs
+++ b/dragonfly-client/src/dynconfig/mod.rs
@@ -64,7 +64,7 @@ pub struct Dynconfig {
 
 /// Dynconfig is the implementation of Dynconfig.
 impl Dynconfig {
-    /// new creates a new Dynconfig.
+    /// Creates a new Dynconfig.
     pub async fn new(
         config: Arc<Config>,
         manager_client: Arc<ManagerClient>,
@@ -167,7 +167,7 @@ impl Dynconfig {
             .await
     }
 
-    /// get_available_schedulers gets the available schedulers.
+    /// Gets the available schedulers.
     #[instrument(skip_all)]
     async fn get_available_schedulers(&self, schedulers: &[Scheduler]) -> Result<Vec<Scheduler>> {
         let mut available_schedulers: Vec<Scheduler> = Vec::new();

--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -52,7 +52,7 @@ pub struct GC {
 }
 
 impl GC {
-    /// new creates a new GC.
+    /// Creates a new GC.
     pub fn new(
         config: Arc<Config>,
         host_id: String,

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -746,7 +746,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         }
     }
 
-    /// stat_local_task stats the local task.
+    /// Gets the local task.
     #[instrument(skip_all, fields(task_id, remote_ip))]
     async fn stat_local_task(
         &self,
@@ -794,7 +794,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         }
     }
 
-    /// list_tasks lists the tasks.
+    /// Lists the tasks.
     #[instrument(skip_all, fields(task_id, url, remote_ip))]
     async fn list_task_entries(
         &self,
@@ -921,7 +921,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         Ok(Response::new(()))
     }
 
-    /// delete_host calls the scheduler to delete the host.
+    /// Calls the scheduler to delete the host.
     #[instrument(skip_all, fields(host_id))]
     async fn delete_host(&self, request: Request<()>) -> Result<Response<()>, Status> {
         // If the parent context is set, use it as the parent context for the span.

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -109,7 +109,7 @@ pub struct DfdaemonUploadServer {
 
 /// DfdaemonUploadServer implements the grpc server of the upload.
 impl DfdaemonUploadServer {
-    /// new creates a new DfdaemonUploadServer.
+    /// Creates a new DfdaemonUploadServer.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
@@ -664,7 +664,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         Ok(Response::new(ReceiverStream::new(out_stream_rx)))
     }
 
-    /// stat_task stats the task.
+    /// Gets the task.
     #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn stat_task(&self, request: Request<StatTaskRequest>) -> Result<Response<Task>, Status> {
         // If the parent context is set, use it as the parent context for the span.
@@ -759,7 +759,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         }
     }
 
-    /// list_tasks lists the tasks.
+    /// Lists the tasks.
     #[instrument(skip_all, fields(task_id, url, remote_ip))]
     async fn list_task_entries(
         &self,
@@ -839,7 +839,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         }))
     }
 
-    /// delete_task deletes the task.
+    /// Deletes the task.
     #[instrument(skip_all, fields(host_id, task_id, remote_ip))]
     async fn delete_task(
         &self,

--- a/dragonfly-client/src/grpc/health.rs
+++ b/dragonfly-client/src/grpc/health.rs
@@ -41,7 +41,7 @@ pub struct HealthClient {
 
 /// HealthClient implements the grpc client of the health.
 impl HealthClient {
-    /// new creates a new HealthClient.
+    /// Creates a new HealthClient.
     pub async fn new(addr: &str, client_tls_config: Option<ClientTlsConfig>) -> Result<Self> {
         let channel = match client_tls_config {
             Some(client_tls_config) => Channel::from_shared(addr.to_string())
@@ -79,7 +79,7 @@ impl HealthClient {
         Ok(Self { client })
     }
 
-    /// new_unix creates a new HealthClient with unix domain socket.
+    /// Creates a new HealthClient with unix domain socket.
     pub async fn new_unix(socket_path: PathBuf) -> Result<Self> {
         // Ignore the uri because it is not used.
         let channel = Endpoint::try_from("http://[::]:50051")
@@ -104,7 +104,7 @@ impl HealthClient {
         Ok(Self { client })
     }
 
-    /// check checks the health of the grpc service without service name.
+    /// Checks the health of the grpc service without service name.
     #[instrument(skip_all)]
     pub async fn check(&self) -> Result<HealthCheckResponse> {
         let request = Self::make_request(HealthCheckRequest {
@@ -114,7 +114,7 @@ impl HealthClient {
         Ok(response.into_inner())
     }
 
-    /// check_service checks the health of the grpc service with service name.
+    /// Checks the health of the grpc service with service name.
     #[instrument(skip_all)]
     pub async fn check_service(&self, service: String) -> Result<HealthCheckResponse> {
         let request = Self::make_request(HealthCheckRequest { service });
@@ -122,21 +122,21 @@ impl HealthClient {
         Ok(response.into_inner())
     }
 
-    /// check_dfdaemon_download checks the health of the dfdaemon download service.
+    /// Checks the health of the dfdaemon download service.
     #[instrument(skip_all)]
     pub async fn check_dfdaemon_download(&self) -> Result<HealthCheckResponse> {
         self.check_service("dfdaemon.v2.DfdaemonDownload".to_string())
             .await
     }
 
-    /// check_dfdaemon_upload checks the health of the dfdaemon upload service.
+    /// Checks the health of the dfdaemon upload service.
     #[instrument(skip_all)]
     pub async fn check_dfdaemon_upload(&self) -> Result<HealthCheckResponse> {
         self.check_service("dfdaemon.v2.DfdaemonUpload".to_string())
             .await
     }
 
-    /// make_request creates a new request with timeout.
+    /// Creates a new request with timeout.
     fn make_request<T>(request: T) -> tonic::Request<T> {
         let mut request = tonic::Request::new(request);
         request.set_timeout(super::REQUEST_TIMEOUT);

--- a/dragonfly-client/src/grpc/manager.rs
+++ b/dragonfly-client/src/grpc/manager.rs
@@ -41,7 +41,7 @@ pub struct ManagerClient {
 
 /// ManagerClient implements the grpc client of the manager.
 impl ManagerClient {
-    /// new creates a new ManagerClient.
+    /// Creates a new ManagerClient.
     pub async fn new(config: Arc<Config>, addr: String) -> Result<Self> {
         let domain_name = Url::parse(addr.as_str())?
             .host_str()
@@ -115,7 +115,7 @@ impl ManagerClient {
         Ok(response.into_inner())
     }
 
-    /// update_seed_peer updates the seed peer information.
+    /// Updates the seed peer information.
     #[instrument(skip_all)]
     pub async fn update_seed_peer(&self, request: UpdateSeedPeerRequest) -> Result<SeedPeer> {
         let request = Self::make_request(request);
@@ -131,7 +131,7 @@ impl ManagerClient {
         Ok(())
     }
 
-    /// make_request creates a new request with timeout.
+    /// Creates a new request with timeout.
     fn make_request<T>(request: T) -> tonic::Request<T> {
         let mut request = tonic::Request::new(request);
         request.set_timeout(super::REQUEST_TIMEOUT);

--- a/dragonfly-client/src/grpc/scheduler.rs
+++ b/dragonfly-client/src/grpc/scheduler.rs
@@ -84,7 +84,7 @@ pub struct SchedulerClient {
 
 /// SchedulerClient implements the grpc client of the scheduler.
 impl SchedulerClient {
-    /// new creates a new SchedulerClient.
+    /// Creates a new SchedulerClient.
     pub async fn new(config: Arc<Config>, dynconfig: Arc<Dynconfig>) -> Result<Self> {
         let client = Self {
             config,
@@ -114,7 +114,7 @@ impl SchedulerClient {
         Ok(response)
     }
 
-    /// stat_peer gets the status of the peer.
+    /// Gets the status of the peer.
     #[instrument(skip(self))]
     pub async fn stat_peer(&self, request: StatPeerRequest) -> Result<Peer> {
         let task_id = request.task_id.clone();
@@ -139,7 +139,7 @@ impl SchedulerClient {
         Ok(())
     }
 
-    /// stat_task gets the status of the task.
+    /// Gets the status of the task.
     #[instrument(skip(self))]
     pub async fn stat_task(&self, request: StatTaskRequest) -> Result<Task> {
         let task_id = request.task_id.clone();
@@ -351,7 +351,7 @@ impl SchedulerClient {
         Ok(response)
     }
 
-    /// stat_persistent_peer gets the status of the persistent peer.
+    /// Gets the status of the persistent peer.
     #[instrument(skip(self))]
     pub async fn stat_persistent_peer(
         &self,
@@ -425,7 +425,7 @@ impl SchedulerClient {
         Ok(())
     }
 
-    /// stat_persistent_task gets the status of the persistent task.
+    /// Gets the status of the persistent task.
     #[instrument(skip(self))]
     pub async fn stat_persistent_task(
         &self,
@@ -648,7 +648,7 @@ impl SchedulerClient {
         )
     }
 
-    /// update_available_scheduler_addrs updates the addresses of available schedulers.
+    /// Updates the addresses of available schedulers.
     #[instrument(skip(self))]
     async fn update_available_scheduler_addrs(&self) -> Result<()> {
         // Get the endpoints of available schedulers.

--- a/dragonfly-client/src/health/mod.rs
+++ b/dragonfly-client/src/health/mod.rs
@@ -35,7 +35,7 @@ pub struct Health {
 
 /// Health implements the health server.
 impl Health {
-    /// new creates a new Health.
+    /// Creates a new Health.
     pub fn new(
         addr: SocketAddr,
         shutdown: shutdown::Shutdown,

--- a/dragonfly-client/src/proxy/header.rs
+++ b/dragonfly-client/src/proxy/header.rs
@@ -147,7 +147,7 @@ impl FromStr for ErrorType {
     }
 }
 
-/// get_tag gets the tag from http header.
+/// Gets the tag from http header.
 pub fn get_tag(header: &HeaderMap) -> Option<String> {
     header
         .get(DRAGONFLY_TAG_HEADER)
@@ -155,7 +155,7 @@ pub fn get_tag(header: &HeaderMap) -> Option<String> {
         .map(|tag| tag.to_string())
 }
 
-/// get_application gets the application from http header.
+/// Gets the application from http header.
 pub fn get_application(header: &HeaderMap) -> Option<String> {
     header
         .get(DRAGONFLY_APPLICATION_HEADER)
@@ -163,7 +163,7 @@ pub fn get_application(header: &HeaderMap) -> Option<String> {
         .map(|application| application.to_string())
 }
 
-/// get_priority gets the priority from http header.
+/// Gets the priority from http header.
 pub fn get_priority(header: &HeaderMap) -> i32 {
     let default_priority = Priority::Level6 as i32;
     match header.get(DRAGONFLY_PRIORITY_HEADER) {
@@ -184,7 +184,7 @@ pub fn get_priority(header: &HeaderMap) -> i32 {
     }
 }
 
-/// get_registry gets the custom address of container registry from http header.
+/// Gets the custom address of container registry from http header.
 pub fn get_registry(header: &HeaderMap) -> Option<String> {
     header
         .get(DRAGONFLY_REGISTRY_HEADER)
@@ -192,7 +192,7 @@ pub fn get_registry(header: &HeaderMap) -> Option<String> {
         .map(|registry| registry.to_string())
 }
 
-/// get_filters gets the filters from http header.
+/// Gets the filters from http header.
 pub fn get_filtered_query_params(
     header: &HeaderMap,
     default_filtered_query_params: Vec<String>,
@@ -209,7 +209,7 @@ pub fn get_filtered_query_params(
     }
 }
 
-/// get_use_p2p gets the use p2p from http header.
+/// Gets the use p2p from http header.
 pub fn get_use_p2p(header: &HeaderMap) -> bool {
     match header.get(DRAGONFLY_USE_P2P_HEADER) {
         Some(value) => match value.to_str() {
@@ -223,7 +223,7 @@ pub fn get_use_p2p(header: &HeaderMap) -> bool {
     }
 }
 
-/// get_prefetch gets the prefetch from http header.
+/// Gets the prefetch from http header.
 pub fn get_prefetch(header: &HeaderMap) -> Option<bool> {
     match header.get(DRAGONFLY_PREFETCH_HEADER) {
         Some(value) => match value.to_str() {
@@ -237,7 +237,7 @@ pub fn get_prefetch(header: &HeaderMap) -> Option<bool> {
     }
 }
 
-/// get_output_path gets the output path from http header.
+/// Gets the output path from http header.
 pub fn get_output_path(header: &HeaderMap) -> Option<String> {
     header
         .get(DRAGONFLY_OUTPUT_PATH_HEADER)
@@ -245,7 +245,7 @@ pub fn get_output_path(header: &HeaderMap) -> Option<String> {
         .map(|output_path| output_path.to_string())
 }
 
-/// get_force_hard_link gets the force hard link from http header.
+/// Gets the force hard link from http header.
 pub fn get_force_hard_link(header: &HeaderMap) -> bool {
     match header.get(DRAGONFLY_FORCE_HARD_LINK_HEADER) {
         Some(value) => match value.to_str() {
@@ -259,7 +259,7 @@ pub fn get_force_hard_link(header: &HeaderMap) -> bool {
     }
 }
 
-/// get_piece_length gets the piece length from http header.
+/// Gets the piece length from http header.
 pub fn get_piece_length(header: &HeaderMap) -> Option<ByteSize> {
     match header.get(DRAGONFLY_PIECE_LENGTH_HEADER) {
         Some(piece_length) => match piece_length.to_str() {
@@ -279,7 +279,7 @@ pub fn get_piece_length(header: &HeaderMap) -> Option<ByteSize> {
     }
 }
 
-/// get_content_for_calculating_task_id gets the content for calculating task id from http header.
+/// Gets the content for calculating task id from http header.
 pub fn get_content_for_calculating_task_id(header: &HeaderMap) -> Option<String> {
     header
         .get(DRAGONFLY_CONTENT_FOR_CALCULATING_TASK_ID_HEADER)

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -98,7 +98,7 @@ pub struct Proxy {
 
 /// Proxy implements the proxy server.
 impl Proxy {
-    /// new creates a new Proxy.
+    /// Creates a new Proxy.
     pub fn new(
         config: Arc<Config>,
         task: Arc<Task>,
@@ -1184,8 +1184,7 @@ fn make_download_task_request(
     })
 }
 
-/// need_prefetch returns whether the prefetch is needed by the configuration and the request
-/// header.
+/// Returns whether the prefetch is needed by the configuration and the request header.
 fn need_prefetch(config: Arc<Config>, header: &http::HeaderMap) -> bool {
     // If the header not contains the range header, the request does not need prefetch.
     if !header.contains_key(reqwest::header::RANGE) {
@@ -1307,7 +1306,7 @@ fn make_error_response(
     response
 }
 
-/// empty returns an empty body.
+/// Returns an empty body.
 fn empty() -> BoxBody<Bytes, ClientError> {
     Empty::<Bytes>::new()
         .map_err(|never| match never {})

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -88,7 +88,7 @@ pub struct PersistentCacheTask {
 
 /// PersistentCacheTask is the implementation of PersistentCacheTask.
 impl PersistentCacheTask {
-    /// new creates a new PersistentCacheTask.
+    /// Creates a new PersistentCacheTask.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
@@ -124,13 +124,13 @@ impl PersistentCacheTask {
         })
     }
 
-    /// get gets a persistent cache task from local.
+    /// Gets a persistent cache task from local.
     #[instrument(skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentCacheTask>> {
         self.storage.get_persistent_cache_task(task_id)
     }
 
-    /// upload creates a persistent cache task from local.
+    /// Creates a persistent cache task from local.
     #[instrument(skip_all)]
     pub async fn upload(
         &self,
@@ -527,7 +527,7 @@ impl PersistentCacheTask {
         Ok(())
     }
 
-    /// download_started updates the metadata of the persistent cache task when the persistent cache task downloads started.
+    /// Updates the metadata of the persistent cache task when the persistent cache task downloads started.
     #[instrument(skip_all)]
     pub async fn download_started(
         &self,
@@ -615,13 +615,13 @@ impl PersistentCacheTask {
         Ok(task)
     }
 
-    /// download_finished updates the metadata of the persistent cache task when the task downloads finished.
+    /// Updates the metadata of the persistent cache task when the task downloads finished.
     #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentCacheTask> {
         self.storage.download_persistent_cache_task_finished(id)
     }
 
-    /// download_failed updates the metadata of the persistent cache task when the task downloads failed.
+    /// Updates the metadata of the persistent cache task when the task downloads failed.
     #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self
@@ -631,7 +631,7 @@ impl PersistentCacheTask {
         Ok(())
     }
 
-    /// is_same_dev_inode checks if the persistent cache task is on the same device inode as the given path.
+    /// Checks if the persistent cache task is on the same device inode as the given path.
     pub async fn is_same_dev_inode(&self, id: &str, to: &Path) -> ClientResult<bool> {
         self.storage
             .is_same_dev_inode_as_persistent_cache_task(id, to)

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -101,7 +101,7 @@ pub struct PersistentTask {
 
 /// PersistentTask is the implementation of PersistentTask.
 impl PersistentTask {
-    /// new creates a new PersistentTask.
+    /// Creates a new PersistentTask.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
@@ -138,13 +138,13 @@ impl PersistentTask {
         })
     }
 
-    /// get gets a persistent task from local.
+    /// Gets a persistent task from local.
     #[instrument(skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentTask>> {
         self.storage.get_persistent_task(task_id)
     }
 
-    /// upload creates a persistent task from local.
+    /// Creates a persistent task from local.
     #[instrument(skip_all)]
     pub async fn upload(
         &self,
@@ -623,7 +623,7 @@ impl PersistentTask {
         Ok(())
     }
 
-    /// download_started updates the metadata of the persistent task when the persistent task downloads started.
+    /// Updates the metadata of the persistent task when the persistent task downloads started.
     #[instrument(skip_all)]
     pub async fn download_started(
         &self,
@@ -804,20 +804,20 @@ impl PersistentTask {
         Ok(task)
     }
 
-    /// download_finished updates the metadata of the persistent task when the task downloads finished.
+    /// Updates the metadata of the persistent task when the task downloads finished.
     #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentTask> {
         self.storage.download_persistent_task_finished(id)
     }
 
-    /// download_failed updates the metadata of the persistent task when the task downloads failed.
+    /// Updates the metadata of the persistent task when the task downloads failed.
     #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self.storage.download_persistent_task_failed(id).await?;
         Ok(())
     }
 
-    /// is_same_dev_inode checks if the persistent task is on the same device inode as the given path.
+    /// Checks if the persistent task is on the same device inode as the given path.
     pub async fn is_same_dev_inode(&self, id: &str, to: &Path) -> ClientResult<bool> {
         self.storage
             .is_same_dev_inode_as_persistent_task(id, to)

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -84,7 +84,7 @@ pub struct Piece {
 
 /// Piece implements the piece manager.
 impl Piece {
-    /// new returns a new Piece.
+    /// Creates a new Piece.
     pub fn new(
         config: Arc<Config>,
         storage: Arc<Storage>,
@@ -112,7 +112,7 @@ impl Piece {
         self.storage.piece_id(task_id, number)
     }
 
-    /// get gets a piece from the local storage.
+    /// Gets a piece from the local storage.
     pub fn get(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_piece(piece_id)
     }
@@ -646,13 +646,13 @@ impl Piece {
         self.storage.persistent_piece_id(task_id, number)
     }
 
-    /// get_persistent gets a persistent piece from the local storage.
+    /// Gets a persistent piece from the local storage.
     #[instrument(skip_all)]
     pub fn get_persistent(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_piece(piece_id)
     }
 
-    /// create_persistent creates a new persistent piece.
+    /// Creates a new persistent piece.
     #[instrument(skip_all)]
     pub async fn create_persistent<R: AsyncRead + Unpin + ?Sized>(
         &self,
@@ -981,13 +981,13 @@ impl Piece {
         self.storage.persistent_cache_piece_id(task_id, number)
     }
 
-    /// get_persistent_cache gets a persistent cache piece from the local storage.
+    /// Gets a persistent cache piece from the local storage.
     #[instrument(skip_all)]
     pub fn get_persistent_cache(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_cache_piece(piece_id)
     }
 
-    /// create_persistent_cache creates a new persistent cache piece.
+    /// Creates a new persistent cache piece.
     #[instrument(skip_all)]
     pub async fn create_persistent_cache<R: AsyncRead + Unpin + ?Sized>(
         &self,

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -72,7 +72,7 @@ pub struct DownloaderFactory {
 
 /// DownloadFactory implements the DownloadFactory trait.
 impl DownloaderFactory {
-    /// new returns a new DownloadFactory.
+    /// Creates a new DownloadFactory.
     pub fn new(protocol: &str, config: Arc<Config>) -> Result<Self> {
         let downloader: Arc<dyn Downloader> = match protocol {
             "tcp" => Arc::new(TCPDownloader::new(
@@ -94,7 +94,7 @@ impl DownloaderFactory {
         Ok(Self { downloader })
     }
 
-    /// build returns the downloader.
+    /// Returns the downloader.
     pub fn build(&self) -> Arc<dyn Downloader> {
         self.downloader.clone()
     }
@@ -129,7 +129,7 @@ impl QUICDownloader {
     /// MAX_CONNECTIONS_PER_ADDRESS is the maximum number of connections per address.
     const MAX_CONNECTIONS_PER_ADDRESS: usize = 32;
 
-    /// new returns a new QUICDownloader.
+    /// Creates a new QUICDownloader.
     pub fn new(config: Arc<Config>, capacity: usize, idle_timeout: Duration) -> Self {
         Self {
             client_pool: PoolBuilder::new(QUICClientFactory {
@@ -280,7 +280,7 @@ impl TCPDownloader {
     /// MAX_CONNECTIONS_PER_ADDRESS is the maximum number of connections per address.
     const MAX_CONNECTIONS_PER_ADDRESS: usize = 32;
 
-    /// new returns a new TCPDownloader.
+    /// Creates a new TCPDownloader.
     pub fn new(config: Arc<Config>, capacity: usize, idle_timeout: Duration) -> Self {
         Self {
             client_pool: PoolBuilder::new(TCPClientFactory {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -95,7 +95,7 @@ pub struct Task {
 
 /// Task implements the task manager.
 impl Task {
-    /// new returns a new Task.
+    /// Creates a new Task.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
@@ -132,13 +132,13 @@ impl Task {
         })
     }
 
-    /// get gets the metadata of the task.
+    /// Gets the metadata of the task.
     #[instrument(skip_all)]
     pub fn get(&self, id: &str) -> ClientResult<Option<metadata::Task>> {
         self.storage.get_task(id)
     }
 
-    /// download_started updates the metadata of the task when the task downloads started.
+    /// Updates the metadata of the task when the task downloads started.
     #[instrument(skip_all)]
     pub async fn download_started(
         &self,
@@ -289,31 +289,31 @@ impl Task {
         task
     }
 
-    /// download_finished updates the metadata of the task when the task downloads finished.
+    /// Updates the metadata of the task when the task downloads finished.
     #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.download_task_finished(id)
     }
 
-    /// download_failed updates the metadata of the task when the task downloads failed.
+    /// Updates the metadata of the task when the task downloads failed.
     #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         self.storage.download_task_failed(id).await.map(|_| ())
     }
 
-    /// prefetch_task_started updates the metadata of the task when the task prefetch started.
+    /// Updates the metadata of the task when the task prefetch started.
     #[instrument(skip_all)]
     pub async fn prefetch_task_started(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_started(id).await
     }
 
-    /// prefetch_task_failed updates the metadata of the task when the task prefetch failed.
+    /// Updates the metadata of the task when the task prefetch failed.
     #[instrument(skip_all)]
     pub async fn prefetch_task_failed(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_failed(id).await
     }
 
-    /// is_same_dev_inode checks if the task is on the same device inode as the given path.
+    /// Checks if the task is on the same device inode as the given path.
     pub async fn is_same_dev_inode(&self, id: &str, to: &Path) -> ClientResult<bool> {
         self.storage.is_same_dev_inode_as_task(id, to).await
     }
@@ -1895,7 +1895,7 @@ impl Task {
         return Ok(finished_pieces);
     }
 
-    /// stat_task returns the task metadata from scheduler.
+    /// Gets the task metadata from scheduler.
     #[instrument(skip_all)]
     pub async fn stat(&self, task_id: &str, host_id: &str) -> ClientResult<CommonTask> {
         self.scheduler_client
@@ -1909,7 +1909,7 @@ impl Task {
             })
     }
 
-    /// stat_local returns the task metadata from local storage.
+    /// Gets the task metadata from local storage.
     #[instrument(skip_all)]
     pub async fn stat_local(&self, task_id: &str) -> ClientResult<StatLocalTaskResponse> {
         let Some(task_metadata) = self.storage.get_task(task_id).inspect_err(|err| {

--- a/dragonfly-client/src/stats/mod.rs
+++ b/dragonfly-client/src/stats/mod.rs
@@ -66,7 +66,7 @@ pub struct Stats {
 
 /// Stats implements the stats server.
 impl Stats {
-    /// new creates a new Stats.
+    /// Creates a new Stats.
     pub fn new(
         addr: SocketAddr,
         shutdown: shutdown::Shutdown,


### PR DESCRIPTION
Replace function-name-based comments with direct verb-based descriptions:
- 'new returns a new' -> 'Creates a new'
- 'xxx returns' -> 'Returns'
- 'xxx gets' -> 'Gets'
- 'xxx checks' -> 'Checks'
- 'xxx loads' -> 'Loads'
- 'default_xxx is' -> 'Returns'

This improves documentation consistency across the codebase by following standard Rust documentation conventions.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
