### PR TITLE
ci(release): configure architecture-specific runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,19 @@ jobs:
   build:
     runs-on:
       group: Default
-      labels: [oracle-vm-32cpu-128gb-x86-64]
+      labels: ${{ matrix.runner }}
     timeout-minutes: 480
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
+        include:
+          - runner: [oracle-vm-24cpu-96gb-x86-64]
+            target: x86_64-unknown-linux-gnu
+          - runner: [oracle-vm-24cpu-96gb-x86-64]
+            target: x86_64-unknown-linux-musl
+          - runner: [oracle-vm-32cpu-128gb-arm64]
+            target: aarch64-unknown-linux-gnu
+          - runner: [oracle-vm-32cpu-128gb-arm64]
+            target: aarch64-unknown-linux-musl
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -137,7 +141,9 @@ jobs:
           draft: true
 
   publish-crates:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
+      labels: [oracle-vm-24cpu-96gb-x86-64]
     timeout-minutes: 360
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/release.yml` to improve build runner selection and consistency across jobs. The main changes involve specifying custom runner labels for different build targets and aligning the runner used for the `publish-crates` job.

**Build runner configuration improvements:**

* The `build` job now selects runners dynamically based on the target architecture by using a matrix that pairs each target with a specific runner label, ensuring builds run on the appropriate hardware.
* The `publish-crates` job is updated to use a specific self-hosted runner group and label (`oracle-vm-24cpu-96gb-x86-64`) instead of the generic `ubuntu-latest`, providing more control and consistency in the release process.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
