### PR TITLE
fix(config): use runtime env vars instead of compile-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.2"
+version = "1.2.3"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.2.2" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.2" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.2" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.2" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.2" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.2" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.2" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.2" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.3" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.3" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.3" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.3" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.3" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.3" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.3" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.3" }
 dragonfly-api = "=2.2.11"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -16,6 +16,7 @@
 
 use clap::{Arg, Command};
 use lazy_static::lazy_static;
+use std::env;
 use std::path::PathBuf;
 
 pub mod dfcache;
@@ -62,8 +63,8 @@ lazy_static! {
     /// INSTANCE_NAME is the name of the instance, formatted as {POD_NAMESPACE}-{POD_NAME}.
     pub static ref INSTANCE_NAME: String = {
         if let (Some(pod_namespace), Some(pod_name)) = (
-            option_env!("POD_NAMESPACE"),
-            option_env!("POD_NAME")
+            env::var("POD_NAMESPACE").ok(),
+            env::var("POD_NAME").ok()
         ) {
             format!("{}-{}", pod_namespace, pod_name)
         } else {

--- a/dragonfly-client-util/src/hashring/mod.rs
+++ b/dragonfly-client-util/src/hashring/mod.rs
@@ -210,4 +210,39 @@ mod tests {
                 && (vnode.id == 0 || vnode.id == 1)
         }));
     }
+
+    #[test]
+    fn test_add_order_does_not_affect_get_result_many_keys() {
+        use uuid::Uuid;
+
+        let nodes_a = vec![
+            "default-pod-1".to_string(),
+            "default-pod-2".to_string(),
+            "default-pod-3".to_string(),
+        ];
+        let nodes_b = vec![
+            "default-pod-3".to_string(),
+            "default-pod-1".to_string(),
+            "default-pod-2".to_string(),
+        ];
+
+        let mut ring_a = VNodeHashRing::new(150);
+        for n in nodes_a {
+            ring_a.add(n);
+        }
+
+        let mut ring_b = VNodeHashRing::new(150);
+        for n in nodes_b {
+            ring_b.add(n);
+        }
+
+        for _ in 0..200 {
+            let key = Uuid::new_v4().to_string();
+
+            let va = ring_a.get(&key).unwrap();
+            let vb = ring_b.get(&key).unwrap();
+
+            assert_eq!(va.to_string(), vb.to_string(), "key={}", key);
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a behavioral change to how environment variables are accessed in the client configuration and adds a new unit test to the hashring utility to verify consistent behavior regardless of node addition order. The most significant changes are grouped below.

Environment variable handling:

* Updated `INSTANCE_NAME` initialization in `dragonfly-client-config/src/lib.rs` to use `env::var` instead of `option_env!`, ensuring that environment variables `POD_NAMESPACE` and `POD_NAME` are read at runtime rather than compile time.
* Added `std::env` import to support the new way of reading environment variables.

Testing and reliability:

* Added a new test `test_add_order_does_not_affect_get_result_many_keys` in `dragonfly-client-util/src/hashring/mod.rs` to confirm that the order in which nodes are added to the `VNodeHashRing` does not affect which node is returned for a given key, improving confidence in the consistency of the hashring implementation.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
