### PR TITLE
feat: rename enableIpv6 to enableIPv6 in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.4"
+version = "1.2.5"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.2.4" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.4" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.4" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.4" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.4" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.4" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.4" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.4" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.5" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.5" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.5" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.5" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.5" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.5" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.5" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.5" }
 dragonfly-api = "=2.2.11"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -1312,6 +1312,7 @@ pub struct Security {
 #[serde(default, rename_all = "camelCase")]
 pub struct Network {
     /// enable_ipv6 indicates whether enable ipv6.
+    #[serde(rename = "enableIPv6")]
     pub enable_ipv6: bool,
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the versioning for the workspace and its dependencies, and improves configuration serialization for the network settings. The most important changes are grouped below:

Version updates:

* Bumped the workspace version in `Cargo.toml` from `1.2.4` to `1.2.5`, ensuring all workspace packages reference the new version.
* Updated all internal workspace dependencies in `Cargo.toml` to use version `1.2.5` instead of `1.2.4` for consistency across the project.

Configuration improvements:

* Added an explicit `#[serde(rename = "enableIPv6")]` attribute to the `enable_ipv6` field in the `Network` struct in `dragonfly-client-config/src/dfdaemon.rs`, improving serialization and deserialization compatibility.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
