### PR TITLE
feat: switch HTTP client to HTTP/1.1 and improve stat request handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.5"
+version = "1.2.6"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.2.5" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.5" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.5" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.5" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.5" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.5" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.5" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.5" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.6" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.6" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.6" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.6" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.6" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.6" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.6" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.6" }
 dragonfly-api = "=2.2.11"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -54,9 +54,6 @@ const HTTP2_STREAM_WINDOW_SIZE: u32 = 16 * 1024 * 1024;
 /// HTTP2_CONNECTION_WINDOW_SIZE is the connection window size for HTTP2 connection.
 const HTTP2_CONNECTION_WINDOW_SIZE: u32 = 16 * 1024 * 1024;
 
-/// HTTP2_MAX_FRAME_SIZE is the max frame size for HTTP2 connection.
-const HTTP2_MAX_FRAME_SIZE: u32 = 16 * 1024 * 1024;
-
 /// MAX_RETRY_TIMES is the max retry times for the request.
 const MAX_RETRY_TIMES: u32 = 1;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the response has Transfer-Encoding header but no Content-Length header, retry with HEAD request to get the correct Content-Length.

This pull request updates the Dragonfly client to version 1.2.6 and introduces several important changes to the HTTP backend to improve HTTP handling, especially regarding protocol usage and response header processing. The most significant changes involve enforcing HTTP/1 usage, improving handling of `Transfer-Encoding` and `Content-Length` headers, and refining redirect logic.

**Dependency and Version Updates:**
- Bumped the workspace and all internal crate versions from `1.2.5` to `1.2.6` in `Cargo.toml` to ensure consistency across the project. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)

**HTTP Protocol Handling Improvements:**
- Enforced the use of HTTP/1 only by adding `.http1_only()` and removing all HTTP/2-specific configuration from the HTTP client builder in `dragonfly-client-backend/src/http.rs`. This reduces complexity and potential protocol-related issues. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR126-L135) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR202-L214)
- Removed the unused `HTTP2_MAX_FRAME_SIZE` constant from `dragonfly-client-backend/src/lib.rs`.

**HTTP Response and Header Handling:**
- Improved handling of responses that use `Transfer-Encoding` without a `Content-Length` header: now, a HEAD request is retried to attempt to obtain the correct content length. This ensures more robust and accurate file size detection. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL25-R27) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL436-R427)
- Refined redirect handling logic: improved processing of `307 Temporary Redirect` responses by checking for the `LOCATION` header and updating the target URL accordingly. Error handling was clarified for cases where the `LOCATION` header is missing. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL360-R365) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL404-R391) [[3]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL542-R531)

These changes collectively improve the reliability and correctness of HTTP operations in the Dragonfly client, especially in edge cases involving redirects and chunked transfers.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4573
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
