### PR TITLE
fix: use Content-Length header value with fallback to parsed value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "dashmap",
  "dragonfly-api",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "dragonfly-client-backend",
  "dragonfly-client-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.6"
+version = "1.2.7"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -23,14 +23,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.2.6" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.6" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.6" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.6" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.6" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.6" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.6" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.6" }
+dragonfly-client = { path = "dragonfly-client", version = "1.2.7" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.2.7" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.2.7" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.2.7" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.2.7" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.2.7" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.2.7" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.2.7" }
 dragonfly-api = "=2.2.11"
 thiserror = "2.0"
 futures = "0.3.31"

--- a/dragonfly-client-core/src/error/mod.rs
+++ b/dragonfly-client-core/src/error/mod.rs
@@ -210,6 +210,10 @@ pub enum DFError {
     #[error(transparent)]
     HTTTHeaderInvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
 
+    // HTTTHeaderToStrError is the error for header to str.
+    #[error(transparent)]
+    HTTTHeaderToStrError(#[from] http::header::ToStrError),
+
     /// URLParseError is the error for url parse.
     #[error(transparent)]
     URLParseError(#[from] url::ParseError),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request primarily updates the workspace version and dependency versions in `Cargo.toml` to 1.2.7, and improves HTTP response header handling in the backend. Additionally, it introduces a new error variant for HTTP header string conversion errors.

Version and Dependency Updates:

* Bumped workspace version to `1.2.7` in `Cargo.toml`, and updated all internal `dragonfly-client-*` dependencies to version `1.2.7` for consistency across the project. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R33)

HTTP Backend Improvements:

* In `dragonfly-client-backend/src/http.rs`, improved content length extraction by first checking the `CONTENT_LENGTH` header and falling back to the response's content length if not present, increasing robustness for HTTP responses.

Error Handling Enhancements:

* Added a new error variant `HTTTHeaderToStrError` to the `DFError` enum in `dragonfly-client-core/src/error/mod.rs`, allowing for better handling of header-to-string conversion errors.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4573
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
