### PR TITLE
fix(proxy): only route GET to dfdaemon, bypass other methods

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -393,6 +393,7 @@ pub async fn http_handler(
                 "proxy HTTP request via dfdaemon by rule config: {:?}",
                 request
             );
+
             return proxy_via_dfdaemon(
                 config,
                 task,
@@ -403,7 +404,8 @@ pub async fn http_handler(
             )
             .await;
         }
-        info!(
+
+        debug!(
             "proxy HTTP request bypassing dfdaemon for non-GET method: {:?}",
             request
         );
@@ -416,15 +418,23 @@ pub async fn http_handler(
             "proxy HTTP request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
             request
         );
-        return proxy_via_dfdaemon(
-            config,
-            task,
-            &Rule::default(),
-            request,
-            remote_ip,
-            dfdaemon_download_client,
-        )
-        .await;
+
+        if request.method() == Method::GET {
+            return proxy_via_dfdaemon(
+                config,
+                task,
+                &Rule::default(),
+                request,
+                remote_ip,
+                dfdaemon_download_client,
+            )
+            .await;
+        }
+
+        debug!(
+            "proxy HTTP request bypassing dfdaemon for non-GET method: {:?}",
+            request
+        );
     }
 
     if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
@@ -432,6 +442,7 @@ pub async fn http_handler(
             "proxy HTTPS request directly to remote server: {:?}",
             request
         );
+
         return proxy_via_https(request, registry_cert).await;
     }
 
@@ -439,6 +450,7 @@ pub async fn http_handler(
         "proxy HTTP request directly to remote server: {:?}",
         request
     );
+
     return proxy_via_http(request).await;
 }
 
@@ -637,6 +649,7 @@ pub async fn upgraded_handler(
                 "proxy HTTPS request via dfdaemon by rule config: {:?}",
                 request,
             );
+
             return proxy_via_dfdaemon(
                 config,
                 task,
@@ -647,7 +660,8 @@ pub async fn upgraded_handler(
             )
             .await;
         }
-        info!(
+
+        debug!(
             "proxy HTTPS request bypassing dfdaemon for non-GET method: {:?}",
             request,
         );
@@ -656,19 +670,27 @@ pub async fn upgraded_handler(
     // If the request header contains the X-Dragonfly-Use-P2P header, proxy the request via the
     // dfdaemon.
     if header::get_use_p2p(request.headers()) {
-        info!(
-            "proxy HTTP request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
+        if request.method() == Method::GET {
+            info!(
+                "proxy HTTP request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
+                request,
+            );
+
+            return proxy_via_dfdaemon(
+                config,
+                task,
+                &Rule::default(),
+                request,
+                remote_ip,
+                dfdaemon_download_client,
+            )
+            .await;
+        }
+
+        debug!(
+            "proxy HTTPS request bypassing dfdaemon for non-GET method: {:?}",
             request,
         );
-        return proxy_via_dfdaemon(
-            config,
-            task,
-            &Rule::default(),
-            request,
-            remote_ip,
-            dfdaemon_download_client,
-        )
-        .await;
     }
 
     if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
@@ -676,6 +698,7 @@ pub async fn upgraded_handler(
             "proxy HTTPS request directly to remote server: {:?}",
             request,
         );
+
         return proxy_via_https(request, registry_cert).await;
     }
 
@@ -683,6 +706,7 @@ pub async fn upgraded_handler(
         "proxy HTTP request directly to remote server: {:?}",
         request,
     );
+
     return proxy_via_http(request).await;
 }
 

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -381,24 +381,32 @@ pub async fn http_handler(
     }
 
     // If find the matching rule, proxy the request via the dfdaemon.
+    // Only GET/HEAD requests are routed to P2P; other methods (PUT/POST/DELETE)
+    // fall through to direct proxy to avoid data loss.
     let request_uri = request.uri();
     if let Some(rule) = find_matching_rule(
         config.proxy.rules.as_deref(),
         url::Url::parse(&request_uri.to_string()).or_err(ErrorType::ParseError)?,
     ) {
+        if request.method() == Method::GET {
+            info!(
+                "proxy HTTP request via dfdaemon by rule config: {:?}",
+                request
+            );
+            return proxy_via_dfdaemon(
+                config,
+                task,
+                &rule,
+                request,
+                remote_ip,
+                dfdaemon_download_client,
+            )
+            .await;
+        }
         info!(
-            "proxy HTTP request via dfdaemon by rule config: {:?}",
+            "proxy HTTP request bypassing dfdaemon for non-GET/HEAD method: {:?}",
             request
         );
-        return proxy_via_dfdaemon(
-            config,
-            task,
-            &rule,
-            request,
-            remote_ip,
-            dfdaemon_download_client,
-        )
-        .await;
     }
 
     // If the request header contains the X-Dragonfly-Use-P2P header, proxy the request via the
@@ -617,24 +625,32 @@ pub async fn upgraded_handler(
     }
 
     // If find the matching rule, proxy the request via the dfdaemon.
+    // Only GET/HEAD requests are routed to P2P; other methods (PUT/POST/DELETE)
+    // fall through to direct proxy to avoid data loss.
     let request_uri = request.uri();
     if let Some(rule) = find_matching_rule(
         config.proxy.rules.as_deref(),
         url::Url::parse(&request_uri.to_string()).or_err(ErrorType::ParseError)?,
     ) {
+        if request.method() == Method::GET {
+            info!(
+                "proxy HTTPS request via dfdaemon by rule config: {:?}",
+                request,
+            );
+            return proxy_via_dfdaemon(
+                config,
+                task,
+                &rule,
+                request,
+                remote_ip,
+                dfdaemon_download_client,
+            )
+            .await;
+        }
         info!(
-            "proxy HTTPS request via dfdaemon by rule config: {:?}",
+            "proxy HTTPS request bypassing dfdaemon for non-GET/HEAD method: {:?}",
             request,
         );
-        return proxy_via_dfdaemon(
-            config,
-            task,
-            &rule,
-            request,
-            remote_ip,
-            dfdaemon_download_client,
-        )
-        .await;
     }
 
     // If the request header contains the X-Dragonfly-Use-P2P header, proxy the request via the

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -381,7 +381,7 @@ pub async fn http_handler(
     }
 
     // If find the matching rule, proxy the request via the dfdaemon.
-    // Only GET/HEAD requests are routed to P2P; other methods (PUT/POST/DELETE)
+    // Only GET requests are routed to P2P; other methods (HEAD/PUT/POST/DELETE)
     // fall through to direct proxy to avoid data loss.
     let request_uri = request.uri();
     if let Some(rule) = find_matching_rule(
@@ -404,7 +404,7 @@ pub async fn http_handler(
             .await;
         }
         info!(
-            "proxy HTTP request bypassing dfdaemon for non-GET/HEAD method: {:?}",
+            "proxy HTTP request bypassing dfdaemon for non-GET method: {:?}",
             request
         );
     }
@@ -625,7 +625,7 @@ pub async fn upgraded_handler(
     }
 
     // If find the matching rule, proxy the request via the dfdaemon.
-    // Only GET/HEAD requests are routed to P2P; other methods (PUT/POST/DELETE)
+    // Only GET requests are routed to P2P; other methods (HEAD/PUT/POST/DELETE)
     // fall through to direct proxy to avoid data loss.
     let request_uri = request.uri();
     if let Some(rule) = find_matching_rule(
@@ -648,7 +648,7 @@ pub async fn upgraded_handler(
             .await;
         }
         info!(
-            "proxy HTTPS request bypassing dfdaemon for non-GET/HEAD method: {:?}",
+            "proxy HTTPS request bypassing dfdaemon for non-GET method: {:?}",
             request,
         );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only route GET requests to `proxy_via_dfdaemon()`. Other methods fall through to direct proxy.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/dragonflyoss/client/issues/1772

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
