### PR TITLE
feat(proxy): Introduce an S3-aware proxy mode in dfdaemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ Dragonfly client written in Rust. It can serve as both a peer and a seed peer.
 
 You can find the full documentation on the [d7y.io](https://d7y.io).
 
+## S3-Aware Proxy Mode
+
+`dfdaemon` can run as an HTTPS proxy for authenticated S3 reads so existing AWS SDK and CLI
+clients can use Dragonfly with `HTTPS_PROXY` plus a trusted proxy CA, without changing
+application code.
+
+V1 behavior:
+
+- `GetObject` uses Dragonfly P2P.
+- Ranged `GetObject` uses Dragonfly P2P. If the caller's SigV4 signature explicitly covers the
+  `Range` header, `dfdaemon` preserves that original signed `Range` on the source request instead
+  of rewriting it.
+- `HeadObject` and `ListObjectsV2` stay direct passthrough.
+- Other S3 APIs stay passthrough and are not accelerated.
+- The proxy preserves caller-provided SigV4 headers or presigned URLs. `dfdaemon` does not
+  discover AWS credentials or re-sign origin requests.
+
+Example client environment:
+
+```shell
+export HTTPS_PROXY=http://127.0.0.1:4001
+export HTTP_PROXY=http://127.0.0.1:4001
+export AWS_CA_BUNDLE=/etc/ssl/certs/dragonfly-proxy-ca.pem
+```
+
+See the sample `dfdaemon` service in [`ci/dfdaemon.service`](./ci/dfdaemon.service) and the
+docker-compose client config template in the
+[dragonfly repository](https://github.com/dragonflyoss/dragonfly/blob/main/deploy/docker-compose/template/client.template.yaml).
+
 ## Community
 
 Join the conversation and help the community grow. Here are the ways to get involved:

--- a/ci/dfdaemon.service
+++ b/ci/dfdaemon.service
@@ -5,6 +5,10 @@ After=network-online.target
 After=network.target
 
 [Service]
+# Configure /etc/dragonfly/dfdaemon.yaml with proxy.s3.enable=true to turn on S3-aware proxy mode.
+# Applications using the proxy should set HTTPS_PROXY and trust the proxy CA via the system store
+# or AWS_CA_BUNDLE. Dfdaemon preserves caller-provided SigV4 headers or presigned URLs and does not
+# source AWS credentials on the caller's behalf.
 ExecStart=/usr/bin/dfdaemon --config /etc/dragonfly/dfdaemon.yaml --console
 
 Type=simple

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -59,7 +59,8 @@ use dragonfly_client_core::{
 use dragonfly_client_util::tls::NoVerifier;
 use futures::TryStreamExt;
 use http::header::{
-    HeaderName, HeaderValue, CONTENT_LENGTH, LOCATION, RANGE, TRANSFER_ENCODING, USER_AGENT,
+    HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_RANGE, LOCATION, RANGE, TRANSFER_ENCODING,
+    USER_AGENT,
 };
 use lru::LruCache;
 use reqwest::header::HeaderMap;
@@ -544,9 +545,19 @@ impl Backend for HTTP {
 
         let response_status_code = response.status();
         let response_header = response.headers().clone();
-        let content_length = match response_header.get(CONTENT_LENGTH) {
-            Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
-            None => response.content_length(),
+        let content_length = if response_status_code == reqwest::StatusCode::PARTIAL_CONTENT {
+            response_header
+                .get(CONTENT_RANGE)
+                .and_then(parse_content_range_total)
+                .or_else(|| match response_header.get(CONTENT_LENGTH) {
+                    Some(content_length) => content_length.to_str().ok()?.parse::<u64>().ok(),
+                    None => response.content_length(),
+                })
+        } else {
+            match response_header.get(CONTENT_LENGTH) {
+                Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
+                None => response.content_length(),
+            }
         };
 
         debug!(
@@ -807,6 +818,17 @@ fn remove_sensitive_headers(headers: &mut HeaderMap, next: &Url, previous: &Url)
         headers.remove(reqwest::header::PROXY_AUTHORIZATION);
         headers.remove(reqwest::header::WWW_AUTHENTICATE);
     }
+}
+
+fn parse_content_range_total(content_range: &HeaderValue) -> Option<u64> {
+    let content_range = content_range.to_str().ok()?;
+    let (_, value) = content_range.split_once(' ')?;
+    let total = value.rsplit('/').next()?;
+    if total == "*" {
+        return None;
+    }
+
+    total.parse::<u64>().ok()
 }
 
 #[cfg(test)]
@@ -1411,6 +1433,15 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
         .unwrap();
         let mut headers = HeaderMap::new();
         assert!(http.make_request_headers(&mut headers, None).is_err());
+    }
+
+    #[test]
+    fn should_parse_content_range_total() {
+        let content_range = HeaderValue::from_static("bytes 0-1023/4096");
+        assert_eq!(parse_content_range_total(&content_range), Some(4096));
+
+        let invalid_total = HeaderValue::from_static("bytes 0-1023/*");
+        assert_eq!(parse_content_range_total(&invalid_total), None);
     }
 
     #[tokio::test]

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -1223,6 +1223,38 @@ impl ProxyServer {
     }
 }
 
+/// ProxyS3 is the S3-aware proxy configuration.
+#[derive(Debug, Clone, Validate, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ProxyS3 {
+    /// Enable indicates whether to enable S3-aware request routing in the proxy.
+    pub enable: bool,
+
+    /// Detect AWS endpoints indicates whether to automatically match common AWS S3 endpoint
+    /// patterns such as path-style, virtual-hosted-style, dualstack, and accelerate hosts.
+    pub detect_aws_endpoints: bool,
+
+    /// Hosts is an allowlist of exact S3-compatible endpoint hosts that should be treated as
+    /// path-style endpoints, such as `minio.example.com`.
+    pub hosts: Vec<String>,
+
+    /// Host suffixes is an allowlist of S3-compatible endpoint suffixes that should be treated as
+    /// both path-style roots and virtual-hosted-style suffixes, such as `minio.example.com`.
+    pub host_suffixes: Vec<String>,
+}
+
+/// ProxyS3 implements Default.
+impl Default for ProxyS3 {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            detect_aws_endpoints: true,
+            hosts: Vec::new(),
+            host_suffixes: Vec::new(),
+        }
+    }
+}
+
 /// Rule is the proxy rule configuration.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1323,6 +1355,9 @@ pub struct Proxy {
     /// Server is the proxy server configuration for dfdaemon.
     pub server: ProxyServer,
 
+    /// S3 is the S3-aware proxy configuration.
+    pub s3: ProxyS3,
+
     /// Rules is the proxy rules.
     pub rules: Option<Vec<Rule>>,
 
@@ -1353,6 +1388,7 @@ impl Default for Proxy {
     fn default() -> Self {
         Self {
             server: ProxyServer::default(),
+            s3: ProxyS3::default(),
             rules: None,
             registry_mirror: RegistryMirror::default(),
             disable_back_to_source: false,
@@ -2189,6 +2225,12 @@ key: /etc/ssl/private/client.pem
                     "filteredQueryParams": ["Signature", "Expires"]
                 }
             ],
+            "s3": {
+                "enable": true,
+                "detectAwsEndpoints": true,
+                "hosts": ["minio.example.com"],
+                "hostSuffixes": ["storage.example.com"]
+            },
             "registryMirror": {
                 "enableTaskIDBasedBlobDigest": true,
                 "addr": "https://mirror.example.com",
@@ -2221,6 +2263,10 @@ key: /etc/ssl/private/client.pem
             proxy.server.basic_auth.as_ref().unwrap().password,
             "password".to_string()
         );
+        assert!(proxy.s3.enable);
+        assert!(proxy.s3.detect_aws_endpoints);
+        assert_eq!(proxy.s3.hosts, vec!["minio.example.com"]);
+        assert_eq!(proxy.s3.host_suffixes, vec!["storage.example.com"]);
 
         let rule = &proxy.rules.as_ref().unwrap()[0];
         assert_eq!(rule.regex.as_str(), "^https?://example\\.com/.*$");

--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -184,6 +184,13 @@ lazy_static! {
             &[]
         ).expect("metric can be created");
 
+    /// S3_PROXY_REQUEST_COUNT is used to count S3-aware proxy routing decisions.
+    pub static ref S3_PROXY_REQUEST_COUNT: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new("s3_proxy_request_total", "Counter of the number of S3-aware proxy requests by operation and route.").namespace(dragonfly_client_config::SERVICE_NAME).subsystem(dragonfly_client_config::NAME),
+            &["operation", "route"]
+        ).expect("metric can be created");
+
     /// UPDATE_TASK_COUNT is used to count the number of update tasks.
     pub static ref UPDATE_TASK_COUNT: IntCounterVec =
         IntCounterVec::new(
@@ -393,6 +400,10 @@ fn register_custom_metrics() {
         .expect("metric can be registered");
 
     REGISTRY
+        .register(Box::new(S3_PROXY_REQUEST_COUNT.clone()))
+        .expect("metric can be registered");
+
+    REGISTRY
         .register(Box::new(UPDATE_TASK_COUNT.clone()))
         .expect("metric can be registered");
 
@@ -483,6 +494,7 @@ fn reset_custom_metrics() {
     PROXY_REQUEST_COUNT.reset();
     PROXY_REQUEST_FAILURE_COUNT.reset();
     PROXY_REQUEST_VIA_DFDAEMON_COUNT.reset();
+    S3_PROXY_REQUEST_COUNT.reset();
     UPDATE_TASK_COUNT.reset();
     UPDATE_TASK_FAILURE_COUNT.reset();
     STAT_TASK_COUNT.reset();
@@ -819,6 +831,13 @@ pub fn collect_proxy_request_failure_metrics() {
 pub fn collect_proxy_request_via_dfdaemon_metrics() {
     PROXY_REQUEST_VIA_DFDAEMON_COUNT
         .with_label_values(&[])
+        .inc();
+}
+
+/// collect_s3_proxy_request_metrics collects the S3-aware proxy routing metrics.
+pub fn collect_s3_proxy_request_metrics(operation: &str, route: &str) {
+    S3_PROXY_REQUEST_COUNT
+        .with_label_values(&[operation, route])
         .inc();
 }
 
@@ -1408,6 +1427,12 @@ mod tests {
             .with_label_values(&[])
             .get();
         assert!(via_dfdaemon_counter > 0);
+
+        collect_s3_proxy_request_metrics("get_object", "dfdaemon");
+        let s3_proxy_counter = S3_PROXY_REQUEST_COUNT
+            .with_label_values(&["get_object", "dfdaemon"])
+            .get();
+        assert!(s3_proxy_counter > 0);
     }
 
     #[test]

--- a/dragonfly-client-util/src/cgroups/mod.rs
+++ b/dragonfly-client-util/src/cgroups/mod.rs
@@ -35,8 +35,8 @@ use std::path::{Path, PathBuf};
 ///
 /// # Examples
 ///
-/// ```rust
-/// use cgroups_rs::get_cgroup_by_pid;
+/// ```no_run
+/// use dragonfly_client_util::cgroups::get_cgroup_by_pid;
 ///
 /// // Get cgroup for the current process
 /// let cgroup = get_cgroup_by_pid(std::process::id()).unwrap();
@@ -78,8 +78,10 @@ pub fn get_cgroup_by_pid(pid: u32) -> Result<Cgroup> {
 /// * `Err(Error)` - If the process doesn't exist or cgroup v2 is not available
 ///
 /// # Example
-/// ```
-/// let cgroup_path = get_cgroup_v2_path_by_pid(1)?;
+/// ```no_run
+/// use dragonfly_client_util::cgroups::get_cgroup_v2_path_by_pid;
+///
+/// let cgroup_path = get_cgroup_v2_path_by_pid(1).unwrap();
 /// // Returns something like: /sys/fs/cgroup/system.slice/service.scope
 /// ```
 pub fn get_cgroup_v2_path_by_pid(pid: u32) -> Result<PathBuf> {

--- a/dragonfly-client-util/src/request/mod.rs
+++ b/dragonfly-client-util/src/request/mod.rs
@@ -21,6 +21,7 @@ use crate::net::format_url;
 use crate::net::preferred_local_ip;
 use crate::pool::{Builder as PoolBuilder, Entry, Factory, Pool};
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use bytes::BytesMut;
 use dragonfly_api::scheduler::v2::scheduler_client::SchedulerClient;
 use errors::{BackendError, DfdaemonError, Error, ProxyError};
@@ -578,18 +579,13 @@ impl Request for Proxy {
             .await
             .map_err(|err| {
                 Error::Internal(format!("failed to authenticate with registry: {}", err))
-            })?
-            .ok_or_else(|| {
-                Error::Internal("registry did not return authentication token".to_string())
             })?;
 
         // Build authorization header for blob downloads through the Dragonfly.
         let mut header = HeaderMap::new();
-        header.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", token))
-                .map_err(|err| Error::Internal(format!("invalid auth token: {}", err)))?,
-        );
+        if let Some(authorization) = Self::make_registry_authorization_header(&auth, token)? {
+            header.insert(AUTHORIZATION, authorization);
+        }
 
         let registry = reference.resolve_registry();
         let repository = reference.repository();
@@ -643,6 +639,9 @@ impl Proxy {
         &self,
         request: &GetRequest,
     ) -> Result<Vec<Entry<ClientWithMiddleware>>> {
+        let filtered_query_params =
+            Self::effective_filtered_query_params(&request.filtered_query_params);
+
         // Generate task id for selecting seed peer.
         let task_id = self
             .id_generator
@@ -657,7 +656,7 @@ impl Proxy {
                         piece_length: request.piece_length,
                         tag: request.tag.clone(),
                         application: request.application.clone(),
-                        filtered_query_params: request.filtered_query_params.clone(),
+                        filtered_query_params,
                         revision: None,
                     }
                 },
@@ -870,6 +869,44 @@ impl Proxy {
         format!("https://{}/v2/{}/blobs/{}", registry, repository, digest)
     }
 
+    /// Returns the configured query-param filters, defaulting to the standard proxy rule filters
+    /// when the caller leaves the list empty.
+    fn effective_filtered_query_params(filtered_query_params: &[String]) -> Vec<String> {
+        if filtered_query_params.is_empty() {
+            default_proxy_rule_filtered_query_params()
+        } else {
+            filtered_query_params.to_vec()
+        }
+    }
+
+    /// Builds the Authorization header for OCI blob downloads.
+    ///
+    /// Prefer a bearer token when the registry returns one. If no token is returned, fall back to
+    /// basic auth when credentials were provided; otherwise send no Authorization header.
+    fn make_registry_authorization_header(
+        auth: &RegistryAuth,
+        bearer_token: Option<String>,
+    ) -> Result<Option<HeaderValue>> {
+        if let Some(token) = bearer_token {
+            return HeaderValue::from_str(&format!("Bearer {}", token))
+                .map(Some)
+                .map_err(|err| Error::Internal(format!("invalid auth token: {}", err)));
+        }
+
+        match auth {
+            RegistryAuth::Basic(username, password) => HeaderValue::from_str(&format!(
+                "Basic {}",
+                BASE64_STANDARD.encode(format!("{}:{}", username, password))
+            ))
+            .map(Some)
+            .map_err(|err| Error::Internal(format!("invalid basic auth header: {}", err))),
+            RegistryAuth::Bearer(token) => HeaderValue::from_str(&format!("Bearer {}", token))
+                .map(Some)
+                .map_err(|err| Error::Internal(format!("invalid auth token: {}", err))),
+            RegistryAuth::Anonymous => Ok(None),
+        }
+    }
+
     /// Builds an OCI client with a platform resolver that matches the requested os/arch.
     fn oci_client(platform: Option<String>) -> Result<OciClient> {
         let mut oci_config = ClientConfig::default();
@@ -1023,5 +1060,64 @@ mod tests {
 
         // Still should be 1 because the proxy1 client should have been cleaned up.
         assert_eq!(pool.size().await, 1);
+    }
+
+    #[test]
+    fn test_effective_filtered_query_params_defaults_when_empty() {
+        let mut actual = Proxy::effective_filtered_query_params(&[]);
+        let mut expected = default_proxy_rule_filtered_query_params();
+        actual.sort();
+        expected.sort();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_effective_filtered_query_params_preserves_explicit_values() {
+        let filters = vec!["Signature".to_string(), "Expires".to_string()];
+        assert_eq!(Proxy::effective_filtered_query_params(&filters), filters);
+    }
+
+    #[test]
+    fn test_make_registry_authorization_header_prefers_bearer_token() {
+        let header = Proxy::make_registry_authorization_header(
+            &RegistryAuth::Basic("user".to_string(), "password".to_string()),
+            Some("token".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(header.to_str().unwrap(), "Bearer token");
+    }
+
+    #[test]
+    fn test_make_registry_authorization_header_uses_basic_auth_without_token() {
+        let header = Proxy::make_registry_authorization_header(
+            &RegistryAuth::Basic("user".to_string(), "password".to_string()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(header.to_str().unwrap(), "Basic dXNlcjpwYXNzd29yZA==");
+    }
+
+    #[test]
+    fn test_make_registry_authorization_header_uses_existing_bearer_auth_without_token() {
+        let header = Proxy::make_registry_authorization_header(
+            &RegistryAuth::Bearer("token".to_string()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(header.to_str().unwrap(), "Bearer token");
+    }
+
+    #[test]
+    fn test_make_registry_authorization_header_allows_anonymous_without_token() {
+        let header =
+            Proxy::make_registry_authorization_header(&RegistryAuth::Anonymous, None).unwrap();
+
+        assert!(header.is_none());
     }
 }

--- a/dragonfly-client-util/src/sysinfo/cpu.rs
+++ b/dragonfly-client-util/src/sysinfo/cpu.rs
@@ -285,7 +285,7 @@ impl CPU {
     /// Parses the usage_usec value from cpu.stat content.
     ///
     /// The cpu.stat file format (cgroup v2) looks like:
-    /// ```
+    /// ```text
     /// usage_usec 123456789
     /// user_usec 100000000
     /// system_usec 23456789

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -18,6 +18,7 @@ use crate::dynconfig::Dynconfig;
 use crate::grpc::block_list::{
     BlockList, DownloadBlockListCheckParams, UploadBlockListCheckParams,
 };
+use crate::proxy::header as proxy_header;
 use crate::resource::{persistent_cache_task, persistent_task, task};
 use dragonfly_api::common::v2::{
     CacheTask, PersistentCacheTask, PersistentTask, Priority, Task, TaskType,
@@ -448,9 +449,8 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // Download's range priority is higher than the request header's range.
         // If download protocol is http, use the range of the request header.
         // If download protocol is not http, use the range of the download.
-        if download.range.is_none() {
-            // Convert the header.
-            let request_header = match hashmap_to_headermap(&download.request_header) {
+        let request_header = if download.range.is_none() {
+            Some(match hashmap_to_headermap(&download.request_header) {
                 Ok(header) => header,
                 Err(e) => {
                     // Download task failed.
@@ -470,30 +470,49 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                     error!("convert header: {}", e);
                     return Err(Status::invalid_argument(e.to_string()));
                 }
+            })
+        } else {
+            None
+        };
+
+        if download.range.is_none() {
+            download.range = match get_range(
+                request_header.as_ref().unwrap(),
+                task.content_length().unwrap_or_default(),
+            ) {
+                Ok(range) => range,
+                Err(e) => {
+                    // Download task failed.
+                    self.task
+                        .download_failed(task_id.as_str())
+                        .await
+                        .unwrap_or_else(|err| error!("download task failed: {}", err));
+
+                    // Collect download task failure metrics.
+                    collect_download_task_failure_metrics(
+                        download.r#type,
+                        download.tag.clone().unwrap_or_default().as_str(),
+                        download.application.clone().unwrap_or_default().as_str(),
+                        download.priority.to_string().as_str(),
+                    );
+
+                    error!("get range failed: {}", e);
+                    return Err(Status::failed_precondition(e.to_string()));
+                }
             };
+        }
 
-            download.range =
-                match get_range(&request_header, task.content_length().unwrap_or_default()) {
-                    Ok(range) => range,
-                    Err(e) => {
-                        // Download task failed.
-                        self.task
-                            .download_failed(task_id.as_str())
-                            .await
-                            .unwrap_or_else(|err| error!("download task failed: {}", err));
-
-                        // Collect download task failure metrics.
-                        collect_download_task_failure_metrics(
-                            download.r#type,
-                            download.tag.clone().unwrap_or_default().as_str(),
-                            download.application.clone().unwrap_or_default().as_str(),
-                            download.priority.to_string().as_str(),
-                        );
-
-                        error!("get range failed: {}", e);
-                        return Err(Status::failed_precondition(e.to_string()));
-                    }
-                };
+        if let Some(request_header) = request_header.as_ref() {
+            let signed_range_bound = proxy_header::range_header_is_signature_bound(
+                request_header,
+                Some(download.url.as_str()),
+            );
+            if signed_range_bound {
+                download.request_header.insert(
+                    proxy_header::DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER.to_string(),
+                    "true".to_string(),
+                );
+            }
         }
 
         // Initialize stream channel.

--- a/dragonfly-client/src/proxy/header.rs
+++ b/dragonfly-client/src/proxy/header.rs
@@ -16,9 +16,11 @@
 
 use bytesize::ByteSize;
 use dragonfly_api::common::v2::Priority;
+use dragonfly_client_util::http::get_range;
 use reqwest::header::HeaderMap;
 use std::{fmt, str::FromStr};
 use tracing::error;
+use url::Url;
 
 /// DRAGONFLY_TAG_HEADER is the header key of tag in http request.
 pub const DRAGONFLY_TAG_HEADER: &str = "X-Dragonfly-Tag";
@@ -73,6 +75,15 @@ pub const DRAGONFLY_FORCE_HARD_LINK_HEADER: &str = "X-Dragonfly-Force-Hard-Link"
 /// be set with human readable format and needs to be greater than or equal
 /// to 4mib, for example: 4mib, 1gib
 pub const DRAGONFLY_PIECE_LENGTH_HEADER: &str = "X-Dragonfly-Piece-Length";
+
+/// DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER is an internal header key used by dfdaemon to indicate
+/// that the original Range header must be preserved for the source stat request.
+pub const DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER: &str = "X-Dragonfly-Preserve-Range-For-Stat";
+
+/// DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER is an internal header key used by dfdaemon
+/// to indicate that the caller's original Range header must be preserved on the source GET request.
+pub const DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER: &str =
+    "X-Dragonfly-Preserve-Original-Range-For-Source";
 
 /// DRAGONFLY_CONTENT_FOR_CALCULATING_TASK_ID_HEADER is the header key of content for calculating task id.
 /// If DRAGONFLY_CONTENT_FOR_CALCULATING_TASK_ID_HEADER is set, use its value to calculate the task ID.
@@ -295,6 +306,103 @@ pub fn get_piece_length(header: &HeaderMap) -> Option<ByteSize> {
     }
 }
 
+/// Get X-Dragonfly-Preserve-Range-For-Stat header value to determine whether the original Range
+/// header should be preserved for the source stat request.
+pub fn get_preserve_range_for_stat(header: &HeaderMap) -> bool {
+    match header.get(DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER) {
+        Some(value) => match value.to_str() {
+            Ok(value) => value.eq_ignore_ascii_case("true"),
+            Err(err) => {
+                error!("get preserve range for stat from header failed: {}", err);
+                false
+            }
+        },
+        None => false,
+    }
+}
+
+/// Get X-Dragonfly-Preserve-Original-Range-For-Source header value to determine whether the
+/// caller's original Range header should be preserved on the source GET request.
+pub fn get_preserve_original_range_for_source(header: &HeaderMap) -> bool {
+    match header.get(DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER) {
+        Some(value) => match value.to_str() {
+            Ok(value) => value.eq_ignore_ascii_case("true"),
+            Err(err) => {
+                error!(
+                    "get preserve original range for source from header failed: {}",
+                    err
+                );
+                false
+            }
+        },
+        None => false,
+    }
+}
+
+/// range_header_is_signature_bound returns whether the caller's authentication material explicitly
+/// signs the Range header for the given request.
+pub fn range_header_is_signature_bound(header: &HeaderMap, url: Option<&str>) -> bool {
+    if !header.contains_key(reqwest::header::RANGE) {
+        return false;
+    }
+
+    if header
+        .get(reqwest::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| sigv4_signed_headers_contains(value, "range"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    url.and_then(|value| Url::parse(value).ok())
+        .map(|parsed_url| presigned_url_signs_header(&parsed_url, "range"))
+        .unwrap_or(false)
+}
+
+/// signed_range_covers_content returns whether the signed Range header safely covers the full
+/// object body after clamping it against the object's content length.
+pub fn signed_range_covers_content(
+    header: &HeaderMap,
+    url: Option<&str>,
+    content_length: u64,
+) -> bool {
+    if !range_header_is_signature_bound(header, url) {
+        return false;
+    }
+
+    matches!(
+        get_range(header, content_length),
+        Ok(Some(range)) if range.start == 0 && range.length == content_length
+    )
+}
+
+fn sigv4_signed_headers_contains(authorization: &str, header_name: &str) -> bool {
+    authorization
+        .split(',')
+        .find_map(|part| part.trim().strip_prefix("SignedHeaders="))
+        .map(|signed_headers| signed_headers_contains_header(signed_headers, header_name))
+        .unwrap_or(false)
+}
+
+fn presigned_url_signs_header(url: &Url, header_name: &str) -> bool {
+    url.query_pairs()
+        .find_map(|(key, value)| {
+            if key.eq_ignore_ascii_case("X-Amz-SignedHeaders") {
+                Some(signed_headers_contains_header(value.as_ref(), header_name))
+            } else {
+                None
+            }
+        })
+        .unwrap_or(false)
+}
+
+fn signed_headers_contains_header(signed_headers: &str, header_name: &str) -> bool {
+    signed_headers
+        .split(';')
+        .any(|value| value.trim().eq_ignore_ascii_case(header_name))
+}
+
 /// Get X-Dragonfly-Content-For-Calculating-Task-ID header value to determine the content for
 /// calculating task ID.
 pub fn get_content_for_calculating_task_id(header: &HeaderMap) -> Option<String> {
@@ -479,6 +587,91 @@ mod tests {
 
         headers.insert(DRAGONFLY_PIECE_LENGTH_HEADER, HeaderValue::from_static("0"));
         assert_eq!(get_piece_length(&headers), Some(ByteSize::b(0)));
+    }
+
+    #[test]
+    fn test_get_preserve_range_for_stat() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER,
+            HeaderValue::from_static("true"),
+        );
+        assert!(get_preserve_range_for_stat(&headers));
+
+        headers.insert(
+            DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER,
+            HeaderValue::from_static("false"),
+        );
+        assert!(!get_preserve_range_for_stat(&headers));
+
+        let empty_headers = HeaderMap::new();
+        assert!(!get_preserve_range_for_stat(&empty_headers));
+    }
+
+    #[test]
+    fn test_get_preserve_original_range_for_source() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER,
+            HeaderValue::from_static("true"),
+        );
+        assert!(get_preserve_original_range_for_source(&headers));
+
+        headers.insert(
+            DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER,
+            HeaderValue::from_static("false"),
+        );
+        assert!(!get_preserve_original_range_for_source(&headers));
+    }
+
+    #[test]
+    fn test_range_header_is_signature_bound() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=0-1023"),
+        );
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=test, SignedHeaders=host;range;x-amz-date, Signature=test",
+            ),
+        );
+        assert!(range_header_is_signature_bound(&headers, None));
+
+        let mut presigned_headers = HeaderMap::new();
+        presigned_headers.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=0-1023"),
+        );
+        assert!(range_header_is_signature_bound(
+            &presigned_headers,
+            Some("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=test"),
+        ));
+
+        let mut unsigned_headers = HeaderMap::new();
+        unsigned_headers.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=0-1023"),
+        );
+        assert!(!range_header_is_signature_bound(&unsigned_headers, None));
+    }
+
+    #[test]
+    fn test_signed_range_covers_content() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=0-52428799"),
+        );
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=test, SignedHeaders=host;range;x-amz-date, Signature=test",
+            ),
+        );
+        assert!(signed_range_covers_content(&headers, None, 15_349_416));
+        assert!(!signed_range_covers_content(&headers, None, 80_000_000));
     }
 
     #[test]

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -27,7 +27,7 @@ use dragonfly_client_core::error::{ErrorType, OrErr};
 use dragonfly_client_core::{Error as ClientError, Result as ClientResult};
 use dragonfly_client_metric::{
     collect_proxy_request_failure_metrics, collect_proxy_request_started_metrics,
-    collect_proxy_request_via_dfdaemon_metrics,
+    collect_proxy_request_via_dfdaemon_metrics, collect_s3_proxy_request_metrics,
 };
 use dragonfly_client_util::{
     http::{hashmap_to_headermap, headermap_to_hashmap},
@@ -62,6 +62,7 @@ use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument, Instrument, Span};
 
 pub mod header;
+pub mod s3;
 
 lazy_static! {
   /// Supported HTTP protocols, including HTTP/1.1 and HTTP/1.0.
@@ -70,6 +71,21 @@ lazy_static! {
 
 /// Response type for the proxy server.
 pub type Response = hyper::Response<BoxBody<Bytes, ClientError>>;
+
+#[derive(Debug, Clone)]
+enum ProxyRouteDecision {
+    Direct,
+    ViaDfdaemon {
+        rule: Rule,
+        preserve_range_for_stat: bool,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct DfdaemonRoute<'a> {
+    rule: &'a Rule,
+    preserve_range_for_stat: bool,
+}
 
 /// Proxy server for intercepting and handling HTTP requests.
 pub struct Proxy {
@@ -380,61 +396,26 @@ pub async fn http_handler(
         }
     }
 
-    // If find the matching rule, proxy the request via the dfdaemon.
-    // Only GET requests are routed to P2P; other methods (HEAD/PUT/POST/DELETE)
-    // fall through to direct proxy to avoid data loss.
-    let request_uri = request.uri();
-    if let Some(rule) = find_matching_rule(
-        config.proxy.rules.as_deref(),
-        url::Url::parse(&request_uri.to_string()).or_err(ErrorType::ParseError)?,
-    ) {
-        if request.method() == Method::GET {
-            info!(
-                "proxy HTTP request via dfdaemon by rule config: {:?}",
-                request
-            );
-
+    match resolve_proxy_route(config.as_ref(), &request)? {
+        ProxyRouteDecision::ViaDfdaemon {
+            rule,
+            preserve_range_for_stat,
+        } => {
             return proxy_via_dfdaemon(
                 config,
                 task,
-                &rule,
+                DfdaemonRoute {
+                    rule: &rule,
+                    preserve_range_for_stat,
+                },
                 request,
                 remote_ip,
                 dfdaemon_download_client,
+                registry_cert,
             )
             .await;
         }
-
-        debug!(
-            "proxy HTTP request bypassing dfdaemon for non-GET method: {:?}",
-            request
-        );
-    }
-
-    // If the request header contains the X-Dragonfly-Use-P2P header, proxy the request via the
-    // dfdaemon.
-    if header::get_use_p2p(request.headers()) {
-        info!(
-            "proxy HTTP request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
-            request
-        );
-
-        if request.method() == Method::GET {
-            return proxy_via_dfdaemon(
-                config,
-                task,
-                &Rule::default(),
-                request,
-                remote_ip,
-                dfdaemon_download_client,
-            )
-            .await;
-        }
-
-        debug!(
-            "proxy HTTP request bypassing dfdaemon for non-GET method: {:?}",
-            request
-        );
+        ProxyRouteDecision::Direct => {}
     }
 
     if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
@@ -636,61 +617,26 @@ pub async fn upgraded_handler(
             .or_err(ErrorType::ParseError)?;
     }
 
-    // If find the matching rule, proxy the request via the dfdaemon.
-    // Only GET requests are routed to P2P; other methods (HEAD/PUT/POST/DELETE)
-    // fall through to direct proxy to avoid data loss.
-    let request_uri = request.uri();
-    if let Some(rule) = find_matching_rule(
-        config.proxy.rules.as_deref(),
-        url::Url::parse(&request_uri.to_string()).or_err(ErrorType::ParseError)?,
-    ) {
-        if request.method() == Method::GET {
-            info!(
-                "proxy HTTPS request via dfdaemon by rule config: {:?}",
-                request,
-            );
-
+    match resolve_proxy_route(config.as_ref(), &request)? {
+        ProxyRouteDecision::ViaDfdaemon {
+            rule,
+            preserve_range_for_stat,
+        } => {
             return proxy_via_dfdaemon(
                 config,
                 task,
-                &rule,
+                DfdaemonRoute {
+                    rule: &rule,
+                    preserve_range_for_stat,
+                },
                 request,
                 remote_ip,
                 dfdaemon_download_client,
+                registry_cert,
             )
             .await;
         }
-
-        debug!(
-            "proxy HTTPS request bypassing dfdaemon for non-GET method: {:?}",
-            request,
-        );
-    }
-
-    // If the request header contains the X-Dragonfly-Use-P2P header, proxy the request via the
-    // dfdaemon.
-    if header::get_use_p2p(request.headers()) {
-        if request.method() == Method::GET {
-            info!(
-                "proxy HTTP request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
-                request,
-            );
-
-            return proxy_via_dfdaemon(
-                config,
-                task,
-                &Rule::default(),
-                request,
-                remote_ip,
-                dfdaemon_download_client,
-            )
-            .await;
-        }
-
-        debug!(
-            "proxy HTTPS request bypassing dfdaemon for non-GET method: {:?}",
-            request,
-        );
+        ProxyRouteDecision::Direct => {}
     }
 
     if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
@@ -715,27 +661,37 @@ pub async fn upgraded_handler(
 async fn proxy_via_dfdaemon(
     config: Arc<Config>,
     task: Arc<Task>,
-    rule: &Rule,
+    route: DfdaemonRoute<'_>,
     request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
     dfdaemon_download_client: DfdaemonDownloadClient,
+    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
 ) -> ClientResult<Response> {
     // Collect the metrics for the proxy request via dfdaemon.
     collect_proxy_request_via_dfdaemon_metrics();
 
+    let request_url = request.uri().to_string();
+    let signed_range_bound =
+        header::range_header_is_signature_bound(request.headers(), Some(request_url.as_str()));
+
     // Make the download task request.
-    let download_task_request =
-        match make_download_task_request(config.clone(), rule, request, remote_ip) {
-            Ok(download_task_request) => download_task_request,
-            Err(err) => {
-                error!("make download task request failed: {}", err);
-                return Ok(make_error_response(
-                    header::ErrorType::Proxy,
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    None,
-                ));
-            }
-        };
+    let download_task_request = match make_download_task_request(
+        config.clone(),
+        route.rule,
+        route.preserve_range_for_stat,
+        &request,
+        remote_ip,
+    ) {
+        Ok(download_task_request) => download_task_request,
+        Err(err) => {
+            error!("make download task request failed: {}", err);
+            return Ok(make_error_response(
+                header::ErrorType::Proxy,
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                None,
+            ));
+        }
+    };
 
     // Download the task by the dfdaemon download client.
     let response = match dfdaemon_download_client
@@ -744,6 +700,15 @@ async fn proxy_via_dfdaemon(
     {
         Ok(response) => response,
         Err(err) => match err {
+            ClientError::TonicStatus(err)
+                if signed_range_bound && err.code() == tonic::Code::FailedPrecondition =>
+            {
+                info!(
+                    "fall back to direct origin for signed S3 range request because dfdaemon cannot accelerate it safely yet: {}",
+                    request.uri()
+                );
+                return proxy_direct_to_origin(request, registry_cert).await;
+            }
             ClientError::TonicStatus(err) if err.code() == tonic::Code::ResourceExhausted => {
                 return Ok(make_error_response(
                     header::ErrorType::Proxy,
@@ -843,7 +808,7 @@ async fn proxy_via_dfdaemon(
         config.host.ip.unwrap(),
         download_task_started_response.clone(),
     )?;
-    *response.status_mut() = http::StatusCode::OK;
+    *response.status_mut() = ranged_response_status(download_task_started_response.range.is_some());
 
     // Return the response if the client return the first piece.
     let mut initialized = false;
@@ -1032,6 +997,17 @@ async fn proxy_via_dfdaemon(
     }
 }
 
+async fn proxy_direct_to_origin(
+    request: Request<hyper::body::Incoming>,
+    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+) -> ClientResult<Response> {
+    if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
+        return proxy_via_https(request, registry_cert).await;
+    }
+
+    proxy_via_http(request).await
+}
+
 /// proxy_via_http proxies the HTTP request directly to the remote server.
 #[instrument(skip_all)]
 async fn proxy_via_http(mut request: Request<hyper::body::Incoming>) -> ClientResult<Response> {
@@ -1059,17 +1035,10 @@ async fn proxy_via_http(mut request: Request<hyper::body::Incoming>) -> ClientRe
         }
     });
 
-    // Override Host header with full authority (including port) to handle
-    // containerd's behavior with non-443 HTTPS ports, which otherwise
-    // causes request failures.
-    let authority = request
-        .uri()
-        .authority()
-        .ok_or_else(|| ClientError::Unknown("request uri authority is not set".to_string()))?
-        .as_str()
-        .parse()
-        .or_err(ErrorType::ParseError)?;
-    request.headers_mut().insert(hyper::header::HOST, authority);
+    let host_header = host_header_for_origin(request.uri())?;
+    request
+        .headers_mut()
+        .insert(hyper::header::HOST, host_header);
 
     let response = client.send_request(request).await?;
     Ok(response.map(|b| b.map_err(ClientError::from).boxed()))
@@ -1105,17 +1074,10 @@ async fn proxy_via_https(
         .build();
     let client = Client::builder(TokioExecutor::new()).build(https);
 
-    // Override Host header with full authority (including port) to handle
-    // containerd's behavior with non-443 HTTPS ports, which otherwise
-    // causes request failures.
-    let authority = request
-        .uri()
-        .authority()
-        .ok_or_else(|| ClientError::Unknown("request uri authority is not set".to_string()))?
-        .as_str()
-        .parse()
-        .or_err(ErrorType::ParseError)?;
-    request.headers_mut().insert(hyper::header::HOST, authority);
+    let host_header = host_header_for_origin(request.uri())?;
+    request
+        .headers_mut()
+        .insert(hyper::header::HOST, host_header);
 
     let response = client.request(request).await.inspect_err(|err| {
         error!("request failed: {:?}", err);
@@ -1169,11 +1131,32 @@ fn make_registry_mirror_request(
     Ok(request)
 }
 
+fn host_header_for_origin(uri: &hyper::Uri) -> ClientResult<hyper::header::HeaderValue> {
+    let host = uri
+        .host()
+        .ok_or_else(|| ClientError::Unknown("request uri host is not set".to_string()))?;
+    let default_port = match uri.scheme_str() {
+        Some("http") => Some(80),
+        Some("https") => Some(443),
+        _ => None,
+    };
+    let host_header = match uri.port_u16() {
+        Some(port) if Some(port) != default_port => uri
+            .authority()
+            .ok_or_else(|| ClientError::Unknown("request uri authority is not set".to_string()))?
+            .as_str(),
+        _ => host,
+    };
+
+    Ok(host_header.parse().or_err(ErrorType::ParseError)?)
+}
+
 /// make_download_task_request makes a download task request by the request.
-fn make_download_task_request(
+fn make_download_task_request<B>(
     config: Arc<Config>,
     rule: &Rule,
-    request: Request<hyper::body::Incoming>,
+    preserve_range_for_stat: bool,
+    request: &Request<B>,
     remote_ip: std::net::IpAddr,
 ) -> ClientResult<DownloadTaskRequest> {
     // Convert the Reqwest header to the Hyper header.
@@ -1191,6 +1174,13 @@ fn make_download_task_request(
                 piece_length, MIN_PIECE_LENGTH
             )));
         }
+    }
+
+    if preserve_range_for_stat {
+        header.insert(
+            header::DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER,
+            "true".parse().or_err(ErrorType::ParseError)?,
+        );
     }
 
     Ok(DownloadTaskRequest {
@@ -1327,6 +1317,14 @@ fn make_response_headers(
     hashmap_to_headermap(&download_task_started_response.response_header)
 }
 
+fn ranged_response_status(has_range: bool) -> http::StatusCode {
+    if has_range {
+        http::StatusCode::PARTIAL_CONTENT
+    } else {
+        http::StatusCode::OK
+    }
+}
+
 /// find_matching_rule returns whether the dfdaemon should be used to download the task.
 /// If the dfdaemon should be used, return the matched rule.
 fn find_matching_rule(rules: Option<&[Rule]>, mut url: url::Url) -> Option<Rule> {
@@ -1339,6 +1337,83 @@ fn find_matching_rule(rules: Option<&[Rule]>, mut url: url::Url) -> Option<Rule>
         .iter()
         .find(|rule| rule.regex.is_match(url.as_str()))
         .cloned()
+}
+
+fn resolve_proxy_route<B>(
+    config: &Config,
+    request: &Request<B>,
+) -> ClientResult<ProxyRouteDecision> {
+    if let Some(classified_request) =
+        s3::classify_request(&config.proxy.s3, request.method(), request.uri())
+    {
+        collect_s3_proxy_request_metrics(
+            classified_request.operation.as_str(),
+            classified_request.route.as_str(),
+        );
+
+        match classified_request.route {
+            s3::Route::ViaDfdaemon => {
+                info!(
+                    "proxy S3 request via dfdaemon: operation={:?}, url={}",
+                    classified_request.operation,
+                    request.uri()
+                );
+                return Ok(ProxyRouteDecision::ViaDfdaemon {
+                    rule: Rule::default(),
+                    preserve_range_for_stat: request.headers().contains_key(reqwest::header::RANGE),
+                });
+            }
+            s3::Route::Passthrough => {
+                info!(
+                    "proxy S3 request directly to origin: operation={:?}, url={}",
+                    classified_request.operation,
+                    request.uri()
+                );
+                return Ok(ProxyRouteDecision::Direct);
+            }
+        }
+    }
+
+    let request_url = url::Url::parse(&request.uri().to_string()).or_err(ErrorType::ParseError)?;
+    if let Some(rule) = find_matching_rule(config.proxy.rules.as_deref(), request_url) {
+        if request.method() == Method::GET {
+            info!(
+                "proxy request via dfdaemon by rule config: {:?}",
+                request.uri()
+            );
+            return Ok(ProxyRouteDecision::ViaDfdaemon {
+                rule,
+                preserve_range_for_stat: false,
+            });
+        }
+
+        debug!(
+            "proxy request bypassing dfdaemon for non-GET method matched by rule config: {:?}",
+            request.uri()
+        );
+        return Ok(ProxyRouteDecision::Direct);
+    }
+
+    if header::get_use_p2p(request.headers()) {
+        if request.method() == Method::GET {
+            info!(
+                "proxy request via dfdaemon by X-Dragonfly-Use-P2P header: {:?}",
+                request.uri()
+            );
+            return Ok(ProxyRouteDecision::ViaDfdaemon {
+                rule: Rule::default(),
+                preserve_range_for_stat: false,
+            });
+        }
+
+        debug!(
+            "proxy request bypassing dfdaemon for non-GET method with X-Dragonfly-Use-P2P header: {:?}",
+            request.uri()
+        );
+        return Ok(ProxyRouteDecision::Direct);
+    }
+
+    Ok(ProxyRouteDecision::Direct)
 }
 
 /// make_error_response makes an error response with the given status and message.
@@ -1369,4 +1444,333 @@ fn empty() -> BoxBody<Bytes, ClientError> {
     Empty::<Bytes>::new()
         .map_err(|never| match never {})
         .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dragonfly_client_util::id_generator::{IDGenerator, TaskIDParameter};
+    use hyper::Request;
+
+    fn task_id_for_download(download: &Download) -> String {
+        IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false)
+            .task_id(TaskIDParameter::URLBased {
+                url: download.url.clone(),
+                piece_length: download.piece_length,
+                tag: download.tag.clone(),
+                application: download.application.clone(),
+                filtered_query_params: download.filtered_query_params.clone(),
+                revision: None,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn should_route_s3_get_object_via_dfdaemon_before_generic_rules() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+        config.proxy.rules = Some(vec![Rule::default()]);
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::ViaDfdaemon { .. } => {}
+            ProxyRouteDecision::Direct => panic!("expected S3 GetObject to route via dfdaemon"),
+        }
+    }
+
+    #[test]
+    fn should_keep_s3_list_objects_v2_on_direct_passthrough() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+        config.proxy.rules = Some(vec![Rule::default()]);
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/?list-type=2&prefix=models/")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::Direct => {}
+            ProxyRouteDecision::ViaDfdaemon { .. } => {
+                panic!("expected ListObjectsV2 to remain direct passthrough")
+            }
+        }
+    }
+
+    #[test]
+    fn should_preserve_s3_auth_headers_in_download_task_request() {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin")
+            .header(
+                reqwest::header::AUTHORIZATION,
+                "AWS4-HMAC-SHA256 Credential=test",
+            )
+            .header("x-amz-date", "20260409T000000Z")
+            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+            .header("x-amz-security-token", "session-token")
+            .header(reqwest::header::HOST, "bucket.s3.us-west-2.amazonaws.com")
+            .body(())
+            .unwrap();
+
+        let task_request = make_download_task_request(
+            Arc::new(Config::default()),
+            &Rule::default(),
+            false,
+            &request,
+            "127.0.0.1".parse().unwrap(),
+        )
+        .unwrap();
+
+        let download = task_request.download.unwrap();
+        assert_eq!(
+            download
+                .request_header
+                .get(reqwest::header::AUTHORIZATION.as_str())
+                .unwrap(),
+            "AWS4-HMAC-SHA256 Credential=test"
+        );
+        assert_eq!(
+            download.request_header.get("x-amz-date").unwrap(),
+            "20260409T000000Z"
+        );
+        assert_eq!(
+            download.request_header.get("x-amz-content-sha256").unwrap(),
+            "UNSIGNED-PAYLOAD"
+        );
+        assert_eq!(
+            download.request_header.get("x-amz-security-token").unwrap(),
+            "session-token"
+        );
+        assert!(!download
+            .request_header
+            .contains_key(reqwest::header::HOST.as_str()));
+    }
+
+    #[test]
+    fn should_mark_s3_ranged_get_for_range_preservation() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin")
+            .header(reqwest::header::RANGE, "bytes=0-1023")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::ViaDfdaemon {
+                preserve_range_for_stat,
+                ..
+            } => assert!(preserve_range_for_stat),
+            ProxyRouteDecision::Direct => {
+                panic!("expected ranged S3 GetObject to route via dfdaemon")
+            }
+        }
+    }
+
+    #[test]
+    fn should_route_sigv4_signed_s3_ranged_get_via_dfdaemon_for_capability_check() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin")
+            .header(
+                reqwest::header::AUTHORIZATION,
+                "AWS4-HMAC-SHA256 Credential=test, SignedHeaders=host;range;x-amz-date, Signature=test",
+            )
+            .header(reqwest::header::RANGE, "bytes=0-1023")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::ViaDfdaemon {
+                preserve_range_for_stat,
+                ..
+            } => assert!(preserve_range_for_stat),
+            ProxyRouteDecision::Direct => {
+                panic!("expected SigV4 signed ranged S3 GetObject to route via dfdaemon first")
+            }
+        }
+    }
+
+    #[test]
+    fn should_route_presigned_s3_ranged_get_with_unsigned_range_via_dfdaemon() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20260410%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260410T000000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=test-signature")
+            .header(reqwest::header::RANGE, "bytes=0-1023")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::ViaDfdaemon {
+                preserve_range_for_stat,
+                ..
+            } => assert!(preserve_range_for_stat),
+            ProxyRouteDecision::Direct => {
+                panic!("expected presigned ranged S3 GetObject with unsigned Range to route via dfdaemon")
+            }
+        }
+    }
+
+    #[test]
+    fn should_route_presigned_s3_ranged_get_with_signed_range_via_dfdaemon_for_capability_check() {
+        let mut config = Config::default();
+        config.proxy.s3.enable = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20260410%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260410T000000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=test-signature")
+            .header(reqwest::header::RANGE, "bytes=0-1023")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::ViaDfdaemon {
+                preserve_range_for_stat,
+                ..
+            } => assert!(preserve_range_for_stat),
+            ProxyRouteDecision::Direct => {
+                panic!("expected presigned ranged S3 GetObject with signed Range to route via dfdaemon first")
+            }
+        }
+    }
+
+    #[test]
+    fn should_generate_same_task_id_for_equivalent_presigned_s3_urls() {
+        let first_request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=first%2F20260409%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260409T000000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=first-signature")
+            .body(())
+            .unwrap();
+        let second_request = Request::builder()
+            .method(Method::GET)
+            .uri("https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=second%2F20260410%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260410T000000Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=second-signature")
+            .body(())
+            .unwrap();
+
+        let first_download = make_download_task_request(
+            Arc::new(Config::default()),
+            &Rule::default(),
+            false,
+            &first_request,
+            "127.0.0.1".parse().unwrap(),
+        )
+        .unwrap()
+        .download
+        .unwrap();
+        let second_download = make_download_task_request(
+            Arc::new(Config::default()),
+            &Rule::default(),
+            false,
+            &second_request,
+            "127.0.0.1".parse().unwrap(),
+        )
+        .unwrap()
+        .download
+        .unwrap();
+
+        assert_eq!(
+            task_id_for_download(&first_download),
+            task_id_for_download(&second_download)
+        );
+    }
+
+    #[test]
+    fn should_keep_non_get_rule_matched_request_on_direct_passthrough() {
+        let mut config = Config::default();
+        config.proxy.rules = Some(vec![Rule::default()]);
+
+        let request = Request::builder()
+            .method(Method::HEAD)
+            .uri("https://example.com/artifacts/model.bin")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&config, &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::Direct => {}
+            ProxyRouteDecision::ViaDfdaemon { .. } => {
+                panic!("expected non-GET rule-matched request to remain direct passthrough")
+            }
+        }
+    }
+
+    #[test]
+    fn should_keep_non_get_use_p2p_request_on_direct_passthrough() {
+        let request = Request::builder()
+            .method(Method::HEAD)
+            .uri("https://example.com/artifacts/model.bin")
+            .header(header::DRAGONFLY_USE_P2P_HEADER, "true")
+            .body(())
+            .unwrap();
+
+        let route = resolve_proxy_route(&Config::default(), &request).unwrap();
+
+        match route {
+            ProxyRouteDecision::Direct => {}
+            ProxyRouteDecision::ViaDfdaemon { .. } => {
+                panic!("expected non-GET X-Dragonfly-Use-P2P request to remain direct passthrough")
+            }
+        }
+    }
+
+    #[test]
+    fn should_preserve_default_https_host_header_without_port() {
+        let uri = "https://bucket.s3.us-west-2.amazonaws.com:443/models/model.bin"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            host_header_for_origin(&uri).unwrap(),
+            "bucket.s3.us-west-2.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn should_preserve_non_default_https_host_header_with_port() {
+        let uri = "https://registry.example.com:5443/v2/library/alpine/manifests/latest"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            host_header_for_origin(&uri).unwrap(),
+            "registry.example.com:5443"
+        );
+    }
+
+    #[test]
+    fn should_return_partial_content_status_for_ranged_downloads() {
+        assert_eq!(
+            ranged_response_status(true),
+            http::StatusCode::PARTIAL_CONTENT
+        );
+        assert_eq!(ranged_response_status(false), http::StatusCode::OK);
+    }
 }

--- a/dragonfly-client/src/proxy/s3.rs
+++ b/dragonfly-client/src/proxy/s3.rs
@@ -1,0 +1,408 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dragonfly_client_config::dfdaemon::ProxyS3;
+use hyper::{Method, Uri};
+use url::Url;
+
+/// Route is how the proxy should handle a classified S3 request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// ViaDfdaemon proxies the request through the Dragonfly download path.
+    ViaDfdaemon,
+
+    /// Passthrough proxies the request directly to the origin.
+    Passthrough,
+}
+
+impl Route {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ViaDfdaemon => "dfdaemon",
+            Self::Passthrough => "passthrough",
+        }
+    }
+}
+
+/// Operation is the S3 API operation inferred from the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// GetObject is a GET request for an object body.
+    GetObject,
+
+    /// HeadObject is a HEAD request for object metadata.
+    HeadObject,
+
+    /// ListObjectsV2 is a GET request for listing bucket contents.
+    ListObjectsV2,
+
+    /// Other is any other S3 API request that should remain passthrough.
+    Other,
+}
+
+impl Operation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::GetObject => "get_object",
+            Self::HeadObject => "head_object",
+            Self::ListObjectsV2 => "list_objects_v2",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// ClassifiedRequest is the S3 classification result for a proxied request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassifiedRequest {
+    /// Operation is the inferred S3 API operation.
+    pub operation: Operation,
+
+    /// Route is how the proxy should handle the request.
+    pub route: Route,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointStyle {
+    Path,
+    VirtualHosted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EndpointMatch {
+    style: EndpointStyle,
+}
+
+/// classify_request classifies a request targeting an S3-compatible endpoint.
+pub fn classify_request(config: &ProxyS3, method: &Method, uri: &Uri) -> Option<ClassifiedRequest> {
+    if !config.enable {
+        return None;
+    }
+
+    let url = Url::parse(&uri.to_string()).ok()?;
+    let host = url.host_str()?;
+    let endpoint = match_endpoint(host, config)?;
+    let object_key = extract_object_key(&url, endpoint.style);
+
+    if is_list_objects_v2(method, &url) {
+        return Some(ClassifiedRequest {
+            operation: Operation::ListObjectsV2,
+            route: Route::Passthrough,
+        });
+    }
+
+    if *method == Method::HEAD && object_key.is_some() && only_head_object_query_params(&url) {
+        return Some(ClassifiedRequest {
+            operation: Operation::HeadObject,
+            route: Route::Passthrough,
+        });
+    }
+
+    if *method == Method::GET && object_key.is_some() && only_get_object_query_params(&url) {
+        return Some(ClassifiedRequest {
+            operation: Operation::GetObject,
+            route: Route::ViaDfdaemon,
+        });
+    }
+
+    Some(ClassifiedRequest {
+        operation: Operation::Other,
+        route: Route::Passthrough,
+    })
+}
+
+fn match_endpoint(host: &str, config: &ProxyS3) -> Option<EndpointMatch> {
+    let normalized_host = host.to_ascii_lowercase();
+
+    if config.detect_aws_endpoints {
+        if let Some(endpoint) = match_aws_endpoint(&normalized_host) {
+            return Some(endpoint);
+        }
+    }
+
+    if config
+        .hosts
+        .iter()
+        .any(|configured_host| configured_host.eq_ignore_ascii_case(normalized_host.as_str()))
+    {
+        return Some(EndpointMatch {
+            style: EndpointStyle::Path,
+        });
+    }
+
+    for suffix in &config.host_suffixes {
+        let normalized_suffix = suffix.trim_start_matches('.').to_ascii_lowercase();
+        if normalized_suffix.is_empty() {
+            continue;
+        }
+
+        if normalized_host == normalized_suffix {
+            return Some(EndpointMatch {
+                style: EndpointStyle::Path,
+            });
+        }
+
+        let virtual_suffix = format!(".{}", normalized_suffix);
+        if normalized_host.ends_with(&virtual_suffix) {
+            return Some(EndpointMatch {
+                style: EndpointStyle::VirtualHosted,
+            });
+        }
+    }
+
+    None
+}
+
+fn match_aws_endpoint(host: &str) -> Option<EndpointMatch> {
+    let is_aws_host = host.ends_with(".amazonaws.com") || host.ends_with(".amazonaws.com.cn");
+    if !is_aws_host {
+        return None;
+    }
+
+    if host.starts_with("s3.") || host.starts_with("s3-") {
+        return Some(EndpointMatch {
+            style: EndpointStyle::Path,
+        });
+    }
+
+    if host.contains(".s3.") || host.contains(".s3-") {
+        return Some(EndpointMatch {
+            style: EndpointStyle::VirtualHosted,
+        });
+    }
+
+    None
+}
+
+fn extract_object_key(url: &Url, style: EndpointStyle) -> Option<String> {
+    let path = url.path().trim_start_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+
+    match style {
+        EndpointStyle::Path => {
+            let (_bucket, key) = path.split_once('/')?;
+            if key.is_empty() {
+                None
+            } else {
+                Some(key.to_string())
+            }
+        }
+        EndpointStyle::VirtualHosted => Some(path.to_string()),
+    }
+}
+
+fn is_list_objects_v2(method: &Method, url: &Url) -> bool {
+    if *method != Method::GET {
+        return false;
+    }
+
+    let mut has_list_type = false;
+    for (key, value) in url.query_pairs() {
+        let key = key.to_ascii_lowercase();
+        if key == "x-id" && value.eq_ignore_ascii_case("ListObjectsV2") {
+            return true;
+        }
+
+        if key == "list-type" && value == "2" {
+            has_list_type = true;
+        }
+    }
+
+    has_list_type && only_list_objects_v2_query_params(url)
+}
+
+fn only_head_object_query_params(url: &Url) -> bool {
+    only_allowed_query_params(url, |key| matches!(key, "versionid" | "x-id"))
+}
+
+fn only_get_object_query_params(url: &Url) -> bool {
+    only_allowed_query_params(url, |key| {
+        matches!(
+            key,
+            "versionid"
+                | "x-id"
+                | "response-cache-control"
+                | "response-content-disposition"
+                | "response-content-encoding"
+                | "response-content-language"
+                | "response-content-type"
+                | "response-expires"
+        )
+    })
+}
+
+fn only_list_objects_v2_query_params(url: &Url) -> bool {
+    only_allowed_query_params(url, |key| {
+        matches!(
+            key,
+            "list-type"
+                | "prefix"
+                | "delimiter"
+                | "continuation-token"
+                | "encoding-type"
+                | "fetch-owner"
+                | "max-keys"
+                | "start-after"
+                | "x-id"
+        )
+    })
+}
+
+fn only_allowed_query_params(url: &Url, is_allowed: impl Fn(&str) -> bool) -> bool {
+    url.query_pairs().all(|(key, _)| {
+        let normalized_key = key.to_ascii_lowercase();
+        normalized_key.starts_with("x-amz-") || is_allowed(normalized_key.as_str())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_config() -> ProxyS3 {
+        ProxyS3 {
+            enable: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn should_not_match_when_s3_proxy_is_disabled() {
+        let request = classify_request(
+            &ProxyS3::default(),
+            &Method::GET,
+            &"https://bucket.s3.us-west-2.amazonaws.com/model.bin"
+                .parse()
+                .unwrap(),
+        );
+
+        assert_eq!(request, None);
+    }
+
+    #[test]
+    fn should_classify_virtual_hosted_get_object() {
+        let request = classify_request(
+            &enabled_config(),
+            &Method::GET,
+            &"https://bucket.s3.us-west-2.amazonaws.com/models/model.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=test"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::GetObject);
+        assert_eq!(request.route, Route::ViaDfdaemon);
+    }
+
+    #[test]
+    fn should_classify_path_style_list_objects_v2() {
+        let request = classify_request(
+            &enabled_config(),
+            &Method::GET,
+            &"https://s3.us-west-2.amazonaws.com/test-bucket?list-type=2&prefix=models/"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::ListObjectsV2);
+        assert_eq!(request.route, Route::Passthrough);
+    }
+
+    #[test]
+    fn should_classify_head_object_as_passthrough() {
+        let request = classify_request(
+            &enabled_config(),
+            &Method::HEAD,
+            &"https://bucket.s3.amazonaws.com/models/model.bin?x-id=HeadObject"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::HeadObject);
+        assert_eq!(request.route, Route::Passthrough);
+    }
+
+    #[test]
+    fn should_passthrough_other_object_subresources() {
+        let request = classify_request(
+            &enabled_config(),
+            &Method::GET,
+            &"https://bucket.s3.amazonaws.com/models/model.bin?tagging"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::Other);
+        assert_eq!(request.route, Route::Passthrough);
+    }
+
+    #[test]
+    fn should_support_custom_exact_host_as_path_style() {
+        let request = classify_request(
+            &ProxyS3 {
+                enable: true,
+                detect_aws_endpoints: false,
+                hosts: vec!["minio.example.com".to_string()],
+                host_suffixes: Vec::new(),
+            },
+            &Method::GET,
+            &"https://minio.example.com/test-bucket/models/model.bin"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::GetObject);
+        assert_eq!(request.route, Route::ViaDfdaemon);
+    }
+
+    #[test]
+    fn should_support_custom_suffix_as_virtual_hosted() {
+        let request = classify_request(
+            &ProxyS3 {
+                enable: true,
+                detect_aws_endpoints: false,
+                hosts: Vec::new(),
+                host_suffixes: vec!["storage.example.com".to_string()],
+            },
+            &Method::GET,
+            &"https://bucket.storage.example.com/models/model.bin"
+                .parse()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::GetObject);
+        assert_eq!(request.route, Route::ViaDfdaemon);
+    }
+
+    #[test]
+    fn should_passthrough_bucket_root_requests() {
+        let request = classify_request(
+            &enabled_config(),
+            &Method::GET,
+            &"https://bucket.s3.amazonaws.com/".parse().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(request.operation, Operation::Other);
+        assert_eq!(request.route, Route::Passthrough);
+    }
+}

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -476,6 +476,44 @@ impl Piece {
         hugging_face: Option<HuggingFace>,
         model_scope: Option<ModelScope>,
     ) -> Result<metadata::Piece> {
+        self.download_from_source_with_options(
+            piece_id,
+            task_id,
+            number,
+            url,
+            offset,
+            length,
+            request_header,
+            is_prefetch,
+            false,
+            object_storage,
+            hdfs,
+            hugging_face,
+            model_scope,
+        )
+        .await
+    }
+
+    /// download_from_source_with_options downloads a single piece from the source with
+    /// additional options for auth-preserving request handling.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all, fields(piece_id))]
+    pub async fn download_from_source_with_options(
+        &self,
+        piece_id: &str,
+        task_id: &str,
+        number: u32,
+        url: &str,
+        offset: u64,
+        length: u64,
+        request_header: HeaderMap,
+        is_prefetch: bool,
+        preserve_original_range_for_source: bool,
+        object_storage: Option<ObjectStorage>,
+        hdfs: Option<Hdfs>,
+        hugging_face: Option<HuggingFace>,
+        model_scope: Option<ModelScope>,
+    ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
@@ -537,10 +575,14 @@ impl Piece {
                 task_id: task_id.to_string(),
                 piece_id: piece_id.to_string(),
                 url: url.to_string(),
-                range: Some(Range {
-                    start: offset,
-                    length,
-                }),
+                range: if preserve_original_range_for_source {
+                    None
+                } else {
+                    Some(Range {
+                        start: offset,
+                        length,
+                    })
+                },
                 http_header: Some(request_header),
                 timeout: self.config.download.piece_timeout,
                 client_cert: None,

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -15,9 +15,11 @@
  */
 
 use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
+use crate::proxy::header as proxy_header;
 use crate::resource::parent_selector::ParentSelector;
+use chrono::Utc;
 use dragonfly_api::common::v2::{
-    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, Peer, Piece, Task as CommonTask,
+    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, Peer, Piece, Range, Task as CommonTask,
     TrafficType,
 };
 use dragonfly_api::dfdaemon::{
@@ -180,10 +182,15 @@ impl Task {
                 error!("convert header: {}", err);
             })?;
 
+        let preserve_range_for_stat = proxy_header::get_preserve_range_for_stat(&request_header);
+        request_header.remove(proxy_header::DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER);
+
         // Remove the range header to prevent the server from
         // returning a 206 partial content and returning
         // a 200 full content.
-        request_header.remove(reqwest::header::RANGE);
+        if !preserve_range_for_stat {
+            request_header.remove(reqwest::header::RANGE);
+        }
 
         // Head the url to get the content length.
         let backend = self.backend_factory.build(request.url.as_str())?;
@@ -196,11 +203,12 @@ impl Task {
             backend.scheme().as_str(),
             http::Method::HEAD.as_str(),
         );
+        let request_url = request.url.clone();
         let response = backend
             .stat(StatRequest {
                 task_id: id.to_string(),
-                url: request.url,
-                http_header: Some(request_header),
+                url: request_url.clone(),
+                http_header: Some(request_header.clone()),
                 timeout: self.config.download.piece_timeout,
                 client_cert: None,
                 object_storage: request.object_storage,
@@ -244,17 +252,24 @@ impl Task {
             None => return Err(Error::InvalidContentLength),
         };
 
-        let piece_length = match request.piece_length {
-            Some(piece_length) => self
-                .piece
-                .calculate_piece_length(piece::PieceLengthStrategy::FixedPieceLength(piece_length)),
-            None => {
-                self.piece
-                    .calculate_piece_length(piece::PieceLengthStrategy::OptimizeByFileLength(
-                        content_length,
-                    ))
-            }
-        };
+        let signed_range_covers_content = proxy_header::signed_range_covers_content(
+            &request_header,
+            Some(request_url.as_str()),
+            content_length,
+        );
+        let piece_length =
+            if signed_range_covers_content {
+                content_length
+            } else {
+                match request.piece_length {
+                    Some(piece_length) => self.piece.calculate_piece_length(
+                        piece::PieceLengthStrategy::FixedPieceLength(piece_length),
+                    ),
+                    None => self.piece.calculate_piece_length(
+                        piece::PieceLengthStrategy::OptimizeByFileLength(content_length),
+                    ),
+                }
+            };
 
         // If the task is not finished, check if the storage has enough space to
         // store the task.
@@ -356,17 +371,18 @@ impl Task {
         };
 
         // Calculate the interested pieces to download.
-        let interested_pieces =
-            match self
-                .piece
-                .calculate_interested(piece_length, content_length, request.range)
-            {
-                Ok(interested_pieces) => interested_pieces,
-                Err(err) => {
-                    error!("calculate interested pieces error: {:?}", err);
-                    return Err(err);
-                }
-            };
+        let interested_pieces = match Self::calculate_interested_pieces(
+            &self.piece,
+            piece_length,
+            content_length,
+            &request,
+        ) {
+            Ok(interested_pieces) => interested_pieces,
+            Err(err) => {
+                error!("calculate interested pieces error: {:?}", err);
+                return Err(err);
+            }
+        };
         debug!(
             "interested pieces: {:?}",
             interested_pieces
@@ -1317,9 +1333,13 @@ impl Task {
         let task_id = task.id.as_str();
 
         // Convert the header.
-        let request_header: HeaderMap = (&request.request_header)
+        let mut request_header: HeaderMap = (&request.request_header)
             .try_into()
             .or_err(ErrorType::ParseError)?;
+        request_header.remove(proxy_header::DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER);
+        let preserve_original_range_for_source =
+            proxy_header::get_preserve_original_range_for_source(&request_header);
+        request_header.remove(proxy_header::DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER);
 
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
@@ -1340,6 +1360,7 @@ impl Task {
                 length: u64,
                 request_header: HeaderMap,
                 is_prefetch: bool,
+                preserve_original_range_for_source: bool,
                 need_piece_content: bool,
                 piece_manager: Arc<piece::Piece>,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
@@ -1353,7 +1374,7 @@ impl Task {
                 info!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
-                    .download_from_source(
+                    .download_from_source_with_options(
                         piece_id.as_str(),
                         task_id.as_str(),
                         number,
@@ -1362,6 +1383,7 @@ impl Task {
                         length,
                         request_header,
                         is_prefetch,
+                        preserve_original_range_for_source,
                         object_storage,
                         hdfs,
                         hugging_face,
@@ -1481,6 +1503,7 @@ impl Task {
                         interested_piece.length,
                         request_header,
                         request.is_prefetch,
+                        preserve_original_range_for_source,
                         request.need_piece_content,
                         piece_manager,
                         download_progress_tx,
@@ -1723,9 +1746,13 @@ impl Task {
         let task_id = task.id.as_str();
 
         // Convert the header.
-        let request_header: HeaderMap = (&request.request_header)
+        let mut request_header: HeaderMap = (&request.request_header)
             .try_into()
             .or_err(ErrorType::ParseError)?;
+        request_header.remove(proxy_header::DRAGONFLY_PRESERVE_RANGE_FOR_STAT_HEADER);
+        let preserve_original_range_for_source =
+            proxy_header::get_preserve_original_range_for_source(&request_header);
+        request_header.remove(proxy_header::DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER);
 
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
@@ -1746,6 +1773,7 @@ impl Task {
                 length: u64,
                 request_header: HeaderMap,
                 is_prefetch: bool,
+                preserve_original_range_for_source: bool,
                 need_piece_content: bool,
                 piece_manager: Arc<piece::Piece>,
                 download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
@@ -1758,7 +1786,7 @@ impl Task {
                 info!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
-                    .download_from_source(
+                    .download_from_source_with_options(
                         piece_id.as_str(),
                         task_id.as_str(),
                         number,
@@ -1767,6 +1795,7 @@ impl Task {
                         length,
                         request_header,
                         is_prefetch,
+                        preserve_original_range_for_source,
                         object_storage,
                         hdfs,
                         hugging_face,
@@ -1863,6 +1892,7 @@ impl Task {
                         interested_piece.length,
                         request_header,
                         request.is_prefetch,
+                        preserve_original_range_for_source,
                         request.need_piece_content,
                         piece_manager,
                         download_progress_tx,
@@ -1908,6 +1938,60 @@ impl Task {
         }
 
         return Ok(finished_pieces);
+    }
+
+    fn calculate_interested_pieces(
+        piece_manager: &piece::Piece,
+        piece_length: u64,
+        content_length: u64,
+        request: &Download,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        if Self::should_preserve_original_range_for_source(request) {
+            if let Some(range) = request.range {
+                return Ok(vec![Self::signed_range_piece(range)]);
+            }
+        }
+
+        piece_manager.calculate_interested(piece_length, content_length, request.range)
+    }
+
+    fn should_preserve_original_range_for_source(request: &Download) -> bool {
+        request.request_header.iter().any(|(key, value)| {
+            key.eq_ignore_ascii_case(
+                proxy_header::DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER,
+            ) && value.eq_ignore_ascii_case("true")
+        })
+    }
+
+    fn signed_range_piece(range: Range) -> metadata::Piece {
+        metadata::Piece {
+            number: Self::signed_range_piece_number(&range),
+            offset: range.start,
+            length: range.length,
+            digest: "".to_string(),
+            parent_id: None,
+            uploading_count: 0,
+            uploaded_count: 0,
+            updated_at: Utc::now().naive_utc(),
+            created_at: Utc::now().naive_utc(),
+            finished_at: None,
+        }
+    }
+
+    fn signed_range_piece_number(range: &Range) -> u32 {
+        // Keep signed-range pieces out of the normal sequential piece namespace.
+        let mut hash = 0x811C_9DC5u32;
+        for byte in range
+            .start
+            .to_le_bytes()
+            .into_iter()
+            .chain(range.length.to_le_bytes())
+        {
+            hash ^= byte as u32;
+            hash = hash.wrapping_mul(0x0100_0193);
+        }
+
+        hash | 0x8000_0000
     }
 
     /// stat_task returns the task metadata from scheduler.
@@ -2031,6 +2115,7 @@ impl Task {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -2076,5 +2161,41 @@ mod tests {
         // Verify that the task has been deleted.
         let task = storage.get_task(task_id).unwrap();
         assert!(task.is_none(), "task should be deleted");
+    }
+
+    #[test]
+    fn test_should_preserve_original_range_for_source() {
+        let request = Download {
+            request_header: HashMap::from([(
+                proxy_header::DRAGONFLY_PRESERVE_ORIGINAL_RANGE_FOR_SOURCE_HEADER.to_string(),
+                "true".to_string(),
+            )]),
+            ..Default::default()
+        };
+        assert!(Task::should_preserve_original_range_for_source(&request));
+
+        let request = Download::default();
+        assert!(!Task::should_preserve_original_range_for_source(&request));
+    }
+
+    #[test]
+    fn test_signed_range_piece_uses_original_offset_and_deterministic_number() {
+        let range = Range {
+            start: 5 * 1024 * 1024,
+            length: 5 * 1024 * 1024,
+        };
+
+        let piece = Task::signed_range_piece(range);
+        assert_eq!(piece.offset, range.start);
+        assert_eq!(piece.length, range.length);
+        assert_eq!(piece.number, Task::signed_range_piece_number(&range));
+        assert_ne!(
+            piece.number,
+            Task::signed_range_piece_number(&Range {
+                start: range.start + 1,
+                length: range.length,
+            })
+        );
+        assert_ne!(piece.number & 0x8000_0000, 0);
     }
 }


### PR DESCRIPTION
## Description

Add an S3-aware proxy mode to `dfdaemon` that classifies incoming S3 requests and routes them
accordingly:

- `GetObject` (full and ranged): accelerated through Dragonfly P2P. If the caller's SigV4
  signature explicitly covers the `Range` header, `dfdaemon` preserves that original signed
  `Range` on the source request instead of rewriting it.
- `HeadObject` and `ListObjectsV2`: direct passthrough.
- Other S3 APIs: passthrough, not accelerated.

## Related Issue

https://github.com/dragonflyoss/client/issues/1778

## Motivation and Context

Organizations storing large ML models, datasets, or media files in S3 and distributing them
across many hosts cannot leverage Dragonfly P2P today without rewriting download logic to use
Dragonfly's API directly. With S3-aware proxy mode, those workloads are accelerated transparently:
applications only need to set `HTTPS_PROXY` and trust the proxy CA, no code changes required.

The proxy preserves caller-provided SigV4 headers and presigned URLs end-to-end. `dfdaemon` does
not discover AWS credentials or re-sign origin requests, keeping the security model unchanged.

## Testing

Tested end-to-end against a real S3 object (`s3://bucket-name/test_dragonfly/file.mp4`,
~50 MB) through a locally deployed Dragonfly cluster (manager, scheduler, seed-client, client via
Docker Compose). All tests ran inside the client container with `HTTPS_PROXY` and `AWS_CA_BUNDLE`
configured to route traffic through the patched `dfdaemon`.

**boto3 test matrix** (all passed with correct proxy routing confirmed via `dfdaemon` logs):

| Test | Method | Route |
|---|---|---|
| HeadObject | `s3.head_object()` | passthrough |
| ListObjectsV2 | `s3.list_objects_v2()` | passthrough |
| GetObject (full) | `s3.get_object()` | P2P via dfdaemon |
| GetObject (small range) | `s3.get_object(Range='bytes=0-1023')` | P2P via dfdaemon |
| GetObject (nonzero range) | `s3.get_object(Range='bytes=1048576-2097151')` | P2P via dfdaemon |
| Multipart download | `s3.download_file()` | P2P via dfdaemon |
| Presigned HEAD | presigned URL + HTTP HEAD | passthrough |
| Presigned GET (full) | presigned URL + HTTP GET | P2P via dfdaemon |
| Presigned GET (ranged) | presigned URL + HTTP GET + Range header | P2P via dfdaemon |

**s5cmd tests** (all passed):

| Test | Command | Route |
|---|---|---|
| Default download (full-object signed range) | `s5cmd cp s3://... .` | P2P via dfdaemon |
| Forced multipart (multiple signed partial ranges) | `s5cmd cp --part-size 5 --concurrency 3 s3://... .` | P2P via dfdaemon |

**Presigned URL test**: Tested a regional presigned URL (`bucket-name.s3.us-east-1.amazonaws.com`) for both full GET and ranged GET — both routed correctly.

**Recursive folder download**: `s3://bucket-name/test_dragonfly/` with nested subdirectories — all objects downloaded with correct sizes and routing.

**cargo test**: Passed after fixing unrelated pre-existing doctest failures in `dragonfly-client-util`.
