### PR TITLE
build(ci): add dragonfly-client-util request example to Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -36,6 +36,9 @@ COPY dragonfly-client-metric/src ./dragonfly-client-metric/src
 COPY dragonfly-client-util/Cargo.toml ./dragonfly-client-util/Cargo.toml
 COPY dragonfly-client-util/src ./dragonfly-client-util/src
 
+COPY dragonfly-client-util/examples/request/Cargo.toml ./dragonfly-client-util/examples/request/Cargo.toml
+COPY dragonfly-client-util/examples/request/src ./dragonfly-client-util/examples/request/src
+
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -36,6 +36,9 @@ COPY dragonfly-client-metric/src ./dragonfly-client-metric/src
 COPY dragonfly-client-util/Cargo.toml ./dragonfly-client-util/Cargo.toml
 COPY dragonfly-client-util/src ./dragonfly-client-util/src
 
+COPY dragonfly-client-util/examples/request/Cargo.toml ./dragonfly-client-util/examples/request/Cargo.toml
+COPY dragonfly-client-util/examples/request/src ./dragonfly-client-util/examples/request/src
+
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 

--- a/ci/Dockerfile.dfinit
+++ b/ci/Dockerfile.dfinit
@@ -36,6 +36,9 @@ COPY dragonfly-client-metric/src ./dragonfly-client-metric/src
 COPY dragonfly-client-util/Cargo.toml ./dragonfly-client-util/Cargo.toml
 COPY dragonfly-client-util/src ./dragonfly-client-util/src
 
+COPY dragonfly-client-util/examples/request/Cargo.toml ./dragonfly-client-util/examples/request/Cargo.toml
+COPY dragonfly-client-util/examples/request/src ./dragonfly-client-util/examples/request/src
+
 COPY dragonfly-client-init/Cargo.toml ./dragonfly-client-init/Cargo.toml
 COPY dragonfly-client-init/src ./dragonfly-client-init/src
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Docker build configuration to include the `dragonfly-client-util/examples/request` example in the Docker images. This ensures that the example code and its dependencies are available in the build context for all relevant Dockerfiles.

Docker build context updates:

* Added `COPY` instructions for `dragonfly-client-util/examples/request/Cargo.toml` and its `src` directory to the `ci/Dockerfile`, ensuring the example is included in the production build.
* Added the same `COPY` instructions to `ci/Dockerfile.debug` for the debug build.
* Added the same `COPY` instructions to `ci/Dockerfile.dfinit` for the dfinit build.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
