### PR TITLE
feat: infer upstream registry from containerd ns= query parameter

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -62,6 +62,7 @@ use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument, Instrument, Span};
 
 pub mod header;
+pub mod query;
 
 lazy_static! {
   /// Supported HTTP protocols, including HTTP/1.1 and HTTP/1.0.
@@ -1124,37 +1125,18 @@ async fn proxy_via_https(
     Ok(response.map(|b| b.map_err(ClientError::from).boxed()))
 }
 
-/// get_ns_from_query extracts the `ns` query parameter from the request URI.
-/// Containerd appends `?ns=<registry>` when routing requests through a mirror
-/// (e.g., `GET /v2/library/nginx/manifests/latest?ns=docker.io`).
-fn get_ns_from_query(uri: &http::Uri) -> Option<String> {
-    uri.query().and_then(|query| {
-        url::form_urlencoded::parse(query.as_bytes())
-            .find(|(key, _)| key == "ns")
-            .map(|(_, value)| {
-                let value = value.to_string();
-                if value.contains("://") {
-                    value
-                } else {
-                    format!("https://{}", value)
-                }
-            })
-    })
-}
-
-/// make_registry_mirror_request makes a registry mirror request by the request.
+/// Get a registry mirror request by the request.
+///
+/// Determine the upstream registry address. Fallback order:
+/// 1. `X-Dragonfly-Registry` header (explicit override).
+/// 2. `ns` query parameter (set by containerd when using registry mirrors).
+/// 3. Static config value (proxy.registry_mirror.addr).
 fn make_registry_mirror_request(
     config: Arc<Config>,
     mut request: Request<hyper::body::Incoming>,
 ) -> ClientResult<Request<hyper::body::Incoming>> {
-    let header = request.headers().clone();
-
-    // Determine the upstream registry address. Fallback order:
-    // 1. X-Dragonfly-Registry header (explicit override)
-    // 2. `ns` query parameter (set by containerd when using registry mirrors)
-    // 3. Static config value (proxy.registry_mirror.addr)
-    let upstream_addr = header::get_registry(&header)
-        .or_else(|| get_ns_from_query(request.uri()))
+    let upstream_addr = header::get_registry(request.headers())
+        .or_else(|| query::get_ns_from_query(request.uri()))
         .unwrap_or_else(|| config.proxy.registry_mirror.addr.clone());
 
     let registry_mirror_uri = format!(
@@ -1382,53 +1364,4 @@ fn empty() -> BoxBody<Bytes, ClientError> {
     Empty::<Bytes>::new()
         .map_err(|never| match never {})
         .boxed()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_ns_from_query_with_ns_param() {
-        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=docker.io"
-            .parse()
-            .unwrap();
-        assert_eq!(
-            get_ns_from_query(&uri),
-            Some("https://docker.io".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_ns_from_query_with_scheme() {
-        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=https://registry.example.com"
-            .parse()
-            .unwrap();
-        assert_eq!(
-            get_ns_from_query(&uri),
-            Some("https://registry.example.com".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_ns_from_query_no_ns_param() {
-        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar"
-            .parse()
-            .unwrap();
-        assert_eq!(get_ns_from_query(&uri), None);
-    }
-
-    #[test]
-    fn test_get_ns_from_query_no_query() {
-        let uri: http::Uri = "/v2/library/nginx/manifests/latest".parse().unwrap();
-        assert_eq!(get_ns_from_query(&uri), None);
-    }
-
-    #[test]
-    fn test_get_ns_from_query_multiple_params() {
-        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar&ns=ghcr.io&baz=qux"
-            .parse()
-            .unwrap();
-        assert_eq!(get_ns_from_query(&uri), Some("https://ghcr.io".to_string()));
-    }
 }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1124,37 +1124,50 @@ async fn proxy_via_https(
     Ok(response.map(|b| b.map_err(ClientError::from).boxed()))
 }
 
+/// get_ns_from_query extracts the `ns` query parameter from the request URI.
+/// Containerd appends `?ns=<registry>` when routing requests through a mirror
+/// (e.g., `GET /v2/library/nginx/manifests/latest?ns=docker.io`).
+fn get_ns_from_query(uri: &http::Uri) -> Option<String> {
+    uri.query().and_then(|query| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(key, _)| key == "ns")
+            .map(|(_, value)| {
+                let value = value.to_string();
+                if value.contains("://") {
+                    value
+                } else {
+                    format!("https://{}", value)
+                }
+            })
+    })
+}
+
 /// make_registry_mirror_request makes a registry mirror request by the request.
 fn make_registry_mirror_request(
     config: Arc<Config>,
     mut request: Request<hyper::body::Incoming>,
 ) -> ClientResult<Request<hyper::body::Incoming>> {
     let header = request.headers().clone();
-    let registry_mirror_uri = match header::get_registry(&header) {
-        Some(registry) => format!(
-            "{}{}",
-            registry,
-            request
-                .uri()
-                .path_and_query()
-                .map(|v| v.as_str())
-                .unwrap_or("/")
-        )
-        .parse::<http::Uri>()
-        .or_err(ErrorType::ParseError)?,
-        None => format!(
-            "{}{}",
-            config.proxy.registry_mirror.addr,
-            request
-                .uri()
-                .path_and_query()
-                .map(|v| v.as_str())
-                .unwrap_or("/")
-        )
-        .parse::<http::Uri>()
-        .or_err(ErrorType::ParseError)?,
-    };
-    header::get_registry(&header);
+
+    // Determine the upstream registry address. Fallback order:
+    // 1. X-Dragonfly-Registry header (explicit override)
+    // 2. `ns` query parameter (set by containerd when using registry mirrors)
+    // 3. Static config value (proxy.registry_mirror.addr)
+    let upstream_addr = header::get_registry(&header)
+        .or_else(|| get_ns_from_query(request.uri()))
+        .unwrap_or_else(|| config.proxy.registry_mirror.addr.clone());
+
+    let registry_mirror_uri = format!(
+        "{}{}",
+        upstream_addr,
+        request
+            .uri()
+            .path_and_query()
+            .map(|v| v.as_str())
+            .unwrap_or("/")
+    )
+    .parse::<http::Uri>()
+    .or_err(ErrorType::ParseError)?;
 
     *request.uri_mut() = registry_mirror_uri.clone();
     request.headers_mut().insert(
@@ -1369,4 +1382,53 @@ fn empty() -> BoxBody<Bytes, ClientError> {
     Empty::<Bytes>::new()
         .map_err(|never| match never {})
         .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_ns_from_query_with_ns_param() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=docker.io"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            get_ns_from_query(&uri),
+            Some("https://docker.io".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_ns_from_query_with_scheme() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=https://registry.example.com"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            get_ns_from_query(&uri),
+            Some("https://registry.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_ns_from_query_no_ns_param() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar"
+            .parse()
+            .unwrap();
+        assert_eq!(get_ns_from_query(&uri), None);
+    }
+
+    #[test]
+    fn test_get_ns_from_query_no_query() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest".parse().unwrap();
+        assert_eq!(get_ns_from_query(&uri), None);
+    }
+
+    #[test]
+    fn test_get_ns_from_query_multiple_params() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar&ns=ghcr.io&baz=qux"
+            .parse()
+            .unwrap();
+        assert_eq!(get_ns_from_query(&uri), Some("https://ghcr.io".to_string()));
+    }
 }

--- a/dragonfly-client/src/proxy/query.rs
+++ b/dragonfly-client/src/proxy/query.rs
@@ -1,0 +1,77 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Extracts the `ns` query parameter from the request URI.
+/// Containerd appends `?ns=<registry>` when routing requests through a mirror
+/// (e.g., `GET /v2/library/nginx/manifests/latest?ns=docker.io`).
+pub fn get_ns_from_query(uri: &http::Uri) -> Option<String> {
+    let query = uri.query()?;
+    let (_, value) = url::form_urlencoded::parse(query.as_bytes()).find(|(key, _)| key == "ns")?;
+    if value.contains("://") {
+        Some(value.into_owned())
+    } else {
+        Some(format!("https://{value}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_ns_from_query_with_ns_param() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=docker.io"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            get_ns_from_query(&uri),
+            Some("https://docker.io".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_ns_from_query_with_scheme() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?ns=https://registry.example.com"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            get_ns_from_query(&uri),
+            Some("https://registry.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_ns_from_query_no_ns_param() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar"
+            .parse()
+            .unwrap();
+        assert_eq!(get_ns_from_query(&uri), None);
+    }
+
+    #[test]
+    fn test_get_ns_from_query_no_query() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest".parse().unwrap();
+        assert_eq!(get_ns_from_query(&uri), None);
+    }
+
+    #[test]
+    fn test_get_ns_from_query_multiple_params() {
+        let uri: http::Uri = "/v2/library/nginx/manifests/latest?foo=bar&ns=ghcr.io&baz=qux"
+            .parse()
+            .unwrap();
+        assert_eq!(get_ns_from_query(&uri), Some("https://ghcr.io".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

When containerd uses registry mirrors, it appends a `?ns=<registry>` query parameter to indicate the original upstream registry (e.g., `GET /v2/library/nginx/manifests/latest?ns=docker.io`). Currently, the dfdaemon proxy only checks the `X-Dragonfly-Registry` header and falls back to the static `proxy.registry_mirror.addr` config.

This PR adds support for extracting the `ns` query parameter as a second fallback, making the registry mirror work correctly with containerd's mirror protocol without requiring the `X-Dragonfly-Registry` header to be set.

### Changes

- Added `get_ns_from_query()` helper function that extracts the `ns` query parameter from the request URI and prepends `https://` if no scheme is present
- Refactored `make_registry_mirror_request()` to use a three-level fallback:
  1. `X-Dragonfly-Registry` header (explicit override)
  2. `ns` query parameter (set by containerd when using registry mirrors)
  3. Static config value (`proxy.registry_mirror.addr`)
- Removed a redundant no-op call to `header::get_registry()`
- Added unit tests for the new `get_ns_from_query()` function

### Backward Compatibility

This change is fully backward compatible. Existing header-based and config-based flows are unaffected — the `ns` parameter is only checked when no header is present.

#1791

Signed-off-by: Jamal Allogie <jamal.allogie@gmail.com>