### PR TITLE
refactor: rename `get_persistent_tasks` to `get_persistent_cache_tasks

### DIFF
--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1593,12 +1593,15 @@ impl PersistentCacheTask {
     /// list_local returns the persistent cache tasks from local storage.
     #[instrument(skip_all)]
     pub async fn list_local(&self) -> ClientResult<ListLocalPersistentCacheTasksResponse> {
-        let tasks = self.storage.get_persistent_tasks().inspect_err(|err| {
-            error!(
-                "list persistent cache tasks from local storage error: {:?}",
-                err
-            );
-        })?;
+        let tasks = self
+            .storage
+            .get_persistent_cache_tasks()
+            .inspect_err(|err| {
+                error!(
+                    "list persistent cache tasks from local storage error: {:?}",
+                    err
+                );
+            })?;
 
         let tasks: Vec<StatLocalPersistentCacheTaskResponse> = tasks
             .into_iter()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a small but important fix to the `PersistentCacheTask` implementation, correcting a method call to ensure the correct retrieval of persistent cache tasks from local storage.

- Changed the method call from `get_persistent_tasks()` to `get_persistent_cache_tasks()` in the `list_local` function to accurately fetch persistent cache tasks from local storage.
<!--- Describe your changes in detail -->

## Related Issue
Fixes https://github.com/dragonflyoss/client/issues/1793
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
