### PR TITLE
feat: add proxy_all_registries option to dfinit containerd module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "cgroups-rs",
  "headers 0.4.1",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "dragonfly-client-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.5"
+version = "1.3.6"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -24,14 +24,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.3.5" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.5" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.5" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.5" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.5" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.5" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.5" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.5" }
+dragonfly-client = { path = "dragonfly-client", version = "1.3.6" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.6" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.6" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.6" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.6" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.6" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.6" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.6" }
 dragonfly-api = "=2.2.28"
 thiserror = "2.0"
 futures = "0.3.32"

--- a/dragonfly-client-config/src/dfinit.rs
+++ b/dragonfly-client-config/src/dfinit.rs
@@ -92,7 +92,7 @@ fn default_proxy_addr() -> String {
 /// default_container_runtime_containerd_registry_host_capabilities is the default
 /// capabilities of the containerd registry.
 #[inline]
-fn default_container_runtime_containerd_registry_capabilities() -> Vec<String> {
+pub fn default_container_runtime_containerd_registry_capabilities() -> Vec<String> {
     vec!["pull".to_string(), "resolve".to_string()]
 }
 

--- a/dragonfly-client-config/src/dfinit.rs
+++ b/dragonfly-client-config/src/dfinit.rs
@@ -96,6 +96,13 @@ fn default_container_runtime_containerd_registry_capabilities() -> Vec<String> {
     vec!["pull".to_string(), "resolve".to_string()]
 }
 
+/// default_container_runtime_containerd_proxy_all_registries is the default value of
+/// whether to proxy all registries through dfdaemon via a catch-all `_default/hosts.toml`.
+#[inline]
+fn default_container_runtime_containerd_proxy_all_registries() -> bool {
+    true
+}
+
 /// Registry is the registry configuration for containerd.
 #[derive(Debug, Clone, Default, Validate, Deserialize, Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -126,7 +133,7 @@ pub struct ContainerdRegistry {
 }
 
 /// Containerd is the containerd configuration for dfinit.
-#[derive(Debug, Clone, Default, Validate, Deserialize, Serialize)]
+#[derive(Debug, Clone, Validate, Deserialize, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Containerd {
     /// config_path is the path of containerd configuration file.
@@ -135,6 +142,24 @@ pub struct Containerd {
 
     /// registries is the list of containerd registries.
     pub registries: Vec<ContainerdRegistry>,
+
+    /// proxy_all_registries enables a catch-all `_default/hosts.toml` entry so that any
+    /// registry not explicitly listed in `registries` is still proxied through dfdaemon.
+    /// The dfdaemon infers the upstream registry from the `ns=` query parameter that
+    /// containerd appends when using a `_default` fallback mirror. Explicitly configured
+    /// registries continue to use their own `hosts.toml` and take precedence.
+    #[serde(default = "default_container_runtime_containerd_proxy_all_registries")]
+    pub proxy_all_registries: bool,
+}
+
+impl Default for Containerd {
+    fn default() -> Self {
+        Self {
+            config_path: PathBuf::default(),
+            registries: Vec::default(),
+            proxy_all_registries: default_container_runtime_containerd_proxy_all_registries(),
+        }
+    }
 }
 
 /// CRIORegistry is the registry configuration for cri-o.
@@ -407,7 +432,8 @@ mod tests {
         let expected = r#"
 containerd:
   configPath: ''
-  registries: []"#;
+  registries: []
+  proxyAllRegistries: true"#;
         assert_eq!(expected.trim(), res.trim());
 
         let runtime_cfg = ContainerRuntimeConfig::Docker(Docker {
@@ -450,7 +476,8 @@ proxy:
 containerRuntime:
   containerd:
     configPath: /root/.dragonfly/config/dfinit/yaml
-    registries: []"#;
+    registries: []
+    proxyAllRegistries: true"#;
         assert_eq!(expected.trim(), res.trim());
     }
 

--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -15,7 +15,9 @@
  */
 
 use dragonfly_client::proxy::header::DRAGONFLY_REGISTRY_HEADER;
-use dragonfly_client_config::dfinit::{self, ContainerdRegistry};
+use dragonfly_client_config::dfinit::{
+    self, default_container_runtime_containerd_registry_capabilities, ContainerdRegistry,
+};
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -96,7 +98,7 @@ impl Containerd {
             .await?;
 
             if self.config.proxy_all_registries {
-                self.add_default_mirror(config_path, self.proxy_config.clone())
+                self.add_default_registry(config_path, self.proxy_config.clone())
                     .await?;
             }
 
@@ -133,7 +135,7 @@ impl Containerd {
         .await?;
 
         if self.config.proxy_all_registries {
-            self.add_default_mirror(config_path, self.proxy_config.clone())
+            self.add_default_registry(config_path, self.proxy_config.clone())
                 .await?;
         }
 
@@ -202,14 +204,14 @@ impl Containerd {
         Ok(())
     }
 
-    /// add_default_mirror writes a catch-all `_default/hosts.toml` under the containerd
+    /// add_default_registry writes a catch-all `_default/hosts.toml` under the containerd
     /// config_path so that registries not explicitly listed in `registries` are still
     /// proxied through dfdaemon. The dfdaemon infers the upstream registry from the `ns=`
     /// query parameter that containerd appends when resolving via the `_default` fallback,
     /// so no `X-Dragonfly-Registry` header and no top-level `server` field are set.
     /// Explicitly configured registries keep their own `hosts.toml` and take precedence.
     #[instrument(skip_all)]
-    pub async fn add_default_mirror(
+    pub async fn add_default_registry(
         &self,
         config_path: &str,
         proxy_config: dfinit::Proxy,
@@ -223,8 +225,9 @@ impl Containerd {
         host_config_table.set_implicit(true);
 
         let mut capabilities = Array::default();
-        capabilities.push(Value::from("pull"));
-        capabilities.push(Value::from("resolve"));
+        for capability in default_container_runtime_containerd_registry_capabilities() {
+            capabilities.push(Value::from(capability));
+        }
         host_config_table.insert("capabilities", value(capabilities));
 
         let mut host_table = Table::new();

--- a/dragonfly-client-init/src/container_runtime/containerd.rs
+++ b/dragonfly-client-init/src/container_runtime/containerd.rs
@@ -88,13 +88,19 @@ impl Containerd {
                 config_path.to_string()
             );
 
-            return self
-                .add_registries(
-                    config_path,
-                    self.config.registries.clone(),
-                    self.proxy_config.clone(),
-                )
-                .await;
+            self.add_registries(
+                config_path,
+                self.config.registries.clone(),
+                self.proxy_config.clone(),
+            )
+            .await?;
+
+            if self.config.proxy_all_registries {
+                self.add_default_mirror(config_path, self.proxy_config.clone())
+                    .await?;
+            }
+
+            return Ok(());
         }
 
         // If containerd does not support mirror mode and config_path not set, create a new
@@ -125,6 +131,11 @@ impl Containerd {
             self.proxy_config.clone(),
         )
         .await?;
+
+        if self.config.proxy_all_registries {
+            self.add_default_mirror(config_path, self.proxy_config.clone())
+                .await?;
+        }
 
         Ok(())
     }
@@ -190,6 +201,50 @@ impl Containerd {
 
         Ok(())
     }
+
+    /// add_default_mirror writes a catch-all `_default/hosts.toml` under the containerd
+    /// config_path so that registries not explicitly listed in `registries` are still
+    /// proxied through dfdaemon. The dfdaemon infers the upstream registry from the `ns=`
+    /// query parameter that containerd appends when resolving via the `_default` fallback,
+    /// so no `X-Dragonfly-Registry` header and no top-level `server` field are set.
+    /// Explicitly configured registries keep their own `hosts.toml` and take precedence.
+    #[instrument(skip_all)]
+    pub async fn add_default_mirror(
+        &self,
+        config_path: &str,
+        proxy_config: dfinit::Proxy,
+    ) -> Result<()> {
+        info!(
+            "add _default catch-all mirror pointing at {}",
+            proxy_config.addr
+        );
+
+        let mut host_config_table = Table::new();
+        host_config_table.set_implicit(true);
+
+        let mut capabilities = Array::default();
+        capabilities.push(Value::from("pull"));
+        capabilities.push(Value::from("resolve"));
+        host_config_table.insert("capabilities", value(capabilities));
+
+        let mut host_table = Table::new();
+        host_table.set_implicit(true);
+        host_table.insert(proxy_config.addr.as_str(), Item::Table(host_config_table));
+
+        let mut default_table = toml_edit::DocumentMut::new();
+        default_table.set_implicit(true);
+        default_table.insert("host", Item::Table(host_table));
+
+        let default_config_dir = PathBuf::from(config_path).join("_default");
+        fs::create_dir_all(default_config_dir.as_os_str()).await?;
+        fs::write(
+            default_config_dir.join("hosts.toml").as_os_str(),
+            default_table.to_string().as_bytes(),
+        )
+        .await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -228,6 +283,7 @@ mod tests {
                     ca: Some(vec!["test-ca-cert".into()]),
                     capabilities: vec!["pull".into(), "resolve".into()],
                 }],
+                proxy_all_registries: false,
             },
             dfinit::Proxy {
                 addr: "http://127.0.0.1:65001".into(),
@@ -263,6 +319,94 @@ X-Dragonfly-Registry = "https://registry.example.com"
     }
 
     #[tokio::test]
+    async fn test_containerd_config_with_proxy_all_registries() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        let certs_dir = temp_dir.path().join("certs.d");
+        let certs_dir_str = certs_dir.to_str().unwrap();
+
+        let initial_config = format!(
+            r#"
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "{}"
+"#,
+            certs_dir_str
+        );
+        fs::write(&config_path, initial_config).await.unwrap();
+
+        let containerd = Containerd::new(
+            dfinit::Containerd {
+                config_path: config_path.clone(),
+                registries: vec![ContainerdRegistry {
+                    host_namespace: "docker.io".into(),
+                    server_addr: "https://registry.example.com".into(),
+                    skip_verify: None,
+                    ca: None,
+                    capabilities: vec!["pull".into(), "resolve".into()],
+                }],
+                proxy_all_registries: true,
+            },
+            dfinit::Proxy {
+                addr: "http://127.0.0.1:65001".into(),
+            },
+        );
+
+        let result = containerd.run().await;
+        assert!(result.is_ok(), "containerd.run() failed: {:?}", result);
+
+        // Explicitly configured registry still gets its own hosts.toml with the registry header.
+        let explicit_hosts = fs::read_to_string(certs_dir.join("docker.io").join("hosts.toml"))
+            .await
+            .unwrap();
+        assert!(explicit_hosts.contains("X-Dragonfly-Registry = \"https://registry.example.com\""));
+
+        // _default catch-all is written, without a top-level `server` or X-Dragonfly-Registry
+        // header — dfdaemon infers the upstream from the containerd `ns=` query parameter.
+        let default_hosts = fs::read_to_string(certs_dir.join("_default").join("hosts.toml"))
+            .await
+            .unwrap();
+        let expected = r#"[host."http://127.0.0.1:65001"]
+capabilities = ["pull", "resolve"]
+"#;
+        assert_eq!(default_hosts.trim(), expected.trim());
+    }
+
+    #[tokio::test]
+    async fn test_containerd_config_without_proxy_all_registries() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        let certs_dir = temp_dir.path().join("certs.d");
+        let certs_dir_str = certs_dir.to_str().unwrap();
+
+        let initial_config = format!(
+            r#"
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "{}"
+"#,
+            certs_dir_str
+        );
+        fs::write(&config_path, initial_config).await.unwrap();
+
+        let containerd = Containerd::new(
+            dfinit::Containerd {
+                config_path: config_path.clone(),
+                registries: vec![],
+                proxy_all_registries: false,
+            },
+            dfinit::Proxy {
+                addr: "http://127.0.0.1:65001".into(),
+            },
+        );
+
+        assert!(containerd.run().await.is_ok());
+        assert!(!certs_dir.join("_default").join("hosts.toml").exists());
+    }
+
+    #[tokio::test]
     async fn test_containerd_config_with_v3_config_path() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("config.toml");
@@ -294,6 +438,7 @@ version = 3
                     ca: Some(vec!["test-ca-cert".into()]),
                     capabilities: vec!["pull".into(), "resolve".into()],
                 }],
+                proxy_all_registries: false,
             },
             dfinit::Proxy {
                 addr: "http://127.0.0.1:65001".into(),


### PR DESCRIPTION
Follow-up to #1792 / closes #1791.

## Motivation

Without explicit per-registry configuration, containerd sends all pulls directly to upstream registries, bypassing dfdaemon. Listing every registry in `registries:` ahead of time is impractical in environments where users can pull from arbitrary registries (e.g. Kubernetes clusters with ad-hoc image sources).

Per @gaius-qi's suggestion in #1791, this adds a config option that enables proxying *all* registries through dfdaemon by writing a catch-all `_default/hosts.toml`.

## Changes

- Adds `proxyAllRegistries: bool` to `dfinit::Containerd`, **defaulting to `true`**.
- When enabled, dfinit writes `<config_path>/_default/hosts.toml` pointing at dfdaemon, with `capabilities = ["pull", "resolve"]` and no top-level `server`/`X-Dragonfly-Registry` header — dfdaemon infers the upstream registry from the `ns=` query parameter (support added in #1792).
- Explicitly configured entries in `registries:` still get their own `hosts.toml` under `<host_namespace>/` and take precedence over the `_default` fallback.
- Works for both code paths (`config_path` present in containerd.toml, or injected by dfinit when missing).

## Example rendered config

```toml
# /etc/containerd/certs.d/_default/hosts.toml
[host."http://127.0.0.1:65001"]
capabilities = ["pull", "resolve"]
```

## Tests

Two new unit tests added alongside the existing `test_containerd_config_with_v2/v3_config_path`:

- `test_containerd_config_with_proxy_all_registries` — asserts that both the explicit `docker.io/hosts.toml` (with `X-Dragonfly-Registry` header) and `_default/hosts.toml` (without header or server) are written when `proxy_all_registries: true`.
- `test_containerd_config_without_proxy_all_registries` — asserts `_default/hosts.toml` is absent when disabled.

Existing v2/v3 tests were updated to set `proxy_all_registries: false` to preserve their original assertions.

## Compatibility notes

- Default is `true`, which is a behavior change for existing users on upgrade: installs that today rely on dfinit *not* touching registries outside the configured list will suddenly see all pulls routed through dfdaemon. Operators who need the old behavior can set `proxyAllRegistries: false` in their dfinit YAML. Happy to flip the default to `false` if that's the project preference.

Closes #1791.