### PR TITLE
fix(gc): increase download task timeout from 2 hours to 24 hours

### DIFF
--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -27,8 +27,8 @@ use tokio::sync::mpsc;
 use tracing::{error, info, instrument};
 
 /// Timeout for downloading tasks. Tasks that exceed this timeout will be
-/// garbage collected by disk usage. Default is 2 hours.
-pub const DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(2 * 60 * 60);
+/// garbage collected by disk usage. Default is 24 hours.
+pub const DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Garbage collector for dfdaemon.
 pub struct GC {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a single, straightforward change to the garbage collection behavior in the `dragonfly-client` codebase. The timeout for download tasks before they are considered for garbage collection has been increased from 2 hours to 24 hours.

- Increased the `DOWNLOAD_TASK_TIMEOUT` constant in `gc/mod.rs` from 2 hours to 24 hours, allowing download tasks to persist longer before being garbage collected.
<!--- Describe your changes in detail -->

## Related Issue
Fixes https://github.com/dragonflyoss/client/issues/1815
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
