### PR TITLE
feat(config): add configurable max_retries for backend requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "cgroups-rs",
  "headers 0.4.1",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anyhow",
  "dragonfly-client-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.7"
+version = "1.3.8"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -24,14 +24,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.3.7" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.7" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.7" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.7" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.7" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.7" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.7" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.7" }
+dragonfly-client = { path = "dragonfly-client", version = "1.3.8" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.8" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.8" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.8" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.8" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.8" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.8" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.8" }
 dragonfly-api = "=2.2.28"
 thiserror = "2.0"
 futures = "0.3.32"

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -47,7 +47,7 @@
 
 use crate::{
     Backend, Body, ExistsRequest, GetRequest, GetResponse, PutRequest, PutResponse, StatRequest,
-    StatResponse, DEFAULT_USER_AGENT, KEEP_ALIVE_INTERVAL, MAX_RETRY_TIMES, POOL_MAX_IDLE_PER_HOST,
+    StatResponse, DEFAULT_USER_AGENT, KEEP_ALIVE_INTERVAL, POOL_MAX_IDLE_PER_HOST,
 };
 use async_trait::async_trait;
 use dashmap::{mapref::entry::Entry, DashMap};
@@ -109,6 +109,11 @@ pub struct HTTP {
     /// which will insert to the each request if original header is not already set.
     request_header: Option<HashMap<String, String>>,
 
+    /// The maximum number of retry attempts when a chunk request to the backend
+    /// storage fails. Once this limit is reached, the request will be considered
+    /// failed and an error will be returned.
+    max_retries: u32,
+
     /// Temporary redirects stores 307 redirect url with TTL (LRU eviction).
     temporary_redirects: Arc<Mutex<LruCache<String, TemporaryRedirectEntry>>>,
 
@@ -137,6 +142,7 @@ impl HTTP {
     pub fn new(
         scheme: &str,
         request_header: Option<HashMap<String, String>>,
+        max_retries: u32,
         enable_cache_temporary_redirect: bool,
         cache_temporary_redirect_ttl: Duration,
         enable_hickory_dns: bool,
@@ -182,8 +188,7 @@ impl HTTP {
                 })) // Disable automatic redirects when status is 307.
                 .build()?;
 
-            let retry_policy =
-                ExponentialBackoff::builder().build_with_max_retries(MAX_RETRY_TIMES);
+            let retry_policy = ExponentialBackoff::builder().build_with_max_retries(max_retries);
             let client = ClientBuilder::new(client)
                 .with(TracingMiddleware::default())
                 .with(RetryTransientMiddleware::new_with_policy(retry_policy))
@@ -202,6 +207,7 @@ impl HTTP {
             scheme: scheme.to_string(),
             clients: Arc::new(clients),
             request_header,
+            max_retries,
             temporary_redirects: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(Self::DEFAULT_CACHE_TEMPORARY_REDIRECT_CAPACITY).unwrap(),
             ))),
@@ -264,7 +270,7 @@ impl HTTP {
                     .build()?;
 
                 let retry_policy =
-                    ExponentialBackoff::builder().build_with_max_retries(MAX_RETRY_TIMES);
+                    ExponentialBackoff::builder().build_with_max_retries(self.max_retries);
                 let client = ClientBuilder::new(client)
                     .with(TracingMiddleware::default())
                     .with(RetryTransientMiddleware::new_with_policy(retry_policy))
@@ -995,7 +1001,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .stat(StatRequest {
                 task_id: "test".to_string(),
@@ -1026,7 +1032,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .stat(StatRequest {
                 task_id: "test".to_string(),
@@ -1057,7 +1063,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let mut resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let mut resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .get(GetRequest {
                 task_id: "test".to_string(),
@@ -1082,7 +1088,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_stat_response_with_self_signed_cert() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let resp = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .stat(StatRequest {
                 task_id: "test".to_string(),
@@ -1104,7 +1110,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_return_error_response_when_stat_with_wrong_cert() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let resp = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .stat(StatRequest {
                 task_id: "test".to_string(),
@@ -1125,7 +1131,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_get_response_with_self_signed_cert() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let mut resp = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true)
+        let mut resp = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .get(GetRequest {
                 task_id: "test".to_string(),
@@ -1150,7 +1156,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_return_error_response_when_get_with_wrong_cert() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let resp = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .get(GetRequest {
                 task_id: "test".to_string(),
@@ -1173,7 +1179,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_stat_response_with_no_verifier() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let resp = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .stat(StatRequest {
                 task_id: "test".to_string(),
@@ -1195,7 +1201,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[tokio::test]
     async fn should_get_response_with_no_verifier() {
         let server_addr = start_https_server(SERVER_CERT, SERVER_KEY).await;
-        let http_backend = HTTP::new(HTTPS_SCHEME, None, true, Duration::from_secs(600), true);
+        let http_backend = HTTP::new(HTTPS_SCHEME, None, 1, true, Duration::from_secs(600), true);
         let mut resp = http_backend
             .unwrap()
             .get(GetRequest {
@@ -1230,7 +1236,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .exists(ExistsRequest {
                 task_id: "test".to_string(),
@@ -1261,7 +1267,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .exists(ExistsRequest {
                 task_id: "test".to_string(),
@@ -1292,7 +1298,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let resp = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true)
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
             .unwrap()
             .exists(ExistsRequest {
                 task_id: "test".to_string(),
@@ -1313,7 +1319,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
     #[test]
     fn should_make_request_headers() {
         // Apply default user-agent when not specified.
-        let http = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true).unwrap();
+        let http = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true).unwrap();
         let mut headers = HeaderMap::new();
         http.make_request_headers(&mut headers, None).unwrap();
         assert_eq!(
@@ -1353,6 +1359,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
         let http = HTTP::new(
             HTTP_SCHEME,
             Some(custom_headers),
+            1,
             true,
             Duration::from_secs(600),
             true,
@@ -1396,6 +1403,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
         let http = HTTP::new(
             HTTP_SCHEME,
             Some(custom_headers),
+            1,
             true,
             Duration::from_secs(600),
             true,
@@ -1413,6 +1421,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
         let http = HTTP::new(
             HTTP_SCHEME,
             Some(custom_headers),
+            1,
             true,
             Duration::from_secs(600),
             true,
@@ -1446,7 +1455,8 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .await;
 
         // First request - should store redirect url.
-        let backend = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true).unwrap();
+        let backend =
+            HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true).unwrap();
         let mut response = backend
             .get(GetRequest {
                 task_id: "025a7b4c4615f86617acb34c7ec3404a0a475c2cfaf847ecead944c0bae6277d"
@@ -1510,7 +1520,8 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .mount(&server)
             .await;
 
-        let backend = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(600), true).unwrap();
+        let backend =
+            HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true).unwrap();
 
         // First request - relative Location should NOT be cached.
         let mut response = backend
@@ -1578,7 +1589,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
             .await;
 
         // Use a very short TTL for this test (1 second).
-        let backend = HTTP::new(HTTP_SCHEME, None, true, Duration::from_secs(1), true).unwrap();
+        let backend = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(1), true).unwrap();
 
         // First request - should store redirect url.
         let mut response = backend

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -58,9 +58,6 @@ const HTTP2_STREAM_WINDOW_SIZE: u32 = 16 * 1024 * 1024;
 /// HTTP2_CONNECTION_WINDOW_SIZE is the connection window size for HTTP2 connection.
 const HTTP2_CONNECTION_WINDOW_SIZE: u32 = 16 * 1024 * 1024;
 
-/// MAX_RETRY_TIMES is the max retry times for the request.
-const MAX_RETRY_TIMES: u32 = 1;
-
 /// DEFAULT_USER_AGENT is the default user agent.
 const DEFAULT_USER_AGENT: &str = concat!("dragonfly", "/", env!("CARGO_PKG_VERSION"));
 
@@ -399,6 +396,7 @@ impl BackendFactory {
             Box::new(http::HTTP::new(
                 http::HTTP_SCHEME,
                 self.config.backend.clone().request_header,
+                self.config.backend.clone().max_retries,
                 enable_cache_temporary_redirect,
                 cache_temporary_redirect_ttl,
                 self.config.backend.enable_hickory_dns,
@@ -411,6 +409,7 @@ impl BackendFactory {
             Box::new(http::HTTP::new(
                 http::HTTPS_SCHEME,
                 self.config.backend.clone().request_header,
+                self.config.backend.clone().max_retries,
                 enable_cache_temporary_redirect,
                 cache_temporary_redirect_ttl,
                 self.config.backend.enable_hickory_dns,

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -170,6 +170,12 @@ fn default_download_concurrent_piece_count() -> u32 {
     8
 }
 
+/// default_backend_max_retries is the default max retries for backend request, default is 1.
+#[inline]
+fn default_backend_max_retries() -> u32 {
+    1
+}
+
 /// default_backend_enable_cache_temporary_redirect is the default value for caching temporary redirects.
 #[inline]
 fn default_backend_enable_cache_temporary_redirect() -> bool {
@@ -1511,6 +1517,12 @@ pub struct Backend {
     /// Request header is the request header of backend.
     pub request_header: Option<HashMap<String, String>>,
 
+    /// The maximum number of retry attempts when a chunk request to the backend
+    /// storage fails. Once this limit is reached, the request will be considered
+    /// failed and an error will be returned.
+    #[serde(default = "default_backend_max_retries")]
+    pub max_retries: u32,
+
     /// Enable cache temporary redirect controls whether to cache HTTP 307 (Temporary Redirect) response URLs.
     ///
     /// Motivation: Dragonfly splits a download URL into multiple pieces and performs multiple
@@ -1566,6 +1578,7 @@ impl Default for Backend {
     fn default() -> Self {
         Self {
             request_header: None,
+            max_retries: default_backend_max_retries(),
             enable_cache_temporary_redirect: default_backend_enable_cache_temporary_redirect(),
             cache_temporary_redirect_ttl: default_backend_cache_temporary_redirect_ttl(),
             put_concurrent_chunk_count: default_backend_put_concurrent_chunk_count(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a configurable maximum retry count for backend HTTP requests, replacing the previous hardcoded value. The change allows users to specify how many times a failed backend request should be retried before giving up, improving flexibility and error handling. The new configuration is exposed in the `Backend` struct, with a sensible default, and is wired through the client creation logic.

Configuration and API changes:

* Added a `max_retries` field to the `Backend` struct in `dragonfly-client-config/src/dfdaemon.rs`, including serde support and a default value of 1. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1520-R1525) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1581) [[3]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR173-R178)
* Updated the `HTTP` backend constructor and struct in `dragonfly-client-backend/src/http.rs` to accept and store the `max_retries` parameter, and use it when building retry policies. [[1]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR112-R116) [[2]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR145) [[3]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL185-R191) [[4]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acR210) [[5]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL267-R273)
* Updated `BackendFactory` in `dragonfly-client-backend/src/lib.rs` to pass the configured `max_retries` value when constructing HTTP/HTTPS backends. [[1]](diffhunk://#diff-6acac939bcda338ef32b3d844b2a6dad132f231935dd23bb8eead046b3effe94R399) [[2]](diffhunk://#diff-6acac939bcda338ef32b3d844b2a6dad132f231935dd23bb8eead046b3effe94R412)

Code cleanup:

* Removed the now-unused constant `MAX_RETRY_TIMES` from `dragonfly-client-backend/src/lib.rs`.
* Removed the `MAX_RETRY_TIMES` import from `dragonfly-client-backend/src/http.rs`.

Dependency and versioning:

* Bumped all crate versions from `1.3.7` to `1.3.8` in `Cargo.toml` to reflect the new feature. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R17) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L27-R34)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
