### PR TITLE
fix(proxy): preserve SigV4-signed ranges

### DIFF
--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -56,7 +56,10 @@ use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
 };
-use dragonfly_client_util::tls::NoVerifier;
+use dragonfly_client_util::{
+    http::{get_content_range, signature_bound_range},
+    tls::NoVerifier,
+};
 use futures::{StreamExt, TryStreamExt};
 use http::header::{
     HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_RANGE, LOCATION, RANGE, TRANSFER_ENCODING,
@@ -397,12 +400,14 @@ impl Backend for HTTP {
                 error!("request header is missing");
             })?;
 
+        let preserve_range = signature_bound_range(&request_header, &request.url).is_some();
+
         // Make the custom request headers with "Range: bytes=0-0", so the origin returns
         // 206 Partial Content with the total length in the Content-Range header and a
         // one-byte body, instead of streaming the whole object body for the stat request.
         self.make_request_headers(
             &mut request_header,
-            Some(Range {
+            (!preserve_range).then_some(Range {
                 start: 0,
                 length: 1,
             }),
@@ -502,7 +507,8 @@ impl Backend for HTTP {
             }
             Ok(response)
                 if response.headers().get(TRANSFER_ENCODING).is_some()
-                    && response.headers().get(CONTENT_LENGTH).is_none() =>
+                    && response.headers().get(CONTENT_LENGTH).is_none()
+                    && !preserve_range =>
             {
                 // If the response has Transfer-Encoding header but no Content-Length header,
                 // retry with HEAD request to get the correct Content-Length.
@@ -537,7 +543,10 @@ impl Backend for HTTP {
                     }
                 }
             }
-            Ok(response) if response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE => {
+            Ok(response)
+                if response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE
+                    && !preserve_range =>
+            {
                 // For zero-byte files, some servers return 416 Range Not Satisfiable for
                 // the "bytes=0-0" request. Retry with a GET request without the Range
                 // header to retrieve headers.
@@ -594,14 +603,15 @@ impl Backend for HTTP {
 
         let response_status_code = response.status();
         let mut response_header = response.headers().clone();
+        let content_range = if response_status_code == reqwest::StatusCode::PARTIAL_CONTENT {
+            get_content_range(&response_header).ok().flatten()
+        } else {
+            None
+        };
         let content_length = if response_status_code == reqwest::StatusCode::PARTIAL_CONTENT {
             // The total length of a ranged response is in the Content-Range header,
             // e.g. "bytes 0-0/1048576".
-            let content_length = response_header
-                .get(CONTENT_RANGE)
-                .and_then(|content_range| content_range.to_str().ok())
-                .and_then(|content_range| content_range.rsplit_once('/'))
-                .and_then(|(_, total)| total.parse::<u64>().ok());
+            let content_length = content_range.map(|range| range.complete_length);
 
             if content_length.is_none() {
                 error!(
@@ -610,21 +620,28 @@ impl Backend for HTTP {
                 );
             }
 
-            // Read the one-byte body to completion, so the connection can be reused by
-            // the connection pool instead of being closed with an unread body.
-            if let Err(err) = response.bytes().await {
-                debug!(
-                    "stat request failed to read response body {} {}: {}",
-                    request.task_id, request_url, err
-                );
+            if preserve_range {
+                // A signature-bound range may be large. Do not download it once for
+                // stat and then again for the actual piece request.
+                drop(response);
+            } else {
+                // Read the one-byte body to completion, so the connection can be reused
+                // by the connection pool instead of being closed with an unread body.
+                if let Err(err) = response.bytes().await {
+                    debug!(
+                        "stat request failed to read response body {} {}: {}",
+                        request.task_id, request_url, err
+                    );
+                }
             }
 
-            // Rewrite the 206-shaped headers to look like the full-object response, since
-            // the response header is persisted as the task response header and echoed to
-            // the clients.
-            response_header.remove(CONTENT_RANGE);
-            if let Some(content_length) = content_length {
-                response_header.insert(CONTENT_LENGTH, HeaderValue::from(content_length));
+            if !preserve_range {
+                // Rewrite the one-byte stat response to look like the full-object response,
+                // since these headers are persisted as task response headers.
+                response_header.remove(CONTENT_RANGE);
+                if let Some(content_length) = content_length {
+                    response_header.insert(CONTENT_LENGTH, HeaderValue::from(content_length));
+                }
             }
 
             content_length
@@ -645,7 +662,12 @@ impl Backend for HTTP {
         );
 
         Ok(StatResponse {
-            success: response_status_code.is_success(),
+            success: if preserve_range {
+                response_status_code == reqwest::StatusCode::PARTIAL_CONTENT
+                    && content_range.is_some()
+            } else {
+                response_status_code.is_success()
+            },
             content_length,
             http_header: Some(response_header),
             http_status_code: Some(response_status_code),
@@ -1143,6 +1165,153 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
         let response_header = resp.http_header.unwrap();
         assert!(response_header.get("content-range").is_none());
         assert_eq!(response_header.get("content-length").unwrap(), "1048576");
+    }
+
+    #[tokio::test]
+    async fn should_preserve_signature_bound_range_when_statting() {
+        let server = wiremock::MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stat"))
+            .and(header("range", "bytes=1048576-2097151"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("Content-Range", "bytes 1048576-2097151/4194304")
+                    .insert_header("ETag", "\"version-1\"")
+                    .set_body_bytes(vec![0u8; 1024]),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut request_header = HeaderMap::new();
+        request_header.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=1048576-2097151"),
+        );
+        request_header.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
+            .unwrap()
+            .stat(StatRequest {
+                task_id: "test".to_string(),
+                url: format!("{}/stat", server.uri()),
+                http_header: Some(request_header),
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(resp.success);
+        assert_eq!(resp.content_length, Some(4194304));
+        let response_header = resp.http_header.unwrap();
+        assert_eq!(
+            response_header.get("content-range").unwrap(),
+            "bytes 1048576-2097151/4194304"
+        );
+        assert_eq!(response_header.get("content-length").unwrap(), "1024");
+        assert_eq!(response_header.get("etag").unwrap(), "\"version-1\"");
+    }
+
+    #[tokio::test]
+    async fn should_reject_non_partial_signature_bound_stat_response() {
+        let server = wiremock::MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stat"))
+            .and(header("range", "bytes=1048576-2097151"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Length", "4194304")
+                    .insert_header("ETag", "\"version-1\""),
+            )
+            .mount(&server)
+            .await;
+
+        let mut request_header = HeaderMap::new();
+        request_header.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=1048576-2097151"),
+        );
+        request_header.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
+            .unwrap()
+            .stat(StatRequest {
+                task_id: "test".to_string(),
+                url: format!("{}/stat", server.uri()),
+                http_header: Some(request_header),
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!resp.success);
+        assert_eq!(resp.http_status_code, Some(StatusCode::OK));
+    }
+
+    #[tokio::test]
+    async fn should_reject_malformed_signature_bound_content_range() {
+        let server = wiremock::MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stat"))
+            .and(header("range", "bytes=1048576-2097151"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("Content-Range", "bytes 1048576-2097151/*")
+                    .insert_header("ETag", "\"version-1\""),
+            )
+            .mount(&server)
+            .await;
+
+        let mut request_header = HeaderMap::new();
+        request_header.insert(
+            reqwest::header::RANGE,
+            HeaderValue::from_static("bytes=1048576-2097151"),
+        );
+        request_header.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        let resp = HTTP::new(HTTP_SCHEME, None, 1, true, Duration::from_secs(600), true)
+            .unwrap()
+            .stat(StatRequest {
+                task_id: "test".to_string(),
+                url: format!("{}/stat", server.uri()),
+                http_header: Some(request_header),
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!resp.success);
+        assert_eq!(resp.content_length, None);
     }
 
     #[tokio::test]

--- a/dragonfly-client-util/src/http/mod.rs
+++ b/dragonfly-client-util/src/http/mod.rs
@@ -19,11 +19,21 @@ use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
 };
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use std::collections::HashMap;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_RANGE, RANGE};
+use std::collections::{HashMap, HashSet};
 
 pub mod basic_auth;
 pub mod query_params;
+
+/// A parsed HTTP Content-Range header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContentRange {
+    /// The returned byte range.
+    pub range: Range,
+
+    /// The complete length of the selected representation.
+    pub complete_length: u64,
+}
 
 /// Converts a headermap to a hashmap.
 pub fn headermap_to_hashmap(header: &HeaderMap<HeaderValue>) -> HashMap<String, String> {
@@ -66,6 +76,170 @@ pub fn header_vec_to_headermap(raw_header: Vec<String>) -> Result<HeaderMap> {
     hashmap_to_headermap(&header_vec_to_hashmap(raw_header)?)
 }
 
+/// Returns the Range header when it is covered by an AWS Signature Version 4
+/// Authorization header or presigned URL.
+///
+/// A signature-bound Range must be forwarded unchanged. Replacing it with a
+/// piece range invalidates the request signature.
+pub fn signature_bound_range<'a>(header: &'a HeaderMap, url: &str) -> Option<&'a str> {
+    let range = header.get(RANGE)?.to_str().ok()?;
+    let authorization = header
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+
+    has_signature_bound_range(authorization, url).then_some(range)
+}
+
+/// Returns the Range header from a string map when it is covered by an AWS
+/// Signature Version 4 Authorization header or presigned URL.
+pub fn signature_bound_range_from_hashmap<'a>(
+    header: &'a HashMap<String, String>,
+    url: &str,
+) -> Option<&'a str> {
+    let range = find_header(header, RANGE.as_str())?;
+    let authorization = find_header(header, AUTHORIZATION.as_str());
+
+    has_signature_bound_range(authorization, url).then_some(range)
+}
+
+/// Headers that select which bytes the origin returns for a ranged GET, and so
+/// have to separate one cached range from another.
+///
+/// This is an allow list rather than a deny list. Keying on every signed header
+/// would fold per-request values into the cache key: the AWS SDK for Java and the
+/// Hadoop S3A connector sign `amz-sdk-invocation-id`, which is a fresh UUID for
+/// every call, so such a key would never be reused and every request would store
+/// its own copy of the same bytes.
+const REPRESENTATION_HEADER_NAMES: &[&str] = &[
+    "accept-encoding",
+    "if-match",
+    "if-modified-since",
+    "if-none-match",
+    "if-range",
+    "if-unmodified-since",
+    "x-amz-checksum-mode",
+    "x-amz-server-side-encryption-customer-algorithm",
+    "x-amz-server-side-encryption-customer-key",
+    "x-amz-server-side-encryption-customer-key-md5",
+];
+
+/// Returns a stable cache-key component for a signature-bound range request.
+///
+/// Rotating authentication material is intentionally excluded so independently
+/// authorized callers can share the same cached bytes. Only the range itself and
+/// the headers that change the selected representation take part in the key.
+pub fn signature_bound_range_cache_key_from_hashmap(
+    header: &HashMap<String, String>,
+    url: &str,
+) -> Option<String> {
+    let range = signature_bound_range_from_hashmap(header, url)?;
+    let selected_names: HashSet<&str> = REPRESENTATION_HEADER_NAMES.iter().copied().collect();
+
+    let mut selected_headers: Vec<(String, &str)> = header
+        .iter()
+        .filter_map(|(name, value)| {
+            let name = name.to_ascii_lowercase();
+            selected_names
+                .contains(name.as_str())
+                .then_some((name, value.trim()))
+        })
+        .collect();
+    selected_headers.sort_unstable();
+
+    let mut key = range.to_string();
+    for (name, value) in selected_headers {
+        key.push('\0');
+        key.push_str(&name);
+        key.push(':');
+        key.push_str(value);
+    }
+    Some(key)
+}
+
+/// Returns whether a Range header value asks for exactly one byte range.
+///
+/// RFC 7233 allows a comma-separated set of ranges. A signature-bound Range
+/// cannot be narrowed to the first entry without invalidating the signature, and
+/// dfdaemon has no way to return a `multipart/byteranges` body, so the multi-range
+/// form has to be rejected instead of partially honoured.
+pub fn is_single_byte_range(range_header_value: &str) -> bool {
+    match range_header_value.split_once('=') {
+        Some((unit, spec)) => unit.trim().eq_ignore_ascii_case("bytes") && !spec.contains(','),
+        None => false,
+    }
+}
+
+fn find_header<'a>(header: &'a HashMap<String, String>, name: &str) -> Option<&'a str> {
+    header
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn has_signature_bound_range(authorization: Option<&str>, url: &str) -> bool {
+    authorization.is_some_and(is_range_signed_in_authorization)
+        || is_range_signed_in_presigned_url(url)
+}
+
+fn is_range_signed_in_authorization(authorization: &str) -> bool {
+    let Some((algorithm, parameters)) = authorization.split_once(' ') else {
+        return false;
+    };
+    if !is_aws_v4_algorithm(algorithm) {
+        return false;
+    }
+
+    let mut has_credential = false;
+    let mut has_signature = false;
+    let mut range_is_signed = false;
+    for parameter in parameters.split(',') {
+        let Some((name, value)) = parameter.trim().split_once('=') else {
+            continue;
+        };
+
+        if name.eq_ignore_ascii_case("Credential") {
+            has_credential = !value.is_empty();
+        } else if name.eq_ignore_ascii_case("Signature") {
+            has_signature = !value.is_empty();
+        } else if name.eq_ignore_ascii_case("SignedHeaders") {
+            range_is_signed = signed_headers_contain_range(value);
+        }
+    }
+
+    has_credential && has_signature && range_is_signed
+}
+
+fn is_range_signed_in_presigned_url(url: &str) -> bool {
+    let Ok(url) = url::Url::parse(url) else {
+        return false;
+    };
+
+    let mut has_algorithm = false;
+    let mut has_signature = false;
+    let mut range_is_signed = false;
+    for (name, value) in url.query_pairs() {
+        if name.eq_ignore_ascii_case("X-Amz-Algorithm") {
+            has_algorithm = is_aws_v4_algorithm(&value);
+        } else if name.eq_ignore_ascii_case("X-Amz-Signature") {
+            has_signature = !value.is_empty();
+        } else if name.eq_ignore_ascii_case("X-Amz-SignedHeaders") {
+            range_is_signed = signed_headers_contain_range(&value);
+        }
+    }
+
+    has_algorithm && has_signature && range_is_signed
+}
+
+fn is_aws_v4_algorithm(algorithm: &str) -> bool {
+    matches!(algorithm, "AWS4-HMAC-SHA256" | "AWS4-ECDSA-P256-SHA256")
+}
+
+fn signed_headers_contain_range(signed_headers: &str) -> bool {
+    signed_headers
+        .split(';')
+        .any(|header| header.trim().eq_ignore_ascii_case(RANGE.as_str()))
+}
+
 /// Gets the range from http header.
 pub fn get_range(header: &HeaderMap, content_length: u64) -> Result<Option<Range>> {
     match header.get(reqwest::header::RANGE) {
@@ -77,9 +251,62 @@ pub fn get_range(header: &HeaderMap, content_length: u64) -> Result<Option<Range
     }
 }
 
+/// Parses a Content-Range header in the form `bytes START-END/TOTAL`.
+pub fn parse_content_range_header(content_range: &str) -> Result<ContentRange> {
+    let (unit, value) = content_range
+        .trim()
+        .split_once(' ')
+        .ok_or(Error::InvalidParameter)?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return Err(Error::InvalidParameter);
+    }
+
+    let (range, complete_length) = value.split_once('/').ok_or(Error::InvalidParameter)?;
+    let complete_length = complete_length
+        .parse::<u64>()
+        .or_err(ErrorType::ParseError)?;
+    let (start, end) = range.split_once('-').ok_or(Error::InvalidParameter)?;
+    let start = start.parse::<u64>().or_err(ErrorType::ParseError)?;
+    let end = end.parse::<u64>().or_err(ErrorType::ParseError)?;
+
+    if start > end || end >= complete_length {
+        return Err(Error::InvalidParameter);
+    }
+
+    let length = end
+        .checked_sub(start)
+        .and_then(|length| length.checked_add(1))
+        .ok_or(Error::InvalidParameter)?;
+
+    Ok(ContentRange {
+        range: Range { start, length },
+        complete_length,
+    })
+}
+
+/// Gets and parses Content-Range from a header map.
+pub fn get_content_range(header: &HeaderMap) -> Result<Option<ContentRange>> {
+    header
+        .get(CONTENT_RANGE)
+        .map(|value| {
+            let value = value.to_str().or_err(ErrorType::ParseError)?;
+            parse_content_range_header(value)
+        })
+        .transpose()
+}
+
+/// Gets and parses Content-Range from a string header map.
+pub fn get_content_range_from_hashmap(
+    header: &HashMap<String, String>,
+) -> Result<Option<ContentRange>> {
+    find_header(header, CONTENT_RANGE.as_str())
+        .map(parse_content_range_header)
+        .transpose()
+}
+
 /// Parses a Range header string as per RFC 7233,
 /// supported Range Header: "Range": "bytes=100-200", "Range": "bytes=-50",
-/// "Range": "bytes=150-", "Range": "bytes=0-0,-1".
+/// "Range": "bytes=150-".
 pub fn parse_range_header(range_header_value: &str, content_length: u64) -> Result<Range> {
     let parsed_ranges =
         http_range_header::parse_range_header(range_header_value).or_err(ErrorType::ParseError)?;
@@ -87,10 +314,11 @@ pub fn parse_range_header(range_header_value: &str, content_length: u64) -> Resu
         .validate(content_length)
         .or_err(ErrorType::ParseError)?;
 
-    // Not support multiple ranges.
-    let valid_range = valid_ranges
-        .first()
-        .ok_or_else(|| Error::EmptyHTTPRangeError)?;
+    if valid_ranges.len() != 1 {
+        return Err(Error::InvalidParameter);
+    }
+
+    let valid_range = valid_ranges.first().ok_or(Error::EmptyHTTPRangeError)?;
 
     let start = valid_range.start().to_owned();
     let length = valid_range.end() - start + 1;
@@ -167,5 +395,257 @@ mod tests {
         let range = parse_range_header("bytes=0-100", 200).unwrap();
         assert_eq!(range.start, 0);
         assert_eq!(range.length, 101);
+
+        assert!(parse_range_header("bytes=0-0,-1", 200).is_err());
+    }
+
+    #[test]
+    fn test_parse_content_range_header() {
+        assert_eq!(
+            parse_content_range_header("bytes 100-199/1000").unwrap(),
+            ContentRange {
+                range: Range {
+                    start: 100,
+                    length: 100,
+                },
+                complete_length: 1000,
+            }
+        );
+        assert_eq!(
+            parse_content_range_header("BYTES 0-0/1").unwrap(),
+            ContentRange {
+                range: Range {
+                    start: 0,
+                    length: 1,
+                },
+                complete_length: 1,
+            }
+        );
+
+        for invalid in [
+            "bytes */1000",
+            "bytes 100-99/1000",
+            "bytes 100-100/100",
+            "items 0-0/1",
+            "bytes 0-0/*",
+            "bytes 0/1",
+        ] {
+            assert!(
+                parse_content_range_header(invalid).is_err(),
+                "{invalid} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_signature_bound_range_with_authorization_header() {
+        let mut header = HeaderMap::new();
+        header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range;x-amz-date, Signature=abc",
+            ),
+        );
+
+        assert_eq!(
+            signature_bound_range(&header, "https://example.com/object"),
+            Some("bytes=100-199")
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_cache_key() {
+        let mut header = HashMap::from([
+            ("range".to_string(), "bytes=100-199".to_string()),
+            (
+                "authorization".to_string(),
+                "AWS4-HMAC-SHA256 Credential=first/scope, SignedHeaders=host;range;if-match;x-amz-date;x-amz-content-sha256, Signature=first".to_string(),
+            ),
+            ("if-match".to_string(), "\"version-1\"".to_string()),
+            ("x-amz-date".to_string(), "20260724T000000Z".to_string()),
+            (
+                "x-amz-content-sha256".to_string(),
+                "UNSIGNED-PAYLOAD".to_string(),
+            ),
+        ]);
+        let first =
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap();
+
+        header.insert(
+            "authorization".to_string(),
+            "AWS4-HMAC-SHA256 Credential=second/scope, SignedHeaders=host;range;if-match;x-amz-date;x-amz-content-sha256, Signature=second".to_string(),
+        );
+        header.insert("x-amz-date".to_string(), "20260724T010000Z".to_string());
+        assert_eq!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+
+        header.insert("if-match".to_string(), "\"version-2\"".to_string());
+        assert_ne!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_cache_key_includes_signed_sse_header() {
+        let mut header = HashMap::from([
+            ("range".to_string(), "bytes=100-199".to_string()),
+            (
+                "authorization".to_string(),
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range;x-amz-server-side-encryption-customer-key, Signature=abc".to_string(),
+            ),
+            (
+                "x-amz-server-side-encryption-customer-key".to_string(),
+                "first-key".to_string(),
+            ),
+        ]);
+        let first =
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap();
+        header.insert(
+            "x-amz-server-side-encryption-customer-key".to_string(),
+            "second-key".to_string(),
+        );
+        assert_ne!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_cache_key_ignores_per_request_sdk_headers() {
+        // The AWS SDK for Java and the Hadoop S3A connector sign these, and
+        // amz-sdk-invocation-id is a fresh UUID for every call.
+        let mut header = HashMap::from([
+            ("range".to_string(), "bytes=100-199".to_string()),
+            (
+                "authorization".to_string(),
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;host;range;x-amz-content-sha256;x-amz-date, Signature=abc".to_string(),
+            ),
+            (
+                "amz-sdk-invocation-id".to_string(),
+                "3d6a2f80-1f2e-4f0b-9d0f-2a0f6b1d0c11".to_string(),
+            ),
+            (
+                "amz-sdk-request".to_string(),
+                "attempt=1; max=3".to_string(),
+            ),
+            ("user-agent".to_string(), "aws-sdk-java/2.25.0".to_string()),
+        ]);
+        let first =
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap();
+
+        header.insert(
+            "amz-sdk-invocation-id".to_string(),
+            "8b1c4e55-6d2a-4f77-9e33-5c0b7a2d9f42".to_string(),
+        );
+        header.insert(
+            "amz-sdk-request".to_string(),
+            "attempt=2; max=3".to_string(),
+        );
+        assert_eq!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_is_single_byte_range() {
+        assert!(is_single_byte_range("bytes=0-99"));
+        assert!(is_single_byte_range("bytes=-50"));
+        assert!(is_single_byte_range("bytes=150-"));
+        assert!(is_single_byte_range("BYTES = 0-99"));
+
+        assert!(!is_single_byte_range("bytes=0-99,200-299"));
+        assert!(!is_single_byte_range("bytes=0-0,-1"));
+        assert!(!is_single_byte_range("items=0-99"));
+        assert!(!is_single_byte_range("0-99"));
+    }
+
+    #[test]
+    fn test_signature_bound_range_with_sigv4a_authorization_header() {
+        let mut header = HeaderMap::new();
+        header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-ECDSA-P256-SHA256 Credential=key/scope, SignedHeaders=host;range;x-amz-date, Signature=abc",
+            ),
+        );
+
+        assert_eq!(
+            signature_bound_range(&header, "https://example.com/object"),
+            Some("bytes=100-199")
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_with_presigned_url() {
+        let mut header = HeaderMap::new();
+        header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        let url = "https://example.com/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=abc";
+
+        assert_eq!(signature_bound_range(&header, url), Some("bytes=100-199"));
+    }
+
+    #[test]
+    fn test_signature_bound_range_rejects_incomplete_signatures() {
+        let mut header = HeaderMap::new();
+        header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer SignedHeaders=host;range"),
+        );
+
+        assert_eq!(
+            signature_bound_range(
+                &header,
+                "https://example.com/object?X-Amz-SignedHeaders=host%3Brange"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_requires_range_in_signed_headers() {
+        let mut header = HeaderMap::new();
+        header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;x-amz-date, Signature=abc",
+            ),
+        );
+
+        assert_eq!(
+            signature_bound_range(&header, "https://example.com/object"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_from_hashmap_is_case_insensitive() {
+        let header = HashMap::from([
+            ("Range".to_string(), "bytes=100-199".to_string()),
+            (
+                "Authorization".to_string(),
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc"
+                    .to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            signature_bound_range_from_hashmap(&header, "https://example.com/object"),
+            Some("bytes=100-199")
+        );
     }
 }

--- a/dragonfly-client-util/src/http/mod.rs
+++ b/dragonfly-client-util/src/http/mod.rs
@@ -111,7 +111,9 @@ pub fn signature_bound_range_from_hashmap<'a>(
 /// every call, so such a key would never be reused and every request would store
 /// its own copy of the same bytes.
 const REPRESENTATION_HEADER_NAMES: &[&str] = &[
+    "accept",
     "accept-encoding",
+    "accept-language",
     "if-match",
     "if-modified-since",
     "if-none-match",
@@ -512,6 +514,37 @@ mod tests {
             "x-amz-server-side-encryption-customer-key".to_string(),
             "second-key".to_string(),
         );
+        assert_ne!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_signature_bound_range_cache_key_includes_standard_representation_headers() {
+        let mut header = HashMap::from([
+            ("range".to_string(), "bytes=100-199".to_string()),
+            (
+                "authorization".to_string(),
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=accept;accept-language;host;range, Signature=abc".to_string(),
+            ),
+            ("accept".to_string(), "application/octet-stream".to_string()),
+            ("accept-language".to_string(), "en-US".to_string()),
+        ]);
+        let first =
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap();
+
+        header.insert("accept".to_string(), "application/json".to_string());
+        assert_ne!(
+            first,
+            signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")
+                .unwrap()
+        );
+
+        header.insert("accept".to_string(), "application/octet-stream".to_string());
+        header.insert("accept-language".to_string(), "fr-FR".to_string());
         assert_ne!(
             first,
             signature_bound_range_cache_key_from_hashmap(&header, "https://example.com/object")

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -189,6 +189,22 @@ impl IDGenerator {
         }
     }
 
+    /// Derives a task id for a signature-bound HTTP range from the normal task
+    /// id. This keeps all of the normal task identity inputs while preventing
+    /// differently signed ranges from sharing partial content.
+    #[inline]
+    pub fn range_task_id(&self, task_id: &str, range: &str) -> String {
+        let mut hasher = Sha256::new();
+        // The compact layout is part of the namespace. Earlier unpublished
+        // iterations stored source-coordinate sparse files under a range-derived
+        // ID; those artifacts must never be reused as compact range tasks.
+        hasher.update(b"dragonfly:signature-bound-range:compact:v2\0");
+        hasher.update(task_id.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(range.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
     /// Generates the persistent task id.
     #[inline]
     pub fn persistent_task_id(&self, parameter: PersistentTaskIDParameter) -> Result<String> {
@@ -413,6 +429,22 @@ mod tests {
             let task_id = generator.task_id(parameter).unwrap();
             assert_eq!(task_id, expected_id);
         }
+    }
+
+    #[test]
+    fn should_generate_range_task_id() {
+        let generator = IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false);
+
+        let first = generator.range_task_id("base-task-id", "bytes=0-99");
+        assert_eq!(first, generator.range_task_id("base-task-id", "bytes=0-99"));
+        assert_ne!(
+            first,
+            generator.range_task_id("base-task-id", "bytes=100-199")
+        );
+        assert_ne!(
+            first,
+            generator.range_task_id("other-task-id", "bytes=0-99")
+        );
     }
 
     #[test]

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -18,7 +18,7 @@ use crate::dynconfig::block_list::{DownloadBlockListCheckParams, UploadBlockList
 use crate::dynconfig::Dynconfig;
 use crate::resource::{persistent_cache_task, persistent_task, task};
 use dragonfly_api::common::v2::{
-    CacheTask, PersistentCacheTask, PersistentTask, Priority, Task, TaskType,
+    CacheTask, PersistentCacheTask, PersistentTask, Priority, Range, Task, TaskType,
 };
 use dragonfly_api::dfdaemon::v2::{
     dfdaemon_download_client::DfdaemonDownloadClient as DfdaemonDownloadGRPCClient,
@@ -62,7 +62,10 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
-    http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
+    http::{
+        hashmap_to_headermap, headermap_to_hashmap, parse_range_header,
+        signature_bound_range_cache_key_from_hashmap, signature_bound_range_from_hashmap,
+    },
     id_generator::{PersistentCacheTaskIDParameter, PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
     shutdown,
@@ -342,6 +345,20 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // If concurrent_piece_count is not set in the request, use the default value in the config.
         download.concurrent_piece_count = Some(self.config.download.concurrent_piece_count);
 
+        // A signature-bound Range cannot be removed for a full-object prefetch or
+        // rewritten as a Dragonfly piece range without invalidating AWS SigV4.
+        let signature_bound_range =
+            signature_bound_range_from_hashmap(&download.request_header, &download.url)
+                .map(str::to_owned);
+        let signature_bound_cache_key =
+            signature_bound_range_cache_key_from_hashmap(&download.request_header, &download.url);
+        if signature_bound_range.is_some() {
+            download.prefetch = false;
+            // Parse the authoritative signed header after stat determines the full
+            // object length. Do not allow a separate protobuf range to diverge.
+            download.range = None;
+        }
+
         // Generate the task id.
         let task_id = self
             .task
@@ -372,6 +389,10 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 error!("generate task id: {}", e);
                 Status::invalid_argument(e.to_string())
             })?;
+        let task_id = match signature_bound_cache_key.as_deref() {
+            Some(cache_key) => self.task.id_generator.range_task_id(&task_id, cache_key),
+            None => task_id,
+        };
 
         // Generate the host id.
         let host_id = self.task.id_generator.host_id();
@@ -421,6 +442,10 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                     }
                 }
             }
+            Err(err @ ClientError::Unsupported(_)) => {
+                error!("download started rejected: {}", err);
+                return Err(Status::unimplemented(err.to_string()));
+            }
             Err(err) => {
                 error!("download started failed: {}", err);
                 return Err(Status::internal(err.to_string()));
@@ -448,7 +473,17 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // Download's range priority is higher than the request header's range.
         // If download protocol is http, use the range of the request header.
         // If download protocol is not http, use the range of the download.
-        if download.range.is_none() {
+        if let Some(range_header) = signature_bound_range.as_deref() {
+            let content_range = task::Task::signature_bound_content_range(&task, range_header)
+                .map_err(|err| {
+                    error!("validate signature-bound range failed: {}", err);
+                    Status::failed_precondition(err.to_string())
+                })?;
+            download.range = Some(Range {
+                start: 0,
+                length: content_range.range.length,
+            });
+        } else if download.range.is_none() {
             // Look up the range header directly instead of converting the whole
             // request header hashmap into a HeaderMap.
             let range_header = download
@@ -554,7 +589,13 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                             return;
                         }
 
-                        if download_clone.range.is_none() {
+                        if download_clone.range.is_none()
+                            || signature_bound_range_from_hashmap(
+                                &download_clone.request_header,
+                                &download_clone.url,
+                            )
+                            .is_some()
+                        {
                             if let Some(output_path) = &download_clone.output_path {
                                 if !download_clone.force_hard_link {
                                     let output_path = Path::new(output_path.as_str());

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -17,7 +17,7 @@
 use crate::resource::{persistent_cache_task, persistent_task, task};
 use chrono::DateTime;
 use dragonfly_api::common::v2::{
-    CacheTask, Host, Network, PersistentCacheTask, PersistentTask, Priority, Task, TaskType,
+    CacheTask, Host, Network, PersistentCacheTask, PersistentTask, Priority, Range, Task, TaskType,
 };
 use dragonfly_api::dfdaemon::v2::{
     dfdaemon_upload_client::DfdaemonUploadClient as DfdaemonUploadGRPCClient,
@@ -53,7 +53,10 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
-    http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
+    http::{
+        hashmap_to_headermap, headermap_to_hashmap, parse_range_header,
+        signature_bound_range_cache_key_from_hashmap, signature_bound_range_from_hashmap,
+    },
     id_generator::{PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
     shutdown,
@@ -297,6 +300,20 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         })?;
         download.concurrent_piece_count = Some(self.config.download.concurrent_piece_count);
 
+        // A signature-bound Range cannot be removed for a full-object prefetch or
+        // rewritten as a Dragonfly piece range without invalidating AWS SigV4.
+        let signature_bound_range =
+            signature_bound_range_from_hashmap(&download.request_header, &download.url)
+                .map(str::to_owned);
+        let signature_bound_cache_key =
+            signature_bound_range_cache_key_from_hashmap(&download.request_header, &download.url);
+        if signature_bound_range.is_some() {
+            download.prefetch = false;
+            // Parse the authoritative signed header after stat determines the full
+            // object length. Do not allow a separate protobuf range to diverge.
+            download.range = None;
+        }
+
         // Generate the task id.
         let task_id = self
             .task
@@ -327,6 +344,10 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                 error!("generate task id: {}", e);
                 Status::invalid_argument(e.to_string())
             })?;
+        let task_id = match signature_bound_cache_key.as_deref() {
+            Some(cache_key) => self.task.id_generator.range_task_id(&task_id, cache_key),
+            None => task_id,
+        };
 
         // Generate the host id.
         let host_id = self.task.id_generator.host_id();
@@ -376,6 +397,10 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     }
                 }
             }
+            Err(err @ ClientError::Unsupported(_)) => {
+                error!("download started rejected: {}", err);
+                return Err(Status::unimplemented(err.to_string()));
+            }
             Err(err) => {
                 error!("download started failed: {}", err);
                 return Err(Status::internal(err.to_string()));
@@ -403,7 +428,17 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         // Download's range priority is higher than the request header's range.
         // If download protocol is http, use the range of the request header.
         // If download protocol is not http, use the range of the download.
-        if download.range.is_none() {
+        if let Some(range_header) = signature_bound_range.as_deref() {
+            let content_range = task::Task::signature_bound_content_range(&task, range_header)
+                .map_err(|err| {
+                    error!("validate signature-bound range failed: {}", err);
+                    Status::failed_precondition(err.to_string())
+                })?;
+            download.range = Some(Range {
+                start: 0,
+                length: content_range.range.length,
+            });
+        } else if download.range.is_none() {
             // Look up the range header directly instead of converting the whole
             // request header hashmap into a HeaderMap.
             let range_header = download
@@ -509,7 +544,13 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                             return;
                         }
 
-                        if download_clone.range.is_none() {
+                        if download_clone.range.is_none()
+                            || signature_bound_range_from_hashmap(
+                                &download_clone.request_header,
+                                &download_clone.url,
+                            )
+                            .is_some()
+                        {
                             if let Some(output_path) = &download_clone.output_path {
                                 if !download_clone.force_hard_link {
                                     let output_path = Path::new(output_path.as_str());

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -402,6 +402,22 @@ pub async fn http_handler(
         }
     }
 
+    // If-Range can legitimately turn a ranged request into a full 200 response
+    // when its validator no longer matches. A compact signed-range task cannot
+    // represent that full response, so preserve HTTP semantics by bypassing P2P.
+    if request.method() == Method::GET
+        && should_proxy_signature_bound_if_range_directly(
+            request.headers(),
+            &request.uri().to_string(),
+        )
+    {
+        info!("proxy signed If-Range request directly to remote server");
+        if request.uri().scheme().cloned() == Some(http::uri::Scheme::HTTPS) {
+            return proxy_via_https(request, registry_cert).await;
+        }
+        return proxy_via_http(request).await;
+    }
+
     // If find the matching rule, proxy the request via the dfdaemon.
     // Only GET requests are routed to P2P; other methods (HEAD/PUT/POST/DELETE)
     // fall through to direct proxy to avoid data loss.
@@ -669,6 +685,19 @@ pub async fn upgraded_handler(
             )
             .build()
             .or_err(ErrorType::ParseError)?;
+    }
+
+    // If-Range can legitimately turn a ranged request into a full 200 response
+    // when its validator no longer matches. A compact signed-range task cannot
+    // represent that full response, so preserve HTTP semantics by bypassing P2P.
+    if request.method() == Method::GET
+        && should_proxy_signature_bound_if_range_directly(
+            request.headers(),
+            &request.uri().to_string(),
+        )
+    {
+        info!("proxy signed If-Range request directly to remote server");
+        return proxy_via_https(request, registry_cert).await;
     }
 
     // If find the matching rule, proxy the request via the dfdaemon.
@@ -1345,15 +1374,22 @@ fn need_prefetch(config: &Config, header: &http::HeaderMap, url: &str) -> bool {
     config.proxy.prefetch
 }
 
+/// Returns whether a signed range must bypass compact P2P storage to preserve
+/// the full-response fallback defined by If-Range.
+fn should_proxy_signature_bound_if_range_directly(header: &http::HeaderMap, url: &str) -> bool {
+    header.contains_key(http::header::IF_RANGE) && signature_bound_range(header, url).is_some()
+}
+
 /// Returns the status code to report to the client for a backend failure.
 ///
-/// The origin's status is only reused when it is itself an error. A signature-bound
-/// range whose response fails validation can carry a success status, and replaying
-/// that verbatim tells the client the request succeeded while the body is empty.
+/// Preserve final origin statuses, including conditional and redirect responses.
+/// Successful statuses carried by a validation error are locally rejected and
+/// cannot be replayed with an empty body.
 fn backend_error_status(status_code: Option<http::StatusCode>) -> http::StatusCode {
     match status_code {
-        Some(status) if status.is_client_error() || status.is_server_error() => status,
-        _ => http::StatusCode::BAD_GATEWAY,
+        Some(status) if status.is_success() => http::StatusCode::BAD_GATEWAY,
+        Some(status) => status,
+        None => http::StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 
@@ -1500,10 +1536,14 @@ fn make_error_response(
             response.headers_mut().insert(k, v.clone());
         }
     }
-    response.headers_mut().insert(
-        http::header::CONTENT_LENGTH,
-        http::HeaderValue::from_static("0"),
-    );
+    // A 304 never carries a response body, and Content-Length on a 304 would
+    // describe the selected representation rather than this empty response.
+    if status != http::StatusCode::NOT_MODIFIED {
+        response.headers_mut().insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("0"),
+        );
+    }
 
     // Insert the error type header for client to identify where the error occurred.
     response.headers_mut().insert(
@@ -1589,8 +1629,8 @@ mod tests {
             http::StatusCode::BAD_GATEWAY
         );
 
-        // A rejected response that still carried a success or redirect status must
-        // not be replayed to the client as one.
+        // A rejected response that still carried a success status must not be
+        // replayed to the client as one.
         assert_eq!(
             backend_error_status(Some(http::StatusCode::OK)),
             http::StatusCode::BAD_GATEWAY
@@ -1601,9 +1641,50 @@ mod tests {
         );
         assert_eq!(
             backend_error_status(Some(http::StatusCode::FOUND)),
-            http::StatusCode::BAD_GATEWAY
+            http::StatusCode::FOUND
         );
-        assert_eq!(backend_error_status(None), http::StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::NOT_MODIFIED)),
+            http::StatusCode::NOT_MODIFIED
+        );
+        assert_eq!(
+            backend_error_status(None),
+            http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn test_signed_if_range_bypasses_compact_task() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::RANGE,
+            http::HeaderValue::from_static("bytes=100-199"),
+        );
+        headers.insert(
+            http::header::AUTHORIZATION,
+            http::HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        assert!(!should_proxy_signature_bound_if_range_directly(
+            &headers,
+            "https://example.com/object",
+        ));
+        headers.insert(
+            http::header::IF_RANGE,
+            http::HeaderValue::from_static("\"version-1\""),
+        );
+        assert!(should_proxy_signature_bound_if_range_directly(
+            &headers,
+            "https://example.com/object",
+        ));
+
+        headers.remove(http::header::AUTHORIZATION);
+        assert!(!should_proxy_signature_bound_if_range_directly(
+            &headers,
+            "https://example.com/object",
+        ));
     }
 
     #[test]
@@ -1639,6 +1720,40 @@ mod tests {
         assert_eq!(
             response.headers().get(http::header::RETRY_AFTER),
             Some(&http::HeaderValue::from_static("1"))
+        );
+    }
+
+    #[test]
+    fn test_not_modified_error_response_has_no_body_framing() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("100"),
+        );
+        headers.insert(
+            http::header::TRANSFER_ENCODING,
+            http::HeaderValue::from_static("chunked"),
+        );
+        headers.insert(
+            http::header::ETAG,
+            http::HeaderValue::from_static("\"version-1\""),
+        );
+
+        let response = make_error_response(
+            header::ErrorType::Backend,
+            http::StatusCode::NOT_MODIFIED,
+            Some(headers),
+        );
+        assert_eq!(response.status(), http::StatusCode::NOT_MODIFIED);
+        assert!(!response
+            .headers()
+            .contains_key(http::header::CONTENT_LENGTH));
+        assert!(!response
+            .headers()
+            .contains_key(http::header::TRANSFER_ENCODING));
+        assert_eq!(
+            response.headers().get(http::header::ETAG).unwrap(),
+            "\"version-1\""
         );
     }
 

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1545,7 +1545,8 @@ fn make_error_response(
         );
     }
 
-    // Insert the error type header for client to identify where the error occurred.
+    // Identify where the response originated. Dragonfly clients use this for
+    // non-2xx classification, including final backend statuses such as 304.
     response.headers_mut().insert(
         header::DRAGONFLY_ERROR_TYPE_HEADER,
         error_type.as_str().parse().unwrap(),
@@ -1721,6 +1722,10 @@ mod tests {
             response.headers().get(http::header::RETRY_AFTER),
             Some(&http::HeaderValue::from_static("1"))
         );
+        assert_eq!(
+            response.headers().get(header::DRAGONFLY_ERROR_TYPE_HEADER),
+            Some(&http::HeaderValue::from_static("backend"))
+        );
     }
 
     #[test]
@@ -1754,6 +1759,10 @@ mod tests {
         assert_eq!(
             response.headers().get(http::header::ETAG).unwrap(),
             "\"version-1\""
+        );
+        assert_eq!(
+            response.headers().get(header::DRAGONFLY_ERROR_TYPE_HEADER),
+            Some(&http::HeaderValue::from_static("backend"))
         );
     }
 

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -18,7 +18,7 @@ use crate::dynconfig::Dynconfig;
 use crate::grpc::REQUEST_TIMEOUT;
 use crate::resource::{piece::MIN_PIECE_LENGTH, task::Task};
 use bytes::Bytes;
-use dragonfly_api::common::v2::{Download, TaskType};
+use dragonfly_api::common::v2::{Download, Range, TaskType};
 use dragonfly_api::dfdaemon::v2::{
     download_task_response, DownloadTaskRequest, DownloadTaskStartedResponse,
 };
@@ -31,7 +31,10 @@ use dragonfly_client_metric::{
     collect_proxy_request_via_dfdaemon_metrics,
 };
 use dragonfly_client_util::{
-    http::{hashmap_to_headermap, headermap_to_hashmap},
+    http::{
+        get_content_range_from_hashmap, hashmap_to_headermap, headermap_to_hashmap,
+        signature_bound_range,
+    },
     shutdown,
     tls::{generate_self_signed_certs_by_ca_cert, generate_simple_self_signed_certs, NoVerifier},
 };
@@ -784,9 +787,16 @@ async fn proxy_via_dfdaemon(
             error!("download task failed: {:?}", err);
             return Ok(make_error_response(
                 header::ErrorType::Backend,
-                err.status_code
-                    .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+                backend_error_status(err.status_code),
                 err.header.clone(),
+            ));
+        }
+        Err(err @ ClientError::Unsupported(_)) => {
+            error!("download task rejected: {}", err);
+            return Ok(make_error_response(
+                header::ErrorType::Dfdaemon,
+                http::StatusCode::NOT_IMPLEMENTED,
+                None,
             ));
         }
         Err(err) => {
@@ -895,6 +905,7 @@ async fn proxy_via_dfdaemon(
     } else {
         http::StatusCode::OK
     };
+    let storage_range = storage_range(&download_task_started_response);
 
     // Return the response if the client return the first piece.
     let mut initialized = false;
@@ -971,7 +982,7 @@ async fn proxy_via_dfdaemon(
                                             .as_str(),
                                         message.task_id.as_str(),
                                         piece_length,
-                                        download_task_started_response.range,
+                                        storage_range,
                                     )
                                     .await
                                 {
@@ -1045,10 +1056,12 @@ async fn proxy_via_dfdaemon(
                                     .send_timeout(
                                         Some(make_error_response(
                                             header::ErrorType::Backend,
-                                            http::StatusCode::from_u16(
-                                                backend.status_code.unwrap_or_default() as u16,
-                                            )
-                                            .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+                                            backend_error_status(backend.status_code.and_then(
+                                                |status_code| {
+                                                    http::StatusCode::from_u16(status_code as u16)
+                                                        .ok()
+                                                },
+                                            )),
                                             Some(
                                                 hashmap_to_headermap(&backend.header)
                                                     .unwrap_or_default(),
@@ -1256,9 +1269,11 @@ fn make_download_task_request(
     let mut request_header = headermap_to_hashmap(header);
     request_header.remove(reqwest::header::HOST.as_str());
 
+    let url = make_download_url(request.uri(), rule.use_tls, rule.redirect.as_deref())?;
+
     Ok(DownloadTaskRequest {
         download: Some(Download {
-            url: make_download_url(request.uri(), rule.use_tls, rule.redirect.as_deref())?,
+            url: url.clone(),
             digest: None,
             // Download range use header range in HTTP protocol.
             range: None,
@@ -1278,7 +1293,7 @@ fn make_download_task_request(
             need_back_to_source: false,
             disable_back_to_source: config.proxy.disable_back_to_source,
             certificate_chain: Vec::new(),
-            prefetch: need_prefetch(&config, header),
+            prefetch: need_prefetch(&config, header, &url),
             object_storage: None,
             hdfs: None,
             hugging_face: None,
@@ -1307,9 +1322,16 @@ fn make_download_task_request(
 
 /// Returns whether the prefetch is needed by the configuration and the request
 /// header.
-fn need_prefetch(config: &Config, header: &http::HeaderMap) -> bool {
+fn need_prefetch(config: &Config, header: &http::HeaderMap, url: &str) -> bool {
     // If the header not contains the range header, the request does not need prefetch.
     if !header.contains_key(reqwest::header::RANGE) {
+        return false;
+    }
+
+    // Prefetching drops the Range header to fetch the whole object, which the origin
+    // rejects when the signature covers Range. Nothing can prefetch this request, so
+    // this outranks the X-Dragonfly-Prefetch header below.
+    if signature_bound_range(header, url).is_some() {
         return false;
     }
 
@@ -1321,6 +1343,18 @@ fn need_prefetch(config: &Config, header: &http::HeaderMap) -> bool {
 
     // Return the prefetch value from the configuration.
     config.proxy.prefetch
+}
+
+/// Returns the status code to report to the client for a backend failure.
+///
+/// The origin's status is only reused when it is itself an error. A signature-bound
+/// range whose response fails validation can carry a success status, and replaying
+/// that verbatim tells the client the request succeeded while the body is empty.
+fn backend_error_status(status_code: Option<http::StatusCode>) -> http::StatusCode {
+    match status_code {
+        Some(status) if status.is_client_error() || status.is_server_error() => status,
+        _ => http::StatusCode::BAD_GATEWAY,
+    }
 }
 
 /// Makes a download url by the given uri.
@@ -1357,18 +1391,30 @@ fn make_response_headers(
     // directly, instead of staging them in the hashmap and parsing them again.
     let mut headers = hashmap_to_headermap(&download_task_started_response.response_header)?;
 
-    // Insert the content range header to the response header.
+    // Insert the content range header to the response header. Compact signed-range
+    // tasks already carry the source object's Content-Range, including its complete
+    // length, so preserve that value instead of rebuilding it from compact length.
     if let Some(range) = download_task_started_response.range.as_ref() {
-        headers.insert(
-            reqwest::header::CONTENT_RANGE,
-            hyper::header::HeaderValue::try_from(format!(
-                "bytes {}-{}/{}",
-                range.start,
-                range.start + range.length - 1,
-                download_task_started_response.content_length
-            ))
-            .or_err(ErrorType::ParseError)?,
-        );
+        let has_compact_content_range =
+            get_content_range_from_hashmap(&download_task_started_response.response_header)
+                .ok()
+                .flatten()
+                .is_some_and(|content_range| {
+                    content_range.range == *range
+                        && download_task_started_response.content_length == range.length
+                });
+        if !has_compact_content_range {
+            headers.insert(
+                reqwest::header::CONTENT_RANGE,
+                hyper::header::HeaderValue::try_from(format!(
+                    "bytes {}-{}/{}",
+                    range.start,
+                    range.start + range.length - 1,
+                    download_task_started_response.content_length
+                ))
+                .or_err(ErrorType::ParseError)?,
+            );
+        }
 
         headers.insert(reqwest::header::CONTENT_LENGTH, range.length.into());
     };
@@ -1400,6 +1446,23 @@ fn make_response_headers(
     Ok(headers)
 }
 
+/// Returns the range to apply while reading local task storage. Compact signed-range
+/// tasks store only the selected bytes at offset zero, even though the HTTP response
+/// range remains in source-object coordinates.
+fn storage_range(download_task_started_response: &DownloadTaskStartedResponse) -> Option<Range> {
+    let range = download_task_started_response.range?;
+    let is_compact =
+        get_content_range_from_hashmap(&download_task_started_response.response_header)
+            .ok()
+            .flatten()
+            .is_some_and(|content_range| {
+                content_range.range == range
+                    && download_task_started_response.content_length == range.length
+            });
+
+    (!is_compact).then_some(range)
+}
+
 /// Returns whether the dfdaemon should be used to download the task.
 /// If the dfdaemon should be used, return the matched rule.
 fn find_matching_rule(rules: Option<&[Rule]>, mut url: url::Url) -> Option<&Rule> {
@@ -1420,11 +1483,27 @@ fn make_error_response(
 ) -> Response {
     let mut response = Response::new(empty());
     *response.status_mut() = status;
-    if let Some(header) = header {
+    if let Some(mut header) = header {
+        // The proxy does not forward the backend error body. Do not retain
+        // representation or framing headers that describe that discarded body;
+        // in particular, signed-range validation can turn a 206 into an empty 502.
+        for name in [
+            http::header::CONTENT_ENCODING,
+            http::header::CONTENT_LENGTH,
+            http::header::CONTENT_RANGE,
+            http::header::TRAILER,
+            http::header::TRANSFER_ENCODING,
+        ] {
+            header.remove(name);
+        }
         for (k, v) in header.iter() {
             response.headers_mut().insert(k, v.clone());
         }
     }
+    response.headers_mut().insert(
+        http::header::CONTENT_LENGTH,
+        http::HeaderValue::from_static("0"),
+    );
 
     // Insert the error type header for client to identify where the error occurred.
     response.headers_mut().insert(
@@ -1440,4 +1519,160 @@ fn empty() -> BoxBody<Bytes, ClientError> {
     Empty::<Bytes>::new()
         .map_err(|never| match never {})
         .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compact_signed_range_response_uses_source_coordinates() {
+        let mut started = DownloadTaskStartedResponse {
+            content_length: 100,
+            range: Some(Range {
+                start: 100,
+                length: 100,
+            }),
+            ..Default::default()
+        };
+        started.response_header.insert(
+            "content-range".to_string(),
+            "bytes 100-199/1000".to_string(),
+        );
+
+        assert_eq!(storage_range(&started), None);
+        let headers = make_response_headers(
+            "task-id",
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            &started,
+        )
+        .unwrap();
+        assert_eq!(
+            headers.get(reqwest::header::CONTENT_RANGE).unwrap(),
+            "bytes 100-199/1000"
+        );
+        assert_eq!(headers.get(reqwest::header::CONTENT_LENGTH).unwrap(), "100");
+    }
+
+    #[test]
+    fn test_regular_range_response_uses_storage_range() {
+        let started = DownloadTaskStartedResponse {
+            content_length: 1000,
+            range: Some(Range {
+                start: 100,
+                length: 100,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(storage_range(&started), started.range);
+        let headers = make_response_headers(
+            "task-id",
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            &started,
+        )
+        .unwrap();
+        assert_eq!(
+            headers.get(reqwest::header::CONTENT_RANGE).unwrap(),
+            "bytes 100-199/1000"
+        );
+    }
+
+    #[test]
+    fn test_backend_error_status() {
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::FORBIDDEN)),
+            http::StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::BAD_GATEWAY)),
+            http::StatusCode::BAD_GATEWAY
+        );
+
+        // A rejected response that still carried a success or redirect status must
+        // not be replayed to the client as one.
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::OK)),
+            http::StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::PARTIAL_CONTENT)),
+            http::StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            backend_error_status(Some(http::StatusCode::FOUND)),
+            http::StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(backend_error_status(None), http::StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_error_response_headers_match_empty_body() {
+        let mut headers = http::HeaderMap::new();
+        for (name, value) in [
+            (http::header::CONTENT_LENGTH, "100"),
+            (http::header::CONTENT_RANGE, "bytes 0-99/1000"),
+            (http::header::TRANSFER_ENCODING, "chunked"),
+            (http::header::CONTENT_ENCODING, "gzip"),
+            (http::header::RETRY_AFTER, "1"),
+        ] {
+            headers.insert(name, http::HeaderValue::from_static(value));
+        }
+
+        let response = make_error_response(
+            header::ErrorType::Backend,
+            http::StatusCode::BAD_GATEWAY,
+            Some(headers),
+        );
+
+        assert_eq!(
+            response.headers().get(http::header::CONTENT_LENGTH),
+            Some(&http::HeaderValue::from_static("0"))
+        );
+        for name in [
+            http::header::CONTENT_RANGE,
+            http::header::TRANSFER_ENCODING,
+            http::header::CONTENT_ENCODING,
+        ] {
+            assert!(!response.headers().contains_key(name));
+        }
+        assert_eq!(
+            response.headers().get(http::header::RETRY_AFTER),
+            Some(&http::HeaderValue::from_static("1"))
+        );
+    }
+
+    #[test]
+    fn test_need_prefetch_skips_signature_bound_range() {
+        let config = Arc::new(Config {
+            proxy: dragonfly_client_config::dfdaemon::Proxy {
+                prefetch: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let url = "https://example.com/object";
+
+        let mut header = http::HeaderMap::new();
+        header.insert(
+            reqwest::header::RANGE,
+            http::HeaderValue::from_static("bytes=100-199"),
+        );
+        assert!(need_prefetch(&config, &header, url));
+
+        header.insert(
+            reqwest::header::AUTHORIZATION,
+            http::HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range;x-amz-date, Signature=abc",
+            ),
+        );
+        assert!(!need_prefetch(&config, &header, url));
+
+        // Even an explicit opt-in cannot prefetch a range the signature covers.
+        header.insert(
+            header::DRAGONFLY_PREFETCH_HEADER,
+            http::HeaderValue::from_static("true"),
+        );
+        assert!(!need_prefetch(&config, &header, url));
+    }
 }

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -18,7 +18,7 @@ use crate::dynconfig::block_list::DownloadBlockListCheckParams;
 use crate::dynconfig::Dynconfig;
 use crate::grpc::DOWNLOAD_STREAM_BUFFER_SIZE;
 use crate::resource::task::Task;
-use dragonfly_api::common::v2::TaskType;
+use dragonfly_api::common::v2::{Range, TaskType};
 use dragonfly_api::dfdaemon::v2::{DownloadTaskRequest, DownloadTaskResponse};
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client_config::dfdaemon::Config;
@@ -30,7 +30,10 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::is_blob_url,
-    http::{headermap_to_hashmap, parse_range_header},
+    http::{
+        headermap_to_hashmap, parse_range_header, signature_bound_range_cache_key_from_hashmap,
+        signature_bound_range_from_hashmap,
+    },
     id_generator::TaskIDParameter,
     types::redacted::RedactedDownload,
 };
@@ -83,6 +86,20 @@ pub async fn download(
     // If concurrent_piece_count is not set in the request, use the default value in the config.
     download.concurrent_piece_count = Some(config.download.concurrent_piece_count);
 
+    // A signature-bound Range cannot be removed for a full-object prefetch or
+    // rewritten as a Dragonfly piece range without invalidating AWS SigV4.
+    let signature_bound_range =
+        signature_bound_range_from_hashmap(&download.request_header, &download.url)
+            .map(str::to_owned);
+    let signature_bound_cache_key =
+        signature_bound_range_cache_key_from_hashmap(&download.request_header, &download.url);
+    if signature_bound_range.is_some() {
+        download.prefetch = false;
+        // Parse the authoritative signed header after stat determines the full
+        // object length. Do not allow a separate protobuf range to diverge.
+        download.range = None;
+    }
+
     // Generate the task id.
     let task_id = task_manager
         .id_generator
@@ -111,6 +128,10 @@ pub async fn download(
         .inspect_err(|err| {
             error!("generate task id: {}", err);
         })?;
+    let task_id = match signature_bound_cache_key.as_deref() {
+        Some(cache_key) => task_manager.id_generator.range_task_id(&task_id, cache_key),
+        None => task_id,
+    };
 
     // Generate the host id.
     let host_id = task_manager.id_generator.host_id();
@@ -165,7 +186,13 @@ pub async fn download(
     // Download's range priority is higher than the request header's range.
     // If download protocol is http, use the range of the request header.
     // If download protocol is not http, use the range of the download.
-    if download.range.is_none() {
+    if let Some(range_header) = signature_bound_range.as_deref() {
+        let content_range = Task::signature_bound_content_range(&task, range_header)?;
+        download.range = Some(Range {
+            start: 0,
+            length: content_range.range.length,
+        });
+    } else if download.range.is_none() {
         // Look up the range header directly instead of converting the whole
         // request header hashmap into a HeaderMap.
         let range_header = download

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -653,7 +653,10 @@ impl Piece {
         let invalid_response = |message: &str| {
             Error::BackendError(Box::new(BackendError {
                 message: message.to_string(),
-                status_code: actual_status,
+                // This is a locally synthesized validation failure, not the
+                // origin's response status. Never expose an empty successful
+                // response when the bytes were rejected before caching.
+                status_code: Some(reqwest::StatusCode::BAD_GATEWAY),
                 header: actual_header.cloned(),
             }))
         };
@@ -1424,14 +1427,20 @@ mod tests {
         )
         .is_ok());
 
-        assert!(Piece::validate_signature_bound_response(
+        let err = Piece::validate_signature_bound_response(
             &request_header,
             "https://example.com/object",
             Some(&expected_header),
             Some(reqwest::StatusCode::OK),
             Some(&actual_header),
         )
-        .is_err());
+        .unwrap_err();
+        match err {
+            Error::BackendError(err) => {
+                assert_eq!(err.status_code, Some(reqwest::StatusCode::BAD_GATEWAY));
+            }
+            err => panic!("expected backend error, got {err:?}"),
+        }
 
         let mut mismatched = actual_header.clone();
         mismatched.insert(

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -25,9 +25,12 @@ use dragonfly_client_metric::{
     collect_backend_request_started_metrics, collect_download_piece_traffic_metrics,
 };
 use dragonfly_client_storage::{io::RangeReader, metadata, Storage};
-use dragonfly_client_util::net::format_socket_addr;
+use dragonfly_client_util::{
+    http::{get_content_range, signature_bound_range},
+    net::format_socket_addr,
+};
 use leaky_bucket::RateLimiter;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, CONTENT_LENGTH, ETAG};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -47,6 +50,15 @@ pub const MIN_PIECE_LENGTH: u64 = 4 * 1024 * 1024;
 
 /// The maximum piece length.
 pub const MAX_PIECE_LENGTH: u64 = 64 * 1024 * 1024;
+
+/// The maximum length of a signature-bound range.
+///
+/// Such a range is signed by the caller and has to reach the origin unchanged, so it
+/// cannot be divided into `MAX_PIECE_LENGTH` pieces and is stored as one piece
+/// instead. This bounds that piece. The limit is well above the part sizes that S3
+/// clients use for ranged reads, so it only rejects requests that would otherwise
+/// make a single peer-to-peer transfer unit arbitrarily large.
+pub const MAX_SIGNATURE_BOUND_RANGE_LENGTH: u64 = 1024 * 1024 * 1024;
 
 /// Sets the optimization strategy of piece length.
 pub enum PieceLengthStrategy {
@@ -472,6 +484,7 @@ impl Piece {
         offset: u64,
         length: u64,
         request_header: HeaderMap,
+        expected_response_header: Option<HeaderMap>,
         is_prefetch: bool,
         object_storage: Option<ObjectStorage>,
         hdfs: Option<Hdfs>,
@@ -532,16 +545,15 @@ impl Piece {
             http::Method::GET.as_str(),
         );
 
+        let range = Self::source_request_range(&request_header, url, offset, length);
+
         let mut response = backend
             .get(GetRequest {
                 task_id: task_id.to_string(),
                 piece_id: piece_id.to_string(),
                 url: url.to_string(),
-                range: Some(Range {
-                    start: offset,
-                    length,
-                }),
-                http_header: Some(request_header),
+                range,
+                http_header: Some(request_header.clone()),
                 timeout: self.config.download.piece_timeout,
                 client_cert: None,
                 object_storage,
@@ -586,6 +598,14 @@ impl Piece {
             })));
         }
 
+        Self::validate_signature_bound_response(
+            &request_header,
+            url,
+            expected_response_header.as_ref(),
+            response.http_status_code,
+            response.http_header.as_ref(),
+        )?;
+
         // Collect the backend request finished metrics.
         collect_backend_request_finished_metrics(
             backend.scheme().as_str(),
@@ -616,6 +636,94 @@ impl Piece {
                 error!("download piece finished: {}", err);
                 Err(err)
             }
+        }
+    }
+
+    fn validate_signature_bound_response(
+        request_header: &HeaderMap,
+        url: &str,
+        expected_header: Option<&HeaderMap>,
+        actual_status: Option<reqwest::StatusCode>,
+        actual_header: Option<&HeaderMap>,
+    ) -> Result<()> {
+        if signature_bound_range(request_header, url).is_none() {
+            return Ok(());
+        }
+
+        let invalid_response = |message: &str| {
+            Error::BackendError(Box::new(BackendError {
+                message: message.to_string(),
+                status_code: actual_status,
+                header: actual_header.cloned(),
+            }))
+        };
+        let expected_header = expected_header
+            .ok_or_else(|| invalid_response("missing signed-range stat response headers"))?;
+        let actual_header =
+            actual_header.ok_or_else(|| invalid_response("missing signed-range GET headers"))?;
+        if actual_status != Some(reqwest::StatusCode::PARTIAL_CONTENT) {
+            return Err(invalid_response(
+                "signed-range GET did not return 206 Partial Content",
+            ));
+        }
+
+        let expected_content_range = get_content_range(expected_header)
+            .ok()
+            .flatten()
+            .ok_or_else(|| invalid_response("invalid signed-range stat Content-Range"))?;
+        let actual_content_range = get_content_range(actual_header)
+            .ok()
+            .flatten()
+            .ok_or_else(|| invalid_response("invalid signed-range GET Content-Range"))?;
+        if actual_content_range != expected_content_range {
+            return Err(invalid_response(
+                "signed-range stat and GET Content-Range differ",
+            ));
+        }
+
+        let actual_content_length = actual_header
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok());
+        if actual_content_length != Some(expected_content_range.range.length) {
+            return Err(invalid_response(
+                "signed-range GET Content-Length does not match Content-Range",
+            ));
+        }
+
+        let expected_etag = expected_header
+            .get(ETAG)
+            .ok_or_else(|| invalid_response("missing signed-range stat ETag"))?;
+        if actual_header.get(ETAG) != Some(expected_etag) {
+            return Err(invalid_response("signed-range stat and GET ETag differ"));
+        }
+
+        if let Some(expected_version) = expected_header.get("x-amz-version-id") {
+            if actual_header.get("x-amz-version-id") != Some(expected_version) {
+                return Err(invalid_response(
+                    "signed-range stat and GET version ID differ",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn source_request_range(
+        request_header: &HeaderMap,
+        url: &str,
+        offset: u64,
+        length: u64,
+    ) -> Option<Range> {
+        if signature_bound_range(request_header, url).is_some() {
+            // Keep the caller's Range header unchanged because it is covered by
+            // the AWS signature.
+            None
+        } else {
+            Some(Range {
+                start: offset,
+                length,
+            })
         }
     }
 
@@ -1154,6 +1262,7 @@ impl Piece {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_RANGE, ETAG, RANGE};
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -1254,5 +1363,124 @@ mod tests {
             assert_eq!(last_piece.offset, expected_last_piece_offset);
             assert_eq!(last_piece.length, expected_last_piece_length);
         }
+    }
+
+    #[test]
+    fn test_source_request_range_preserves_signature_bound_header() {
+        let mut request_header = HeaderMap::new();
+        request_header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        request_header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        assert_eq!(
+            Piece::source_request_range(&request_header, "https://example.com/object", 0, 1024,),
+            None
+        );
+
+        request_header.remove(AUTHORIZATION);
+        assert_eq!(
+            Piece::source_request_range(&request_header, "https://example.com/object", 0, 1024,),
+            Some(Range {
+                start: 0,
+                length: 1024,
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_signature_bound_response() {
+        let mut request_header = HeaderMap::new();
+        request_header.insert(RANGE, HeaderValue::from_static("bytes=100-199"));
+        request_header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc",
+            ),
+        );
+
+        let mut expected_header = HeaderMap::new();
+        expected_header.insert(
+            CONTENT_RANGE,
+            HeaderValue::from_static("bytes 100-199/1000"),
+        );
+        expected_header.insert(ETAG, HeaderValue::from_static("\"version-1\""));
+        expected_header.insert(
+            "x-amz-version-id",
+            HeaderValue::from_static("source-version-1"),
+        );
+
+        let mut actual_header = expected_header.clone();
+        actual_header.insert(CONTENT_LENGTH, HeaderValue::from_static("100"));
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::PARTIAL_CONTENT),
+            Some(&actual_header),
+        )
+        .is_ok());
+
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::OK),
+            Some(&actual_header),
+        )
+        .is_err());
+
+        let mut mismatched = actual_header.clone();
+        mismatched.insert(
+            CONTENT_RANGE,
+            HeaderValue::from_static("bytes 101-200/1000"),
+        );
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::PARTIAL_CONTENT),
+            Some(&mismatched),
+        )
+        .is_err());
+
+        let mut mismatched = actual_header.clone();
+        mismatched.insert(CONTENT_LENGTH, HeaderValue::from_static("99"));
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::PARTIAL_CONTENT),
+            Some(&mismatched),
+        )
+        .is_err());
+
+        let mut mismatched = actual_header.clone();
+        mismatched.insert(ETAG, HeaderValue::from_static("\"version-2\""));
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::PARTIAL_CONTENT),
+            Some(&mismatched),
+        )
+        .is_err());
+
+        let mut mismatched = actual_header;
+        mismatched.insert(
+            "x-amz-version-id",
+            HeaderValue::from_static("source-version-2"),
+        );
+        assert!(Piece::validate_signature_bound_response(
+            &request_header,
+            "https://example.com/object",
+            Some(&expected_header),
+            Some(reqwest::StatusCode::PARTIAL_CONTENT),
+            Some(&mismatched),
+        )
+        .is_err());
     }
 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -48,7 +48,11 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_storage::{metadata, Storage};
 use dragonfly_client_util::{
-    http::{hashmap_to_headermap, headermap_to_hashmap},
+    http::{
+        get_content_range, get_content_range_from_hashmap, hashmap_to_headermap,
+        headermap_to_hashmap, is_single_byte_range, parse_range_header, signature_bound_range,
+        signature_bound_range_from_hashmap, ContentRange,
+    },
     id_generator::IDGenerator,
     shutdown,
 };
@@ -155,7 +159,24 @@ impl Task {
         id: &str,
         request: Download,
     ) -> ClientResult<metadata::Task> {
+        let signed_range =
+            signature_bound_range_from_hashmap(&request.request_header, &request.url)
+                .map(str::to_owned);
+
+        // A task holds one contiguous range and there is no way to emit a
+        // multipart/byteranges body, so a signature-bound multi-range has no
+        // representation here. Reject it before stat forwards the signed header
+        // unchanged; leave existing unsigned-range behavior alone.
+        if let Some(range_header) = signed_range.as_deref() {
+            if !is_single_byte_range(range_header) {
+                return Err(Error::Unsupported(format!(
+                    "multi-range request {range_header}"
+                )));
+            }
+        }
+
         let (task, reused) = self.storage.prepare_download_task(id)?;
+
         if reused {
             // Attempt to create a hard link from the task file to the output path.
             //
@@ -187,10 +208,14 @@ impl Task {
                 error!("convert header: {}", err);
             })?;
 
+        let preserve_range = signed_range.is_some();
+
         // Remove the range header to prevent the server from
         // returning a 206 partial content and returning
         // a 200 full content.
-        request_header.remove(reqwest::header::RANGE);
+        if !preserve_range {
+            request_header.remove(reqwest::header::RANGE);
+        }
 
         // Head the url to get the content length.
         let backend = self.backend_factory.build(request.url.as_str())?;
@@ -246,22 +271,59 @@ impl Task {
             start_time.elapsed(),
         );
 
-        let content_length = match response.content_length {
+        let source_content_length = match response.content_length {
             Some(content_length) => content_length,
             None => return Err(Error::InvalidContentLength),
         };
 
-        let piece_length = match request.piece_length {
-            Some(piece_length) => self
-                .piece
-                .calculate_piece_length(piece::PieceLengthStrategy::FixedPieceLength(piece_length)),
-            None => {
-                self.piece
-                    .calculate_piece_length(piece::PieceLengthStrategy::OptimizeByFileLength(
-                        content_length,
-                    ))
+        let content_length = if let Some(signed_range) = signed_range.as_deref() {
+            let response_header = response
+                .http_header
+                .as_ref()
+                .ok_or(Error::InvalidParameter)?;
+            let content_range =
+                get_content_range(response_header)?.ok_or(Error::InvalidParameter)?;
+            let requested_range = parse_range_header(signed_range, content_range.complete_length)?;
+
+            if content_range.complete_length != source_content_length
+                || content_range.range != requested_range
+                || response_header.get(reqwest::header::ETAG).is_none()
+            {
+                return Err(Error::InvalidParameter);
             }
+
+            // The origin has to receive the signed Range verbatim, so the range cannot
+            // be split across pieces and becomes a single piece below. Bound it here,
+            // because the piece is the unit of peer-to-peer transfer and of the
+            // in-memory copy taken when a caller asks for piece content.
+            if content_range.range.length > piece::MAX_SIGNATURE_BOUND_RANGE_LENGTH {
+                return Err(Error::Unsupported(format!(
+                    "signature-bound range of {} bytes exceeds the maximum of {} bytes",
+                    content_range.range.length,
+                    piece::MAX_SIGNATURE_BOUND_RANGE_LENGTH
+                )));
+            }
+
+            content_range.range.length
+        } else {
+            source_content_length
         };
+
+        let piece_length =
+            if preserve_range {
+                // The origin must receive the signature-bound Range exactly once. Keep it
+                // as one compact local piece whose offset starts at zero.
+                content_length
+            } else {
+                match request.piece_length {
+                    Some(piece_length) => self.piece.calculate_piece_length(
+                        piece::PieceLengthStrategy::FixedPieceLength(piece_length),
+                    ),
+                    None => self.piece.calculate_piece_length(
+                        piece::PieceLengthStrategy::OptimizeByFileLength(content_length),
+                    ),
+                }
+            };
 
         // If the task is not finished, check if the storage has enough space to
         // store the task.
@@ -298,6 +360,29 @@ impl Task {
         }
 
         task
+    }
+
+    /// Resolves and validates a signed source range from compact task metadata.
+    pub(crate) fn signature_bound_content_range(
+        task: &metadata::Task,
+        range_header: &str,
+    ) -> ClientResult<ContentRange> {
+        let content_range = get_content_range_from_hashmap(&task.response_header)?
+            .ok_or(Error::InvalidParameter)?;
+        let requested_range = parse_range_header(range_header, content_range.complete_length)?;
+
+        if requested_range != content_range.range
+            || task.content_length() != Some(content_range.range.length)
+            || task.piece_length() != Some(content_range.range.length)
+            || !task
+                .response_header
+                .keys()
+                .any(|name| name.eq_ignore_ascii_case(reqwest::header::ETAG.as_str()))
+        {
+            return Err(Error::InvalidParameter);
+        }
+
+        Ok(content_range)
     }
 
     /// Updates the metadata of the task when the task downloads finished.
@@ -399,6 +484,12 @@ impl Task {
             });
         }
 
+        let response_range =
+            match signature_bound_range_from_hashmap(&request.request_header, &request.url) {
+                Some(range) => Some(Self::signature_bound_content_range(task, range)?.range),
+                None => request.range,
+            };
+
         // Send the download task started request.
         download_progress_tx
             .send_timeout(
@@ -410,7 +501,7 @@ impl Task {
                         download_task_response::Response::DownloadTaskStartedResponse(
                             dfdaemon::v2::DownloadTaskStartedResponse {
                                 content_length,
-                                range: request.range,
+                                range: response_range,
                                 response_header: task.response_header.clone(),
                                 pieces,
                                 is_finished: task.is_finished(),
@@ -512,10 +603,7 @@ impl Task {
         // If the range length is less than or equal to the min piece
         // length, download the pieces from the source directly.
         if !request.disable_back_to_source
-            && (request
-                .range
-                .is_some_and(|range| range.length <= super::piece::MIN_PIECE_LENGTH)
-                || content_length <= super::piece::MIN_PIECE_LENGTH)
+            && Self::should_download_directly_from_source(&request, content_length)
         {
             debug!("peer downloads the range task from source directly, skipping the scheduler");
 
@@ -1591,6 +1679,12 @@ impl Task {
         let request_header: HeaderMap = (&request.request_header)
             .try_into()
             .or_err(ErrorType::ParseError)?;
+        let expected_response_header =
+            if signature_bound_range(&request_header, &request.url).is_some() {
+                Some(hashmap_to_headermap(&task.response_header)?)
+            } else {
+                None
+            };
 
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
@@ -1610,6 +1704,7 @@ impl Task {
                 offset: u64,
                 length: u64,
                 request_header: HeaderMap,
+                expected_response_header: Option<HeaderMap>,
                 is_prefetch: bool,
                 need_piece_content: bool,
                 piece_manager: Arc<piece::Piece>,
@@ -1632,6 +1727,7 @@ impl Task {
                         offset,
                         length,
                         request_header,
+                        expected_response_header,
                         is_prefetch,
                         object_storage,
                         hdfs,
@@ -1755,6 +1851,7 @@ impl Task {
             let peer_id = peer_id.to_string();
             let url = request.url.clone();
             let request_header = request_header.clone();
+            let expected_response_header = expected_response_header.clone();
             let piece_manager = self.piece.clone();
             let download_progress_tx = download_progress_tx.clone();
             let in_stream_tx = in_stream_tx.clone();
@@ -1775,6 +1872,7 @@ impl Task {
                         interested_piece.offset,
                         interested_piece.length,
                         request_header,
+                        expected_response_header,
                         request.is_prefetch,
                         request.need_piece_content,
                         piece_manager,
@@ -2160,6 +2258,12 @@ impl Task {
         let request_header: HeaderMap = (&request.request_header)
             .try_into()
             .or_err(ErrorType::ParseError)?;
+        let expected_response_header =
+            if signature_bound_range(&request_header, &request.url).is_some() {
+                Some(hashmap_to_headermap(&task.response_header)?)
+            } else {
+                None
+            };
 
         // Initialize the finished pieces.
         let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
@@ -2179,6 +2283,7 @@ impl Task {
                 offset: u64,
                 length: u64,
                 request_header: HeaderMap,
+                expected_response_header: Option<HeaderMap>,
                 is_prefetch: bool,
                 need_piece_content: bool,
                 piece_manager: Arc<piece::Piece>,
@@ -2200,6 +2305,7 @@ impl Task {
                         offset,
                         length,
                         request_header,
+                        expected_response_header,
                         is_prefetch,
                         object_storage,
                         hdfs,
@@ -2302,6 +2408,7 @@ impl Task {
             let peer_id = peer_id.to_string();
             let url = request.url.clone();
             let request_header = request_header.clone();
+            let expected_response_header = expected_response_header.clone();
             let piece_manager = self.piece.clone();
             let download_progress_tx = download_progress_tx.clone();
             let object_storage = request.object_storage.clone();
@@ -2321,6 +2428,7 @@ impl Task {
                         interested_piece.offset,
                         interested_piece.length,
                         request_header,
+                        expected_response_header,
                         request.is_prefetch,
                         request.need_piece_content,
                         piece_manager,
@@ -2367,6 +2475,19 @@ impl Task {
         }
 
         return Ok(finished_pieces);
+    }
+
+    fn should_download_directly_from_source(request: &Download, content_length: u64) -> bool {
+        if signature_bound_range_from_hashmap(&request.request_header, &request.url).is_some() {
+            // Even small signed ranges need to enter the scheduler so another peer can
+            // serve the compact cached piece.
+            return false;
+        }
+
+        request
+            .range
+            .is_some_and(|range| range.length <= super::piece::MIN_PIECE_LENGTH)
+            || content_length <= super::piece::MIN_PIECE_LENGTH
     }
 
     /// Returns the task metadata from scheduler.
@@ -2490,6 +2611,7 @@ impl Task {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dragonfly_api::common::v2::Range;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -2523,5 +2645,57 @@ mod tests {
         storage.delete_task(task_id).await;
         let task = storage.get_task(task_id).unwrap();
         assert!(task.is_none(), "task should be deleted");
+    }
+
+    #[test]
+    fn test_signature_bound_content_range() {
+        let mut task = metadata::Task {
+            piece_length: Some(5),
+            content_length: Some(5),
+            ..Default::default()
+        };
+        task.response_header
+            .insert("content-range".to_string(), "bytes 5-9/100".to_string());
+        task.response_header
+            .insert("etag".to_string(), "\"version-1\"".to_string());
+
+        let content_range = Task::signature_bound_content_range(&task, "bytes=5-9").unwrap();
+        assert_eq!(
+            content_range,
+            ContentRange {
+                range: Range {
+                    start: 5,
+                    length: 5
+                },
+                complete_length: 100
+            }
+        );
+
+        assert!(Task::signature_bound_content_range(&task, "bytes=6-9").is_err());
+        task.content_length = Some(100);
+        assert!(Task::signature_bound_content_range(&task, "bytes=5-9").is_err());
+    }
+
+    #[test]
+    fn test_signature_bound_small_range_uses_scheduler() {
+        let mut request = Download {
+            url: "https://example.com/object".to_string(),
+            range: Some(Range {
+                start: 0,
+                length: 1024,
+            }),
+            ..Default::default()
+        };
+        assert!(Task::should_download_directly_from_source(&request, 1024));
+
+        request
+            .request_header
+            .insert("range".to_string(), "bytes=0-1023".to_string());
+        request.request_header.insert(
+            "authorization".to_string(),
+            "AWS4-HMAC-SHA256 Credential=key/scope, SignedHeaders=host;range, Signature=abc"
+                .to_string(),
+        );
+        assert!(!Task::should_download_directly_from_source(&request, 1024));
     }
 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -178,6 +178,14 @@ impl Task {
         let (task, reused) = self.storage.prepare_download_task(id)?;
 
         if reused {
+            if let Some(piece_length) = task.piece_length() {
+                Self::validate_signature_bound_piece_content(
+                    signed_range.is_some(),
+                    request.need_piece_content,
+                    piece_length,
+                )?;
+            }
+
             // Attempt to create a hard link from the task file to the output path.
             //
             // Behavior based on force_hard_link setting:
@@ -325,6 +333,12 @@ impl Task {
                 }
             };
 
+        Self::validate_signature_bound_piece_content(
+            preserve_range,
+            request.need_piece_content,
+            piece_length,
+        )?;
+
         // If the task is not finished, check if the storage has enough space to
         // store the task.
         if !task.is_finished() && !self.storage.has_enough_space(content_length)? {
@@ -360,6 +374,27 @@ impl Task {
         }
 
         task
+    }
+
+    /// Rejects embedding an oversized signature-bound piece in a download response.
+    ///
+    /// The proxy streams piece bytes from storage and does not request piece content,
+    /// so it can continue to use the larger signature-bound range limit. gRPC callers
+    /// that request piece content receive one protobuf message per piece, which would
+    /// otherwise require a contiguous allocation as large as the signed range.
+    fn validate_signature_bound_piece_content(
+        signature_bound: bool,
+        need_piece_content: bool,
+        piece_length: u64,
+    ) -> ClientResult<()> {
+        if signature_bound && need_piece_content && piece_length > piece::MAX_PIECE_LENGTH {
+            return Err(Error::Unsupported(format!(
+                "signature-bound piece of {piece_length} bytes exceeds the maximum inline piece content length of {} bytes",
+                piece::MAX_PIECE_LENGTH
+            )));
+        }
+
+        Ok(())
     }
 
     /// Resolves and validates a signed source range from compact task metadata.
@@ -2697,5 +2732,33 @@ mod tests {
                 .to_string(),
         );
         assert!(!Task::should_download_directly_from_source(&request, 1024));
+    }
+
+    #[test]
+    fn test_validate_signature_bound_piece_content() {
+        assert!(
+            Task::validate_signature_bound_piece_content(true, true, piece::MAX_PIECE_LENGTH,)
+                .is_ok()
+        );
+        assert!(matches!(
+            Task::validate_signature_bound_piece_content(true, true, piece::MAX_PIECE_LENGTH + 1,),
+            Err(Error::Unsupported(_))
+        ));
+
+        // Proxy streaming never embeds the complete piece in one message.
+        assert!(Task::validate_signature_bound_piece_content(
+            true,
+            false,
+            piece::MAX_PIECE_LENGTH + 1,
+        )
+        .is_ok());
+
+        // Keep the pre-existing explicit-piece behavior for unsigned downloads.
+        assert!(Task::validate_signature_bound_piece_content(
+            false,
+            true,
+            piece::MAX_PIECE_LENGTH + 1,
+        )
+        .is_ok());
     }
 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -178,13 +178,15 @@ impl Task {
         let (task, reused) = self.storage.prepare_download_task(id)?;
 
         if reused {
-            if let Some(piece_length) = task.piece_length() {
-                Self::validate_signature_bound_piece_content(
-                    signed_range.is_some(),
-                    request.need_piece_content,
-                    piece_length,
-                )?;
-            }
+            // Storage only marks fully initialized tasks as reusable. Keep this
+            // fail-closed so an invariant violation cannot skip the inline-content
+            // allocation guard for a signature-bound range.
+            let piece_length = task.piece_length().ok_or(Error::InvalidPieceLength)?;
+            Self::validate_signature_bound_piece_content(
+                signed_range.is_some(),
+                request.need_piece_content,
+                piece_length,
+            )?;
 
             // Attempt to create a hard link from the task file to the output path.
             //


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes multipart S3 downloads through dfdaemon's HTTP proxy when AWS SigV4 or SigV4a covers the `Range` header.

The change is limited to signature-bound ranges:

- Detect `Range` in SigV4/SigV4a signed headers, including presigned URLs.
- Preserve the caller's exact signed range across stat and source-piece requests.
- Reject signature-bound multi-range requests because dfdaemon cannot produce a multipart/byteranges response without changing the signed request.
- Derive stable, compact range task IDs from the normal task ID, requested range, and representation-selecting headers while excluding rotating credentials.
- Include `Accept`, `Accept-Language`, and `Accept-Encoding` in compact-range cache identity to avoid cross-representation cache reuse.
- Store each signed range at local offset zero and translate the proxy response back to source coordinates.
- Allow small signed ranges to use the scheduler, peers, and local cache.
- Validate `206 Partial Content`, `Content-Range`, `Content-Length`, `ETag`, and S3 version ID when present before caching source bytes.
- Keep download and upload paths consistent for compact range tasks.
- Send signed `If-Range` requests directly to origin because a validator mismatch can legitimately return a full `200` response that a compact range task cannot represent.
- Additionally limit inline gRPC piece content to 64 MiB to avoid a very large protobuf allocation, while streaming proxy requests remain supported up to the overall 1 GiB signature-bound range limit.
- Preserve real origin error and conditional statuses, including `304`, while reporting locally generated validation failures on nominal success responses as `502 Bad Gateway` and correctly framing empty responses.

Unrelated S3-aware routing, TLS policy, proxy authentication, redirect, logging, and general cache-revalidation changes are intentionally excluded.

## Related Issue

Fixes #1821

## Motivation and Context

Multipart S3 clients such as s5cmd sign each `Range` request. dfdaemon normally rewrites ranges into Dragonfly piece ranges, which changes the canonical request and causes S3 to reject it with `403 SignatureDoesNotMatch`.

For requests that do not explicitly sign `Range`, the existing download path remains unchanged.

## Tests

Validated on commit `1ef00b966b55a0cf4696edc4873dffb3e6d49de2` against `main` at `6a9b8c184961ff1a9928d25356c27513b188d829`:

- `cargo fmt --all -- --check`
- `cargo check --all --all-targets`
- `cargo clippy --all --all-targets -- -D warnings`
- Focused `dragonfly-client` library tests (66 tests)
- `cargo test --all-features --workspace` (461 tests, 0 failures; 4 doc tests ignored)

The exact PR head was also exercised with a Linux binary built from that commit, two dfdaemons, S3-compatible MinIO, a recording relay, and s5cmd v2.3.0 using a 24 MiB object split into five signed ranges. Direct, cold-client, seed-cache, and warm-client outputs were byte-identical. The cold client received all bytes from the seed; later seed and client downloads were local-cache hits with no ranged origin requests. The five task IDs remained stable across fresh SigV4 dates and signatures, and every ranged origin GET preserved its exact range with `host;range` signed. No signature or signed-response validation errors were observed.

## Validation Boundaries

- The integration environment used MinIO, not an AWS S3 bucket.
- Each node that first handles a signed-range task replays the unchanged signed GET to validate metadata. In the two-daemon cold test, each range caused two validation GETs and one data GET; cached repeats caused no ranged GETs, although s5cmd still sent its normal object `HEAD`.
- A signed range remains one Dragonfly piece because subdividing it would require rewriting the signed header.
- Streaming proxy requests are limited to a 1 GiB signed range; inline gRPC piece content is limited to 64 MiB.
- Signed `If-Range` requests intentionally bypass P2P to preserve HTTP validator semantics.
- Cache identity covers the common representation selectors above, but this PR does not implement arbitrary `Vary` processing.
- Cache freshness and authorization retain Dragonfly's existing task lifetime and deployment trust model; this PR does not add local SigV4 verification or a new cache revalidation protocol.

## AI Assistance

AI assistance was used to review and refine the scope and implementation. The final patch was checked against the linked issue and validated with the commands listed above.

## Screenshots (if appropriate)

N/A
