### PR TITLE
fix: avoid panic when no preferred local IP is available

### DIFF
--- a/dragonfly-client-util/src/request/mod.rs
+++ b/dragonfly-client-util/src/request/mod.rs
@@ -399,8 +399,18 @@ impl Builder {
 
         // Get local IP address and hostname.
         // In IPv6-only environments, IPv4 detection may fail, so we use a best-effort IPv4->IPv6 fallback.
-        let local_ip = preferred_local_ip().unwrap().to_string();
-        let hostname = hostname::get().unwrap().to_string_lossy().to_string();
+        let local_ip = preferred_local_ip()
+            .ok_or_else(|| {
+                Error::Internal(
+                    "failed to detect a preferred local IP address (no default network route?)"
+                        .to_string(),
+                )
+            })?
+            .to_string();
+        let hostname = hostname::get()
+            .map_err(|err| Error::Internal(format!("failed to get hostname: {}", err)))?
+            .to_string_lossy()
+            .to_string();
         let id_generator = IDGenerator::new(local_ip, hostname, true);
         let proxy = Proxy {
             seed_peer_selector,

--- a/dragonfly-client-util/src/request/mod.rs
+++ b/dragonfly-client-util/src/request/mod.rs
@@ -401,10 +401,7 @@ impl Builder {
         // In IPv6-only environments, IPv4 detection may fail, so we use a best-effort IPv4->IPv6 fallback.
         let local_ip = preferred_local_ip()
             .ok_or_else(|| {
-                Error::Internal(
-                    "failed to detect a preferred local IP address (no default network route?)"
-                        .to_string(),
-                )
+                Error::Internal("failed to detect a preferred local IP address".to_string())
             })?
             .to_string();
         let hostname = hostname::get()


### PR DESCRIPTION
## Description

Replace `preferred_local_ip().unwrap()` and `hostname::get().unwrap()` in `Proxy::build` (`dragonfly-client-util/src/request/mod.rs`) with proper error propagation via `Error::Internal`, so the proxy SDK surfaces a clear error instead of panicking when no default network route is available.

## Related Issue

Fixes #1822.

## Motivation and Context

`build()` already returns `Result<Proxy>`, so propagating the error keeps callers in control and prevents the `tokio-rt-worker` panic reported in containers without a default route gateway.