### PR TITLE
feat(storage): add connect timeout for QUIC and TCP clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "cgroups-rs",
  "headers 0.4.1",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "bincode",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "anyhow",
  "dragonfly-client-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.8"
+version = "1.3.9"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
@@ -24,14 +24,14 @@ readme = "README.md"
 edition = "2021"
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.3.8" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.8" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.8" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.8" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.8" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.8" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.8" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.8" }
+dragonfly-client = { path = "dragonfly-client", version = "1.3.9" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.9" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.9" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.9" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.9" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.9" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.9" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.9" }
 dragonfly-api = "=2.2.28"
 thiserror = "2.0"
 futures = "0.3.32"

--- a/dragonfly-client-storage/src/client/mod.rs
+++ b/dragonfly-client-storage/src/client/mod.rs
@@ -25,6 +25,9 @@ const DEFAULT_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 /// DEFAULT_RECV_BUFFER_SIZE is the default size of the receive buffer for network connections.
 const DEFAULT_RECV_BUFFER_SIZE: usize = 16 * 1024 * 1024;
 
+/// DEFAULT_CONNECT_TIMEOUT is the default timeout for establishing network connections.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// DEFAULT_KEEPALIVE_INTERVAL is the default interval for sending keepalive messages.
 const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(3);
 

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -263,10 +263,12 @@ impl QUICClient {
 
         // Connect's server name used for verifying the certificate. Since we used
         // NoVerifier, it can be anything.
-        let connection = endpoint
+        let connecting = endpoint
             .connect(self.addr.parse().or_err(ErrorType::ParseError)?, "d7y")
-            .or_err(ErrorType::ConnectError)?
-            .await
+            .or_err(ErrorType::ConnectError)?;
+
+        let connection = tokio::time::timeout(super::DEFAULT_CONNECT_TIMEOUT, connecting)
+            .await?
             .inspect_err(|err| error!("failed to connect to {}: {}", self.addr, err))
             .or_err(ErrorType::ConnectError)?;
 

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -236,7 +236,12 @@ impl TCPClient {
         &self,
         request: Bytes,
     ) -> ClientResult<(OwnedReadHalf, OwnedWriteHalf)> {
-        let stream = tokio::net::TcpStream::connect(self.addr.clone()).await?;
+        let stream = tokio::time::timeout(
+            super::DEFAULT_CONNECT_TIMEOUT,
+            tokio::net::TcpStream::connect(self.addr.clone()),
+        )
+        .await??;
+
         let socket = SockRef::from(&stream);
         socket.set_tcp_nodelay(true)?;
         socket.set_nonblocking(true)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a default connection timeout for network clients to improve reliability and prevent indefinite hangs during connection attempts. The timeout is now consistently applied to both TCP and QUIC client connections.

**Connection timeout improvements:**

* Added a new constant `DEFAULT_CONNECT_TIMEOUT` (2 seconds) in `mod.rs` to define the default timeout for establishing network connections.
* Updated the TCP client (`tcp.rs`) to wrap connection attempts in a timeout using `DEFAULT_CONNECT_TIMEOUT`, ensuring that TCP connections fail quickly if the server is unreachable.
* Updated the QUIC client (`quic.rs`) to wrap connection attempts in the same timeout, applying consistent behavior across protocols.
<!--- Describe your changes in detail -->

## Related Issue
Fixed https://github.com/dragonflyoss/client/issues/1831
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
