### PR TITLE
Feature/add dfget args --hf-base-url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.2.28"
+version = "2.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60161cdd03ffc6fff2b4f5e4f942758555a5c10b57bd4304dca5ec6bd0a35d81"
+checksum = "cc71e0b2ce9c6315d54945d1c64de28a210a93aed009e981e87f35f2895482e7"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -5755,9 +5755,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.9
 dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.9" }
 dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.9" }
 dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.9" }
-dragonfly-api = "=2.2.28"
+dragonfly-api = "=2.2.30"
 thiserror = "2.0"
 futures = "0.3.32"
 reqwest = { version = "0.12.28", features = [

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -234,7 +234,7 @@ impl HuggingFace {
     /// Resolves the base URLs from gRPC Hugging Face options.
     fn resolve_base_urls(base_url: Option<&str>) -> Result<(Url, Url)> {
         let base_url = Url::parse(base_url.unwrap_or(HUGGING_FACE_BASE_URL))?;
-        let api_base_url = base_url.join("/api")?;
+        let api_base_url = base_url.join("/api/")?;
         Ok((base_url, api_base_url))
     }
 
@@ -243,71 +243,81 @@ impl HuggingFace {
         parsed_url: &ParsedURL,
         file_path: &str,
         revision: &str,
-        base_url: &str,
-    ) -> String {
-        match parsed_url.repository_type {
+        base_url: &Url,
+    ) -> Result<Url> {
+        let path = match parsed_url.repository_type {
             RepositoryType::Model => {
                 format!(
-                    "{}/{}/resolve/{}/{}",
-                    base_url, parsed_url.repository_id, revision, file_path
+                    "{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
                 )
             }
             RepositoryType::Dataset => {
                 format!(
-                    "{}/datasets/{}/resolve/{}/{}",
-                    base_url, parsed_url.repository_id, revision, file_path
+                    "datasets/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
                 )
             }
             RepositoryType::Space => {
                 format!(
-                    "{}/spaces/{}/resolve/{}/{}",
-                    base_url, parsed_url.repository_id, revision, file_path
+                    "spaces/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
                 )
             }
-        }
+        };
+
+        Ok(base_url.join(&path)?)
     }
 
     /// Builds the API URL for fetching repository information based on the repository type and ID.
-    fn build_repository_url(parsed_url: &ParsedURL, api_base_url: &str) -> String {
-        format!(
-            "{}/{}/{}",
-            api_base_url,
+    fn build_repository_url(parsed_url: &ParsedURL, api_base_url: &Url) -> Result<Url> {
+        let path = format!(
+            "{}/{}",
             parsed_url.repository_type.as_str(),
             parsed_url.repository_id
-        )
+        );
+
+        Ok(api_base_url.join(&path)?)
     }
 
     /// Builds the API URL for fetching repository information at a specific revision.
     fn build_repository_revision_url(
         parsed_url: &ParsedURL,
         revision: &str,
-        api_base_url: &str,
-    ) -> String {
-        format!(
-            "{}/{}/{}?revision={}",
-            api_base_url,
+        api_base_url: &Url,
+    ) -> Result<Url> {
+        let path = format!(
+            "{}/{}?revision={}",
             parsed_url.repository_type.as_str(),
             parsed_url.repository_id,
             revision
-        )
+        );
+
+        Ok(api_base_url.join(&path)?)
     }
 
     /// Builds an `hf://` URL for a file so downstream downloads continue to
     /// use the HF backend (preserving auth and URL semantics).
-    fn build_hf_url(parsed_url: &ParsedURL, filename: &str) -> String {
-        match parsed_url.repository_type {
+    fn build_hf_url(parsed_url: &ParsedURL, filename: &str) -> Result<Url> {
+        let url = match parsed_url.repository_type {
             RepositoryType::Model => {
                 format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename)
             }
-            RepositoryType::Dataset => format!(
-                "{}://datasets/{}/{}",
-                SCHEME, parsed_url.repository_id, filename
-            ),
-            RepositoryType::Space => format!(
-                "{}://spaces/{}/{}",
-                SCHEME, parsed_url.repository_id, filename
-            ),
-        }
+            RepositoryType::Dataset => {
+                format!(
+                    "{}://datasets/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+            RepositoryType::Space => {
+                format!(
+                    "{}://spaces/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+        };
+
+        Ok(Url::parse(&url)?)
     }
 
     /// Build the request headers for Hugging Face API requests, including authentication if a
@@ -383,11 +393,12 @@ impl Backend for HuggingFace {
                     &parsed_url,
                     file_path,
                     &hugging_face.revision,
-                    base_url.as_str(),
-                );
+                    &base_url,
+                )?;
+
                 let response = match self
                     .client
-                    .head(&download_url)
+                    .head(download_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
@@ -440,12 +451,12 @@ impl Backend for HuggingFace {
                 let repository_revision_url = Self::build_repository_revision_url(
                     &parsed_url,
                     &hugging_face.revision,
-                    api_base_url.as_str(),
-                );
+                    &api_base_url,
+                )?;
 
                 let response = match self
                     .client
-                    .get(&repository_revision_url)
+                    .get(repository_revision_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
@@ -513,28 +524,28 @@ impl Backend for HuggingFace {
                     }))
                 })?;
 
-                let entries = repository
+                let entries: Vec<DirEntry> = repository
                     .siblings
                     .unwrap_or_default()
                     .into_iter()
-                    .map(|sibling| {
+                    .map(|sibling: Sibling| -> Result<DirEntry> {
                         // Return hf:// URLs so downstream downloads continue to use the HF
                         // backend (preserving auth headers and URL semantics).
-                        let hf_url = Self::build_hf_url(&parsed_url, &sibling.rfilename);
-                        let content_length = sibling
+                        let hf_url: Url = Self::build_hf_url(&parsed_url, &sibling.rfilename)?;
+                        let content_length: u64 = sibling
                             .lfs
                             .as_ref()
-                            .map(|lfs| lfs.size)
+                            .map(|lfs: &Lfs| lfs.size)
                             .or(sibling.size)
                             .unwrap_or(0);
 
-                        DirEntry {
-                            url: hf_url,
+                        Ok(DirEntry {
+                            url: hf_url.to_string(),
                             content_length: content_length as usize,
                             is_dir: false,
-                        }
+                        })
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>>>()?;
 
                 debug!(
                     "stat response {} {}: {:?} {:?} {:?}",
@@ -596,15 +607,11 @@ impl Backend for HuggingFace {
         };
 
         let (base_url, _) = Self::resolve_base_urls(hugging_face.base_url.as_deref())?;
-        let download_url = Self::build_download_url(
-            &parsed_url,
-            file_path,
-            &hugging_face.revision,
-            base_url.as_str(),
-        );
+        let download_url =
+            Self::build_download_url(&parsed_url, file_path, &hugging_face.revision, &base_url)?;
         let response = match self
             .client
-            .get(&download_url)
+            .get(download_url.as_str())
             .headers(request_header)
             .timeout(request.timeout)
             .send()
@@ -697,11 +704,12 @@ impl Backend for HuggingFace {
                     &parsed_url,
                     file_path,
                     &hugging_face.revision,
-                    base_url.as_str(),
-                );
+                    &base_url,
+                )?;
+
                 let response = self
                     .client
-                    .head(&download_url)
+                    .head(download_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
@@ -725,10 +733,10 @@ impl Backend for HuggingFace {
                 Ok(response_status_code.is_success())
             }
             None => {
-                let repository_url = Self::build_repository_url(&parsed_url, api_base_url.as_str());
+                let repository_url = Self::build_repository_url(&parsed_url, &api_base_url)?;
                 let response = self
                     .client
-                    .head(&repository_url)
+                    .head(repository_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
@@ -843,10 +851,11 @@ mod tests {
             &parsed_url,
             "model.safetensors",
             "main",
-            HUGGING_FACE_BASE_URL,
-        );
+            &Url::parse(HUGGING_FACE_BASE_URL).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
-            url,
+            url.as_str(),
             "https://huggingface.co/deepseek-ai/DeepSeek-OCR/resolve/main/model.safetensors"
         );
     }
@@ -858,10 +867,11 @@ mod tests {
             &parsed_url,
             "train.json",
             "main",
-            HUGGING_FACE_BASE_URL,
-        );
+            &Url::parse(HUGGING_FACE_BASE_URL).unwrap(),
+        )
+        .unwrap();
         assert_eq!(
-            url,
+            url.as_str(),
             "https://huggingface.co/datasets/huggingface/squad/resolve/main/train.json"
         );
     }
@@ -869,9 +879,13 @@ mod tests {
     #[test]
     fn test_build_api_url_model() {
         let parsed_url = ParsedURL::try_from("hf://deepseek-ai/DeepSeek-OCR").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url, "https://huggingface.co/api");
+        let url = HuggingFace::build_repository_url(
+            &parsed_url,
+            &Url::parse("https://huggingface.co/api/").unwrap(),
+        )
+        .unwrap();
         assert_eq!(
-            url,
+            url.as_str(),
             "https://huggingface.co/api/models/deepseek-ai/DeepSeek-OCR"
         );
     }
@@ -879,22 +893,32 @@ mod tests {
     #[test]
     fn test_build_api_url_dataset() {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url, "https://huggingface.co/api");
-        assert_eq!(url, "https://huggingface.co/api/datasets/huggingface/squad");
+        let url = HuggingFace::build_repository_url(
+            &parsed_url,
+            &Url::parse("https://huggingface.co/api/").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://huggingface.co/api/datasets/huggingface/squad"
+        );
     }
 
     #[test]
     fn test_build_hf_url_model() {
         let parsed_url = ParsedURL::try_from("hf://deepseek-ai/DeepSeek-OCR").unwrap();
-        let url = HuggingFace::build_hf_url(&parsed_url, "model.safetensors");
-        assert_eq!(url, "hf://deepseek-ai/DeepSeek-OCR/model.safetensors");
+        let url = HuggingFace::build_hf_url(&parsed_url, "model.safetensors").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "hf://deepseek-ai/DeepSeek-OCR/model.safetensors"
+        );
     }
 
     #[test]
     fn test_build_hf_url_dataset() {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad").unwrap();
-        let url = HuggingFace::build_hf_url(&parsed_url, "train.json");
-        assert_eq!(url, "hf://datasets/huggingface/squad/train.json");
+        let url = HuggingFace::build_hf_url(&parsed_url, "train.json").unwrap();
+        assert_eq!(url.as_str(), "hf://datasets/huggingface/squad/train.json");
     }
 
     #[test]
@@ -902,7 +926,7 @@ mod tests {
         let (base_url, api_base_url) =
             HuggingFace::resolve_base_urls(Some("https://hf-mirror.com/")).unwrap();
         assert_eq!(base_url.as_str(), "https://hf-mirror.com/");
-        assert_eq!(api_base_url.as_str(), "https://hf-mirror.com/api");
+        assert_eq!(api_base_url.as_str(), "https://hf-mirror.com/api/");
     }
 
     #[test]

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -901,7 +901,7 @@ mod tests {
     fn test_resolve_base_urls() {
         let (base_url, api_base_url) =
             HuggingFace::resolve_base_urls(Some("https://hf-mirror.com/")).unwrap();
-        assert_eq!(base_url.as_str(), "https://hf-mirror.com");
+        assert_eq!(base_url.as_str(), "https://hf-mirror.com/");
         assert_eq!(api_base_url.as_str(), "https://hf-mirror.com/api");
     }
 

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -292,12 +292,17 @@ impl HuggingFace {
     /// use the HF backend (preserving auth and URL semantics).
     fn build_hf_url(parsed_url: &ParsedURL, filename: &str) -> String {
         match parsed_url.repository_type {
-            RepositoryType::Model => format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename),
+            RepositoryType::Model => {
+                format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename)
+            }
             RepositoryType::Dataset => format!(
                 "{}://datasets/{}/{}",
                 SCHEME, parsed_url.repository_id, filename
             ),
-            RepositoryType::Space => format!("{}://spaces/{}/{}", SCHEME, parsed_url.repository_id, filename),
+            RepositoryType::Space => format!(
+                "{}://spaces/{}/{}",
+                SCHEME, parsed_url.repository_id, filename
+            ),
         }
     }
 
@@ -600,8 +605,7 @@ impl Backend for HuggingFace {
         };
 
         let (base_url, _) = Self::resolve_base_urls(request.http_header.as_ref());
-        let download_url =
-            Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
+        let download_url = Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
         let response = match self
             .client
             .get(&download_url)

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -576,7 +576,7 @@ impl Backend for HuggingFace {
                 .hugging_face
                 .as_ref()
                 .and_then(|hf| hf.token.clone()),
-            request.range.clone(),
+            request.range,
         )?;
 
         // Get the revision from the request, request must contain revision for stat request,

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -48,6 +48,7 @@ use futures::TryStreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, RANGE, USER_AGENT};
 use reqwest::Client;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::error::Error as _;
 use std::io::{Error as IOError, ErrorKind};
 use std::sync::Arc;
@@ -63,6 +64,12 @@ const HUGGING_FACE_BASE_URL: &str = "https://huggingface.co";
 
 /// HUGGING_FACE_API_BASE_URL is the API base URL for Hugging Face API.
 const HUGGING_FACE_API_BASE_URL: &str = "https://huggingface.co/api";
+
+/// HUGGING_FACE_BASE_URL_HEADER is the internal request header key for overriding the base URL.
+pub const HUGGING_FACE_BASE_URL_HEADER: &str = "X-Dragonfly-Hugging-Face-Base-Url";
+
+/// HUGGING_FACE_API_BASE_URL_HEADER is the internal request header key for overriding the API base URL.
+pub const HUGGING_FACE_API_BASE_URL_HEADER: &str = "X-Dragonfly-Hugging-Face-Api-Base-Url";
 
 /// Repository represents the Hugging Face repository information returned by the API.
 #[derive(Default, Debug, Deserialize)]
@@ -235,44 +242,53 @@ impl HuggingFace {
     }
 
     /// Builds the download URL for a file based on the repository type and path.
-    fn build_download_url(parsed_url: &ParsedURL, file_path: &str, revision: &str) -> String {
+    fn build_download_url(
+        parsed_url: &ParsedURL,
+        file_path: &str,
+        revision: &str,
+        base_url: &str,
+    ) -> String {
         match parsed_url.repository_type {
             RepositoryType::Model => {
                 format!(
                     "{}/{}/resolve/{}/{}",
-                    HUGGING_FACE_BASE_URL, parsed_url.repository_id, revision, file_path
+                    base_url, parsed_url.repository_id, revision, file_path
                 )
             }
             RepositoryType::Dataset => {
                 format!(
                     "{}/datasets/{}/resolve/{}/{}",
-                    HUGGING_FACE_BASE_URL, parsed_url.repository_id, revision, file_path
+                    base_url, parsed_url.repository_id, revision, file_path
                 )
             }
             RepositoryType::Space => {
                 format!(
                     "{}/spaces/{}/resolve/{}/{}",
-                    HUGGING_FACE_BASE_URL, parsed_url.repository_id, revision, file_path
+                    base_url, parsed_url.repository_id, revision, file_path
                 )
             }
         }
     }
 
     /// Builds the API URL for fetching repository information based on the repository type and ID.
-    fn build_repository_url(parsed_url: &ParsedURL) -> String {
+    fn build_repository_url(parsed_url: &ParsedURL, api_base_url: &str) -> String {
         format!(
             "{}/{}/{}",
-            HUGGING_FACE_API_BASE_URL,
+            api_base_url,
             parsed_url.repository_type.as_str(),
             parsed_url.repository_id
         )
     }
 
     /// Builds the API URL for fetching repository information at a specific revision.
-    fn build_repository_revision_url(parsed_url: &ParsedURL, revision: &str) -> String {
+    fn build_repository_revision_url(
+        parsed_url: &ParsedURL,
+        revision: &str,
+        api_base_url: &str,
+    ) -> String {
         format!(
             "{}/{}/{}?revision={}",
-            HUGGING_FACE_API_BASE_URL,
+            api_base_url,
             parsed_url.repository_type.as_str(),
             parsed_url.repository_id,
             revision
@@ -283,18 +299,32 @@ impl HuggingFace {
     /// use the HF backend (preserving auth and URL semantics).
     fn build_hf_url(parsed_url: &ParsedURL, filename: &str) -> String {
         match parsed_url.repository_type {
-            RepositoryType::Model => {
-                format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename)
-            }
+            RepositoryType::Model => format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename),
             RepositoryType::Dataset => format!(
                 "{}://datasets/{}/{}",
                 SCHEME, parsed_url.repository_id, filename
             ),
-            RepositoryType::Space => format!(
-                "{}://spaces/{}/{}",
-                SCHEME, parsed_url.repository_id, filename
-            ),
+            RepositoryType::Space => format!("{}://spaces/{}/{}", SCHEME, parsed_url.repository_id, filename),
         }
+    }
+
+    /// Resolves the base URLs from explicit request headers.
+    fn resolve_base_urls(request_headers: Option<&HashMap<String, String>>) -> (String, String) {
+        let base_url = request_headers
+            .and_then(|headers| headers.get(HUGGING_FACE_BASE_URL_HEADER))
+            .cloned()
+            .unwrap_or_else(|| HUGGING_FACE_BASE_URL.to_string())
+            .trim_end_matches('/')
+            .to_string();
+
+        let api_base_url = request_headers
+            .and_then(|headers| headers.get(HUGGING_FACE_API_BASE_URL_HEADER))
+            .cloned()
+            .unwrap_or_else(|| HUGGING_FACE_API_BASE_URL.to_string())
+            .trim_end_matches('/')
+            .to_string();
+
+        (base_url, api_base_url)
     }
 
     /// Build the request headers for Hugging Face API requests, including authentication if a
@@ -366,9 +396,11 @@ impl Backend for HuggingFace {
             .revision;
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
+        let (base_url, api_base_url) = Self::resolve_base_urls(request.http_header.as_ref());
         match &parsed_url.file_path {
             Some(file_path) => {
-                let download_url = Self::build_download_url(&parsed_url, file_path, &revision);
+                let download_url =
+                    Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
                 let response = match self
                     .client
                     .head(&download_url)
@@ -422,7 +454,7 @@ impl Backend for HuggingFace {
             }
             None => {
                 let repository_revision_url =
-                    Self::build_repository_revision_url(&parsed_url, &revision);
+                    Self::build_repository_revision_url(&parsed_url, &revision, &api_base_url);
                 let response = match self
                     .client
                     .get(&repository_revision_url)
@@ -578,7 +610,9 @@ impl Backend for HuggingFace {
             return Err(Error::InvalidParameter);
         };
 
-        let download_url = Self::build_download_url(&parsed_url, file_path, &revision);
+        let (base_url, _) = Self::resolve_base_urls(request.http_header.as_ref());
+        let download_url =
+            Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
         let response = match self
             .client
             .get(&download_url)
@@ -670,9 +704,11 @@ impl Backend for HuggingFace {
             .revision;
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
+        let (base_url, api_base_url) = Self::resolve_base_urls(request.http_header.as_ref());
         match &parsed_url.file_path {
             Some(file_path) => {
-                let download_url = Self::build_download_url(&parsed_url, file_path, &revision);
+                let download_url =
+                    Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
                 let response = self
                     .client
                     .head(&download_url)
@@ -699,7 +735,7 @@ impl Backend for HuggingFace {
                 Ok(response_status_code.is_success())
             }
             None => {
-                let repository_url = Self::build_repository_url(&parsed_url);
+                let repository_url = Self::build_repository_url(&parsed_url, &api_base_url);
                 let response = self
                     .client
                     .head(&repository_url)
@@ -813,7 +849,12 @@ mod tests {
     fn test_build_download_url_model() {
         let parsed_url =
             ParsedURL::try_from("hf://deepseek-ai/DeepSeek-OCR/model.safetensors").unwrap();
-        let url = HuggingFace::build_download_url(&parsed_url, "model.safetensors", "main");
+        let url = HuggingFace::build_download_url(
+            &parsed_url,
+            "model.safetensors",
+            "main",
+            HUGGING_FACE_BASE_URL,
+        );
         assert_eq!(
             url,
             "https://huggingface.co/deepseek-ai/DeepSeek-OCR/resolve/main/model.safetensors"
@@ -823,7 +864,12 @@ mod tests {
     #[test]
     fn test_build_download_url_dataset() {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad/train.json").unwrap();
-        let url = HuggingFace::build_download_url(&parsed_url, "train.json", "main");
+        let url = HuggingFace::build_download_url(
+            &parsed_url,
+            "train.json",
+            "main",
+            HUGGING_FACE_BASE_URL,
+        );
         assert_eq!(
             url,
             "https://huggingface.co/datasets/huggingface/squad/resolve/main/train.json"
@@ -833,7 +879,7 @@ mod tests {
     #[test]
     fn test_build_api_url_model() {
         let parsed_url = ParsedURL::try_from("hf://deepseek-ai/DeepSeek-OCR").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url);
+        let url = HuggingFace::build_repository_url(&parsed_url, HUGGING_FACE_API_BASE_URL);
         assert_eq!(
             url,
             "https://huggingface.co/api/models/deepseek-ai/DeepSeek-OCR"
@@ -843,7 +889,7 @@ mod tests {
     #[test]
     fn test_build_api_url_dataset() {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url);
+        let url = HuggingFace::build_repository_url(&parsed_url, HUGGING_FACE_API_BASE_URL);
         assert_eq!(url, "https://huggingface.co/api/datasets/huggingface/squad");
     }
 
@@ -859,6 +905,24 @@ mod tests {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad").unwrap();
         let url = HuggingFace::build_hf_url(&parsed_url, "train.json");
         assert_eq!(url, "hf://datasets/huggingface/squad/train.json");
+    }
+
+    #[test]
+    fn test_resolve_base_urls_from_headers() {
+        let parsed_url = ParsedURL::try_from("hf://Qwen/Qwen3-8B").unwrap();
+        let headers = HashMap::from([
+            (
+                HUGGING_FACE_BASE_URL_HEADER.to_string(),
+                "https://hf-mirror.com/".to_string(),
+            ),
+            (
+                HUGGING_FACE_API_BASE_URL_HEADER.to_string(),
+                "https://hf-mirror.com/api/".to_string(),
+            ),
+        ]);
+        let (base_url, api_base_url) = HuggingFace::resolve_base_urls(Some(&headers));
+        assert_eq!(base_url, "https://hf-mirror.com");
+        assert_eq!(api_base_url, "https://hf-mirror.com/api");
     }
 
     #[test]

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -37,7 +37,7 @@ use crate::{
     StatRequest, StatResponse, DEFAULT_USER_AGENT, KEEP_ALIVE_INTERVAL, POOL_MAX_IDLE_PER_HOST,
 };
 use async_trait::async_trait;
-use dragonfly_api::common::v2::{HuggingFace as HuggingFaceOptions, Range};
+use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{BackendError, ErrorType, OrErr},
@@ -231,6 +231,13 @@ impl HuggingFace {
         })
     }
 
+    /// Resolves the base URLs from gRPC Hugging Face options.
+    fn resolve_base_urls(base_url: Option<&str>) -> Result<(Url, Url)> {
+        let base_url = Url::parse(base_url.unwrap_or(HUGGING_FACE_BASE_URL))?;
+        let api_base_url = base_url.join("/api")?;
+        Ok((base_url, api_base_url))
+    }
+
     /// Builds the download URL for a file based on the repository type and path.
     fn build_download_url(
         parsed_url: &ParsedURL,
@@ -303,19 +310,6 @@ impl HuggingFace {
         }
     }
 
-    /// Resolves the base URLs from gRPC Hugging Face options.
-    fn resolve_base_urls(hugging_face: Option<&HuggingFaceOptions>) -> (String, String) {
-        let base_url = hugging_face
-            .and_then(|hf| hf.base_url.clone())
-            .unwrap_or_else(|| HUGGING_FACE_BASE_URL.to_string())
-            .trim_end_matches('/')
-            .to_string();
-
-        let api_base_url = format!("{}/api", base_url);
-
-        (base_url, api_base_url)
-    }
-
     /// Build the request headers for Hugging Face API requests, including authentication if a
     /// token is provided by the `--hf-token` CLI flag.
     fn build_request_headers(token: Option<String>, range: Option<Range>) -> Result<HeaderMap> {
@@ -370,28 +364,27 @@ impl Backend for HuggingFace {
             None,
         )?;
 
-        // Get the revision from the request, request must contain revision for stat request,
-        // otherwise return error.
-        let revision = request
-            .hugging_face
-            .as_ref()
-            .ok_or_else(|| {
-                error!(
-                    "stat request {} {}: missing Hugging Face information",
-                    request.task_id, request.url
-                );
+        // Get the Hugging Face information from the request, request must contain Hugging Face
+        // information for stat request, otherwise return error.
+        let hugging_face = request.hugging_face.as_ref().ok_or_else(|| {
+            error!(
+                "stat request {} {}: missing Hugging Face information",
+                request.task_id, request.url
+            );
 
-                Error::InvalidParameter
-            })?
-            .revision
-            .clone();
+            Error::InvalidParameter
+        })?;
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
-        let (base_url, api_base_url) = Self::resolve_base_urls(request.hugging_face.as_ref());
+        let (base_url, api_base_url) = Self::resolve_base_urls(hugging_face.base_url.as_deref())?;
         match &parsed_url.file_path {
             Some(file_path) => {
-                let download_url =
-                    Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
+                let download_url = Self::build_download_url(
+                    &parsed_url,
+                    file_path,
+                    &hugging_face.revision,
+                    base_url.as_str(),
+                );
                 let response = match self
                     .client
                     .head(&download_url)
@@ -444,8 +437,12 @@ impl Backend for HuggingFace {
                 })
             }
             None => {
-                let repository_revision_url =
-                    Self::build_repository_revision_url(&parsed_url, &revision, &api_base_url);
+                let repository_revision_url = Self::build_repository_revision_url(
+                    &parsed_url,
+                    &hugging_face.revision,
+                    api_base_url.as_str(),
+                );
+
                 let response = match self
                     .client
                     .get(&repository_revision_url)
@@ -576,21 +573,16 @@ impl Backend for HuggingFace {
             request.range,
         )?;
 
-        // Get the revision from the request, request must contain revision for stat request,
-        // otherwise return error.
-        let revision = request
-            .hugging_face
-            .as_ref()
-            .ok_or_else(|| {
-                error!(
-                    "get request {} {}: missing Hugging Face information",
-                    request.task_id, request.url
-                );
+        // Get the Hugging Face information from the request, request must contain Hugging Face
+        // information for get request, otherwise return error.
+        let hugging_face = request.hugging_face.as_ref().ok_or_else(|| {
+            error!(
+                "get request {} {}: missing Hugging Face information",
+                request.task_id, request.url
+            );
 
-                Error::InvalidParameter
-            })?
-            .revision
-            .clone();
+            Error::InvalidParameter
+        })?;
 
         // Parse the URL and build the download URL for the specified file.
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
@@ -603,8 +595,13 @@ impl Backend for HuggingFace {
             return Err(Error::InvalidParameter);
         };
 
-        let (base_url, _) = Self::resolve_base_urls(request.hugging_face.as_ref());
-        let download_url = Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
+        let (base_url, _) = Self::resolve_base_urls(hugging_face.base_url.as_deref())?;
+        let download_url = Self::build_download_url(
+            &parsed_url,
+            file_path,
+            &hugging_face.revision,
+            base_url.as_str(),
+        );
         let response = match self
             .client
             .get(&download_url)
@@ -681,28 +678,27 @@ impl Backend for HuggingFace {
             None,
         )?;
 
-        // Get the revision from the request, request must contain revision for stat request,
-        // otherwise return error.
-        let revision = request
-            .hugging_face
-            .as_ref()
-            .ok_or_else(|| {
-                error!(
-                    "stat request {} {}: missing Hugging Face information",
-                    request.task_id, request.url
-                );
+        // Get the Hugging Face information from the request, request must contain Hugging Face
+        // information for exists request, otherwise return error.
+        let hugging_face = request.hugging_face.as_ref().ok_or_else(|| {
+            error!(
+                "exists request {} {}: missing Hugging Face information",
+                request.task_id, request.url
+            );
 
-                Error::InvalidParameter
-            })?
-            .revision
-            .clone();
+            Error::InvalidParameter
+        })?;
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
-        let (base_url, api_base_url) = Self::resolve_base_urls(request.hugging_face.as_ref());
+        let (base_url, api_base_url) = Self::resolve_base_urls(hugging_face.base_url.as_deref())?;
         match &parsed_url.file_path {
             Some(file_path) => {
-                let download_url =
-                    Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
+                let download_url = Self::build_download_url(
+                    &parsed_url,
+                    file_path,
+                    &hugging_face.revision,
+                    base_url.as_str(),
+                );
                 let response = self
                     .client
                     .head(&download_url)
@@ -729,7 +725,7 @@ impl Backend for HuggingFace {
                 Ok(response_status_code.is_success())
             }
             None => {
-                let repository_url = Self::build_repository_url(&parsed_url, &api_base_url);
+                let repository_url = Self::build_repository_url(&parsed_url, api_base_url.as_str());
                 let response = self
                     .client
                     .head(&repository_url)
@@ -902,16 +898,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_base_urls_from_options() {
-        let options = HuggingFaceOptions {
-            revision: "main".to_string(),
-            token: None,
-            base_url: Some("https://hf-mirror.com/".to_string()),
-        };
-
-        let (base_url, api_base_url) = HuggingFace::resolve_base_urls(Some(&options));
-        assert_eq!(base_url, "https://hf-mirror.com");
-        assert_eq!(api_base_url, "https://hf-mirror.com/api");
+    fn test_resolve_base_urls() {
+        let (base_url, api_base_url) =
+            HuggingFace::resolve_base_urls(Some("https://hf-mirror.com/")).unwrap();
+        assert_eq!(base_url.as_str(), "https://hf-mirror.com");
+        assert_eq!(api_base_url.as_str(), "https://hf-mirror.com/api");
     }
 
     #[test]

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -48,7 +48,6 @@ use futures::TryStreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, RANGE, USER_AGENT};
 use reqwest::Client;
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::error::Error as _;
 use std::io::{Error as IOError, ErrorKind};
 use std::sync::Arc;
@@ -62,14 +61,8 @@ pub const SCHEME: &str = "hf";
 /// HUGGING_FACE_BASE_URL is the base URL for Hugging Face Hub.
 const HUGGING_FACE_BASE_URL: &str = "https://huggingface.co";
 
-/// HUGGING_FACE_API_BASE_URL is the API base URL for Hugging Face API.
-const HUGGING_FACE_API_BASE_URL: &str = "https://huggingface.co/api";
-
 /// HUGGING_FACE_BASE_URL_HEADER is the internal request header key for overriding the base URL.
 pub const HUGGING_FACE_BASE_URL_HEADER: &str = "X-Dragonfly-Hugging-Face-Base-Url";
-
-/// HUGGING_FACE_API_BASE_URL_HEADER is the internal request header key for overriding the API base URL.
-pub const HUGGING_FACE_API_BASE_URL_HEADER: &str = "X-Dragonfly-Hugging-Face-Api-Base-Url";
 
 /// Repository represents the Hugging Face repository information returned by the API.
 #[derive(Default, Debug, Deserialize)]
@@ -309,20 +302,16 @@ impl HuggingFace {
     }
 
     /// Resolves the base URLs from explicit request headers.
-    fn resolve_base_urls(request_headers: Option<&HashMap<String, String>>) -> (String, String) {
+    fn resolve_base_urls(request_headers: Option<&HeaderMap>) -> (String, String) {
         let base_url = request_headers
             .and_then(|headers| headers.get(HUGGING_FACE_BASE_URL_HEADER))
-            .cloned()
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_string())
             .unwrap_or_else(|| HUGGING_FACE_BASE_URL.to_string())
             .trim_end_matches('/')
             .to_string();
 
-        let api_base_url = request_headers
-            .and_then(|headers| headers.get(HUGGING_FACE_API_BASE_URL_HEADER))
-            .cloned()
-            .unwrap_or_else(|| HUGGING_FACE_API_BASE_URL.to_string())
-            .trim_end_matches('/')
-            .to_string();
+        let api_base_url = format!("{}/api", base_url);
 
         (base_url, api_base_url)
     }
@@ -879,7 +868,7 @@ mod tests {
     #[test]
     fn test_build_api_url_model() {
         let parsed_url = ParsedURL::try_from("hf://deepseek-ai/DeepSeek-OCR").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url, HUGGING_FACE_API_BASE_URL);
+        let url = HuggingFace::build_repository_url(&parsed_url, "https://huggingface.co/api");
         assert_eq!(
             url,
             "https://huggingface.co/api/models/deepseek-ai/DeepSeek-OCR"
@@ -889,7 +878,7 @@ mod tests {
     #[test]
     fn test_build_api_url_dataset() {
         let parsed_url = ParsedURL::try_from("hf://datasets/huggingface/squad").unwrap();
-        let url = HuggingFace::build_repository_url(&parsed_url, HUGGING_FACE_API_BASE_URL);
+        let url = HuggingFace::build_repository_url(&parsed_url, "https://huggingface.co/api");
         assert_eq!(url, "https://huggingface.co/api/datasets/huggingface/squad");
     }
 
@@ -909,17 +898,11 @@ mod tests {
 
     #[test]
     fn test_resolve_base_urls_from_headers() {
-        let parsed_url = ParsedURL::try_from("hf://Qwen/Qwen3-8B").unwrap();
-        let headers = HashMap::from([
-            (
-                HUGGING_FACE_BASE_URL_HEADER.to_string(),
-                "https://hf-mirror.com/".to_string(),
-            ),
-            (
-                HUGGING_FACE_API_BASE_URL_HEADER.to_string(),
-                "https://hf-mirror.com/api/".to_string(),
-            ),
-        ]);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HUGGING_FACE_BASE_URL_HEADER,
+            HeaderValue::from_static("https://hf-mirror.com/"),
+        );
         let (base_url, api_base_url) = HuggingFace::resolve_base_urls(Some(&headers));
         assert_eq!(base_url, "https://hf-mirror.com");
         assert_eq!(api_base_url, "https://hf-mirror.com/api");

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -576,7 +576,7 @@ impl Backend for HuggingFace {
                 .hugging_face
                 .as_ref()
                 .and_then(|hf| hf.token.clone()),
-            None,
+            request.range.clone(),
         )?;
 
         // Get the revision from the request, request must contain revision for stat request,
@@ -932,6 +932,22 @@ mod tests {
         assert_eq!(
             request_headers.get(USER_AGENT).unwrap(),
             HeaderValue::from_static(DEFAULT_USER_AGENT)
+        );
+    }
+
+    #[test]
+    fn test_build_headers_with_range() {
+        let request_headers = HuggingFace::build_request_headers(
+            None,
+            Some(Range {
+                start: 0,
+                length: 1024,
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            request_headers.get(RANGE).unwrap(),
+            HeaderValue::from_static("bytes=0-1023")
         );
     }
 }

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -37,7 +37,7 @@ use crate::{
     StatRequest, StatResponse, DEFAULT_USER_AGENT, KEEP_ALIVE_INTERVAL, POOL_MAX_IDLE_PER_HOST,
 };
 use async_trait::async_trait;
-use dragonfly_api::common::v2::Range;
+use dragonfly_api::common::v2::{HuggingFace as HuggingFaceOptions, Range};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{BackendError, ErrorType, OrErr},
@@ -60,9 +60,6 @@ pub const SCHEME: &str = "hf";
 
 /// HUGGING_FACE_BASE_URL is the base URL for Hugging Face Hub.
 const HUGGING_FACE_BASE_URL: &str = "https://huggingface.co";
-
-/// HUGGING_FACE_BASE_URL_HEADER is the internal request header key for overriding the base URL.
-pub const HUGGING_FACE_BASE_URL_HEADER: &str = "X-Dragonfly-Hugging-Face-Base-Url";
 
 /// Repository represents the Hugging Face repository information returned by the API.
 #[derive(Default, Debug, Deserialize)]
@@ -306,12 +303,10 @@ impl HuggingFace {
         }
     }
 
-    /// Resolves the base URLs from explicit request headers.
-    fn resolve_base_urls(request_headers: Option<&HeaderMap>) -> (String, String) {
-        let base_url = request_headers
-            .and_then(|headers| headers.get(HUGGING_FACE_BASE_URL_HEADER))
-            .and_then(|v| v.to_str().ok())
-            .map(|v| v.to_string())
+    /// Resolves the base URLs from gRPC Hugging Face options.
+    fn resolve_base_urls(hugging_face: Option<&HuggingFaceOptions>) -> (String, String) {
+        let base_url = hugging_face
+            .and_then(|hf| hf.base_url.clone())
             .unwrap_or_else(|| HUGGING_FACE_BASE_URL.to_string())
             .trim_end_matches('/')
             .to_string();
@@ -379,6 +374,7 @@ impl Backend for HuggingFace {
         // otherwise return error.
         let revision = request
             .hugging_face
+            .as_ref()
             .ok_or_else(|| {
                 error!(
                     "stat request {} {}: missing Hugging Face information",
@@ -387,10 +383,11 @@ impl Backend for HuggingFace {
 
                 Error::InvalidParameter
             })?
-            .revision;
+            .revision
+            .clone();
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
-        let (base_url, api_base_url) = Self::resolve_base_urls(request.http_header.as_ref());
+        let (base_url, api_base_url) = Self::resolve_base_urls(request.hugging_face.as_ref());
         match &parsed_url.file_path {
             Some(file_path) => {
                 let download_url =
@@ -583,6 +580,7 @@ impl Backend for HuggingFace {
         // otherwise return error.
         let revision = request
             .hugging_face
+            .as_ref()
             .ok_or_else(|| {
                 error!(
                     "get request {} {}: missing Hugging Face information",
@@ -591,7 +589,8 @@ impl Backend for HuggingFace {
 
                 Error::InvalidParameter
             })?
-            .revision;
+            .revision
+            .clone();
 
         // Parse the URL and build the download URL for the specified file.
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
@@ -604,7 +603,7 @@ impl Backend for HuggingFace {
             return Err(Error::InvalidParameter);
         };
 
-        let (base_url, _) = Self::resolve_base_urls(request.http_header.as_ref());
+        let (base_url, _) = Self::resolve_base_urls(request.hugging_face.as_ref());
         let download_url = Self::build_download_url(&parsed_url, file_path, &revision, &base_url);
         let response = match self
             .client
@@ -686,6 +685,7 @@ impl Backend for HuggingFace {
         // otherwise return error.
         let revision = request
             .hugging_face
+            .as_ref()
             .ok_or_else(|| {
                 error!(
                     "stat request {} {}: missing Hugging Face information",
@@ -694,10 +694,11 @@ impl Backend for HuggingFace {
 
                 Error::InvalidParameter
             })?
-            .revision;
+            .revision
+            .clone();
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
-        let (base_url, api_base_url) = Self::resolve_base_urls(request.http_header.as_ref());
+        let (base_url, api_base_url) = Self::resolve_base_urls(request.hugging_face.as_ref());
         match &parsed_url.file_path {
             Some(file_path) => {
                 let download_url =
@@ -901,13 +902,14 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_base_urls_from_headers() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            HUGGING_FACE_BASE_URL_HEADER,
-            HeaderValue::from_static("https://hf-mirror.com/"),
-        );
-        let (base_url, api_base_url) = HuggingFace::resolve_base_urls(Some(&headers));
+    fn test_resolve_base_urls_from_options() {
+        let options = HuggingFaceOptions {
+            revision: "main".to_string(),
+            token: None,
+            base_url: Some("https://hf-mirror.com/".to_string()),
+        };
+
+        let (base_url, api_base_url) = HuggingFace::resolve_base_urls(Some(&options));
         assert_eq!(base_url, "https://hf-mirror.com");
         assert_eq!(api_base_url, "https://hf-mirror.com/api");
     }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -354,6 +354,13 @@ struct Args {
 
     #[arg(
         long,
+        env = "DFGET_HF_BASE_URL",
+        help = "Specify the base URL for Hugging Face Hub, for example: https://hf-mirror.com"
+    )]
+    hf_base_url: Option<String>,
+
+    #[arg(
+        long,
         default_value_t = 100,
         env = "DFGET_MAX_FILES",
         help = "Specify the max count of file to download when downloading a directory. If the actual file count is greater than this value, the downloading will be rejected"
@@ -792,7 +799,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
     // Get all entries in the directory with include files filter.
     let entries: Vec<DirEntry> = get_all_entries(
         &args.url,
-        args.header.clone(),
+        build_request_headers(&args),
         args.include_files.clone(),
         object_storage,
         hdfs,
@@ -1061,7 +1068,7 @@ async fn download(
                 application: Some(args.application),
                 priority: args.priority,
                 filtered_query_params,
-                request_header: header_vec_to_hashmap(args.header)?,
+                request_header: header_vec_to_hashmap(build_request_headers(&args))?,
                 piece_length: args.piece_length.map(|piece_length| piece_length.as_u64()),
                 output_path,
                 timeout: Some(
@@ -1255,6 +1262,31 @@ async fn download(
 
     progress_bar.finish();
     Ok(())
+}
+
+/// Builds request headers for backend requests, including internal Hugging Face overrides.
+fn build_request_headers(args: &Args) -> Vec<String> {
+    let mut headers = args.header.clone().unwrap_or_default();
+
+    if args.url.scheme() == hugging_face::SCHEME {
+        if let Some(base_url) = &args.hf_base_url {
+            let base_url = base_url.trim_end_matches('/');
+            headers.push(format!(
+                "{}: {}",
+                hugging_face::HUGGING_FACE_BASE_URL_HEADER,
+                base_url
+            ));
+
+            let api_base_url = format!("{}/api", base_url);
+            headers.push(format!(
+                "{}: {}",
+                hugging_face::HUGGING_FACE_API_BASE_URL_HEADER,
+                api_base_url
+            ));
+        }
+    }
+
+    headers
 }
 
 /// Retrieves all directory entries from a remote storage location.

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1041,6 +1041,8 @@ async fn download(
         None
     };
 
+    let request_header = header_vec_to_hashmap(build_request_headers(&args))?;
+
     // If the `filtered_query_params` is not provided, then use the default value.
     let filtered_query_params = args
         .filtered_query_params
@@ -1068,7 +1070,7 @@ async fn download(
                 application: Some(args.application),
                 priority: args.priority,
                 filtered_query_params,
-                request_header: header_vec_to_hashmap(build_request_headers(&args))?,
+                request_header,
                 piece_length: args.piece_length.map(|piece_length| piece_length.as_u64()),
                 output_path,
                 timeout: Some(
@@ -1266,7 +1268,7 @@ async fn download(
 
 /// Builds request headers for backend requests, including internal Hugging Face overrides.
 fn build_request_headers(args: &Args) -> Vec<String> {
-    let mut headers = args.header.clone().unwrap_or_default();
+    let mut headers = args.header.clone();
 
     if args.url.scheme() == hugging_face::SCHEME {
         if let Some(base_url) = &args.hf_base_url {
@@ -1275,13 +1277,6 @@ fn build_request_headers(args: &Args) -> Vec<String> {
                 "{}: {}",
                 hugging_face::HUGGING_FACE_BASE_URL_HEADER,
                 base_url
-            ));
-
-            let api_base_url = format!("{}/api", base_url);
-            headers.push(format!(
-                "{}: {}",
-                hugging_face::HUGGING_FACE_API_BASE_URL_HEADER,
-                api_base_url
             ));
         }
     }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -354,7 +354,7 @@ struct Args {
     #[arg(
         long,
         env = "DFGET_HF_BASE_URL",
-        help = "Specify the base URL for Hugging Face Hub, for example: https://hf-mirror.com"
+        help = "Specify the base URL of the Hugging Face Hub endpoint (e.g., https://hf-mirror.com). If unspecified, it defaults to https://huggingface.co"
     )]
     hf_base_url: Option<String>,
 
@@ -753,10 +753,6 @@ async fn run(mut args: Args, dfdaemon_download_client: DfdaemonDownloadClient) -
 /// locally and downloads files while preserving the remote directory hierarchy.
 async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Result<()> {
     let url = Url::parse(args.url.as_str()).or_err(ErrorType::ParseError)?;
-    let hf_base_url = args
-        .hf_base_url
-        .as_ref()
-        .map(|base_url| base_url.trim_end_matches('/').to_string());
     let object_storage = if object_storage::Scheme::is_supported(url.scheme()) {
         Some(ObjectStorage {
             access_key_id: args.storage_access_key_id.clone(),
@@ -785,7 +781,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
         Some(HuggingFace {
             revision: args.hf_revision.clone(),
             token: args.hf_token.clone(),
-            base_url: hf_base_url.clone(),
+            base_url: args.hf_base_url.clone(),
         })
     } else {
         None
@@ -804,7 +800,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
     // Get all entries in the directory with include files filter.
     let entries: Vec<DirEntry> = get_all_entries(
         &args.url,
-        build_request_headers(&args),
+        args.header.clone(),
         args.include_files.clone(),
         object_storage,
         hdfs,
@@ -1004,10 +1000,6 @@ async fn download(
     download_client: DfdaemonDownloadClient,
 ) -> Result<()> {
     let url = Url::parse(args.url.as_str()).or_err(ErrorType::ParseError)?;
-    let hf_base_url = args
-        .hf_base_url
-        .as_ref()
-        .map(|base_url| base_url.trim_end_matches('/').to_string());
     let object_storage = if object_storage::Scheme::is_supported(url.scheme()) {
         Some(ObjectStorage {
             access_key_id: args.storage_access_key_id.clone(),
@@ -1036,7 +1028,7 @@ async fn download(
         Some(HuggingFace {
             revision: args.hf_revision.clone(),
             token: args.hf_token.clone(),
-            base_url: hf_base_url.clone(),
+            base_url: args.hf_base_url.clone(),
         })
     } else {
         None
@@ -1051,8 +1043,6 @@ async fn download(
     } else {
         None
     };
-
-    let request_header = header_vec_to_hashmap(build_request_headers(&args))?;
 
     // If the `filtered_query_params` is not provided, then use the default value.
     let filtered_query_params = args
@@ -1081,7 +1071,7 @@ async fn download(
                 application: Some(args.application),
                 priority: args.priority,
                 filtered_query_params,
-                request_header,
+                request_header: header_vec_to_hashmap(args.header)?,
                 piece_length: args.piece_length.map(|piece_length| piece_length.as_u64()),
                 output_path,
                 timeout: Some(
@@ -1275,11 +1265,6 @@ async fn download(
 
     progress_bar.finish();
     Ok(())
-}
-
-/// Builds request headers for backend requests from user-provided header flags.
-fn build_request_headers(args: &Args) -> Vec<String> {
-    args.header.clone()
 }
 
 /// Retrieves all directory entries from a remote storage location.

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -754,6 +754,10 @@ async fn run(mut args: Args, dfdaemon_download_client: DfdaemonDownloadClient) -
 /// locally and downloads files while preserving the remote directory hierarchy.
 async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Result<()> {
     let url = Url::parse(args.url.as_str()).or_err(ErrorType::ParseError)?;
+    let hf_base_url = args
+        .hf_base_url
+        .as_ref()
+        .map(|base_url| base_url.trim_end_matches('/').to_string());
     let object_storage = if object_storage::Scheme::is_supported(url.scheme()) {
         Some(ObjectStorage {
             access_key_id: args.storage_access_key_id.clone(),
@@ -782,6 +786,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
         Some(HuggingFace {
             revision: args.hf_revision.clone(),
             token: args.hf_token.clone(),
+            base_url: hf_base_url.clone(),
         })
     } else {
         None
@@ -791,6 +796,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
         Some(ModelScope {
             revision: args.ms_revision.clone(),
             token: args.ms_token.clone(),
+            base_url: None,
         })
     } else {
         None
@@ -999,6 +1005,10 @@ async fn download(
     download_client: DfdaemonDownloadClient,
 ) -> Result<()> {
     let url = Url::parse(args.url.as_str()).or_err(ErrorType::ParseError)?;
+    let hf_base_url = args
+        .hf_base_url
+        .as_ref()
+        .map(|base_url| base_url.trim_end_matches('/').to_string());
     let object_storage = if object_storage::Scheme::is_supported(url.scheme()) {
         Some(ObjectStorage {
             access_key_id: args.storage_access_key_id.clone(),
@@ -1027,6 +1037,7 @@ async fn download(
         Some(HuggingFace {
             revision: args.hf_revision.clone(),
             token: args.hf_token.clone(),
+            base_url: hf_base_url.clone(),
         })
     } else {
         None
@@ -1036,6 +1047,7 @@ async fn download(
         Some(ModelScope {
             revision: args.ms_revision.clone(),
             token: args.ms_token.clone(),
+            base_url: None,
         })
     } else {
         None
@@ -1266,22 +1278,9 @@ async fn download(
     Ok(())
 }
 
-/// Builds request headers for backend requests, including internal Hugging Face overrides.
+/// Builds request headers for backend requests from user-provided header flags.
 fn build_request_headers(args: &Args) -> Vec<String> {
-    let mut headers = args.header.clone();
-
-    if args.url.scheme() == hugging_face::SCHEME {
-        if let Some(base_url) = &args.hf_base_url {
-            let base_url = base_url.trim_end_matches('/');
-            headers.push(format!(
-                "{}: {}",
-                hugging_face::HUGGING_FACE_BASE_URL_HEADER,
-                base_url
-            ));
-        }
-    }
-
-    headers
+    args.header.clone()
 }
 
 /// Retrieves all directory entries from a remote storage location.

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -27,7 +27,6 @@ use dragonfly_api::dfdaemon::v2::{
     DownloadCacheTaskRequest, DownloadCacheTaskResponse, DownloadPersistentCacheTaskRequest,
     DownloadPersistentCacheTaskResponse, DownloadPersistentTaskRequest,
     DownloadPersistentTaskResponse, DownloadTaskRequest, DownloadTaskResponse, Entry,
-    ExchangeIbVerbsQueuePairEndpointRequest, ExchangeIbVerbsQueuePairEndpointResponse,
     ListTaskEntriesRequest, ListTaskEntriesResponse, StatCacheTaskRequest, StatLocalTaskRequest,
     StatLocalTaskResponse, StatPersistentCacheTaskRequest, StatPersistentTaskRequest,
     StatTaskRequest, StatTaskRequest as DfdaemonStatTaskRequest, SyncCachePiecesRequest,
@@ -2439,15 +2438,6 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         Ok(Response::new(ReceiverStream::new(out_stream_rx)))
     }
 
-    // Exchanges the ib verbs queue pair endpoint.
-    #[instrument(skip_all, fields(num, lid, gid))]
-    async fn exchange_ib_verbs_queue_pair_endpoint(
-        &self,
-        _request: Request<ExchangeIbVerbsQueuePairEndpointRequest>,
-    ) -> Result<Response<ExchangeIbVerbsQueuePairEndpointResponse>, Status> {
-        unimplemented!()
-    }
-
     /// Download cache task stream is the stream of the download cache task response.
     type DownloadCacheTaskStream = ReceiverStream<Result<DownloadCacheTaskResponse, Status>>;
 
@@ -2795,21 +2785,6 @@ impl DfdaemonUploadClient {
             .sync_persistent_cache_pieces(request)
             .await?;
         Ok(response)
-    }
-
-    /// Exchanges ib verbs queue pair endpoint.
-    #[instrument(skip_all)]
-    pub async fn exchange_ib_verbs_queue_pair_endpoint(
-        &self,
-        request: ExchangeIbVerbsQueuePairEndpointRequest,
-    ) -> ClientResult<ExchangeIbVerbsQueuePairEndpointResponse> {
-        let request = Self::make_request(request);
-        let response = self
-            .client
-            .clone()
-            .exchange_ib_verbs_queue_pair_endpoint(request)
-            .await?;
-        Ok(response.into_inner())
     }
 
     /// Creates a new request with timeout.


### PR DESCRIPTION
## Background / Motivation

In environments with poor connectivity or restricted access to Hugging Face, users often rely on Hugging Face mirror sites (e.g. `https://hf-mirror.com`). Today, `dfget hf://...` resolves to the official Hugging Face endpoints (`https://huggingface.co` and `https://huggingface.co/api`) and cannot be easily redirected to a mirror.

## What’s in this PR

- Add a new `dfget` option to override the Hugging Face base URL:
  - CLI: `--hf-base-url`
  - Env: `DFGET_HF_BASE_URL`
- When downloading via the `hf://` scheme, `dfget` propagates the override to dfdaemon/backend using an internal header for URL resolution.
- In the Hugging Face backend:
  - Hub base URL is overridden by `--hf-base-url` (trailing `/` is normalized)
  - API base URL is derived automatically as `<hf-base-url>/api` (no separate API flag needed)
- Fix several Rust ownership / partial-move issues in `dfget` request building introduced by the new header wiring.
- Update Hugging Face backend header parsing and unit tests to match `HeaderMap` usage.

## Usage

```bash
dfget hf://Qwen/Qwen3-8B -O ./zyh-test -r --hf-base-url=https://hf-mirror.com
# or
export DFGET_HF_BASE_URL=https://hf-mirror.com
dfget hf://Qwen/Qwen3-8B -O ./zyh-test -r
```

Note: avoid backticks and extra spaces in the flag value. For example,
`--hf-base-url= \`https://hf-mirror.com\`` may not behave as expected.

## Compatibility

- If `--hf-base-url` is not provided, behavior is unchanged (defaults to `https://huggingface.co`).
- The override only applies to `hf://` downloads and does not affect other backends (HTTP/S3/HDFS/etc.).

## Testing

- Local build: `cargo build --release --bin dfget`
- Runtime verification: run `dfget hf://<owner>/<repo> -r --hf-base-url=<mirror>` and confirm dfdaemon/backend requests are sent to `<mirror>/api/...`.
