### PR TITLE
feat(dfget): skip existing output files by default when overwrite is disabled

### DIFF
--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -143,6 +143,14 @@ struct Args {
     overwrite: bool,
 
     #[arg(
+        long = "skip-if-exists",
+        default_value_t = false,
+        env = "DFGET_SKIP_IF_EXISTS",
+        help = "Specify whether to skip the download and return success if the output file already exists. For recursive downloads, existing files will be skipped. Cannot be used with `--overwrite=true`"
+    )]
+    skip_if_exists: bool,
+
+    #[arg(
         long = "force-hard-link",
         default_value_t = false,
         env = "DFGET_FORCE_HARD_LINK",
@@ -991,6 +999,15 @@ async fn download(
     progress_bar: ProgressBar,
     download_client: DfdaemonDownloadClient,
 ) -> Result<()> {
+    if should_skip_existing_output(&args) {
+        info!(
+            "output path {} already exists, skip download",
+            args.output.display()
+        );
+        progress_bar.finish_with_message(format!("{} (skipped)", args.output.display()));
+        return Ok(());
+    }
+
     let url = Url::parse(args.url.as_str()).or_err(ErrorType::ParseError)?;
     let object_storage = if object_storage::Scheme::is_supported(url.scheme()) {
         Some(ObjectStorage {
@@ -1367,6 +1384,12 @@ fn convert_args(mut args: Args) -> Args {
 /// The validation prevents common user errors and potential security issues before
 /// starting the download process.
 fn validate_args(args: &Args) -> Result<()> {
+    if args.overwrite && args.skip_if_exists {
+        return Err(Error::ValidationError(
+            "`--skip-if-exists` cannot be used with `--overwrite=true`".to_string(),
+        ));
+    }
+
     // If the URL is a directory, the output path should be a directory.
     if args.url.path().ends_with('/') && !args.output.is_dir() {
         return Err(Error::ValidationError(format!(
@@ -1396,7 +1419,7 @@ fn validate_args(args: &Args) -> Result<()> {
             }
         }
 
-        if !args.overwrite && absolute_path.exists() {
+        if !args.overwrite && !args.skip_if_exists && absolute_path.exists() {
             return Err(Error::ValidationError(format!(
                 "output path {} is already exist",
                 args.output.to_string_lossy()
@@ -1433,6 +1456,10 @@ fn validate_args(args: &Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn should_skip_existing_output(args: &Args) -> bool {
+    !args.url.path().ends_with('/') && args.skip_if_exists && args.output.exists()
 }
 
 /// Validates that a path string is a normal relative path without unsafe components.
@@ -1541,6 +1568,20 @@ mod tests {
 
         let result = validate_args(&args);
         assert!(result.is_ok());
+
+        // Skip download when the output file already exists.
+        let existing_file_path = tempdir.path().join("existing.txt");
+        std::fs::File::create(&existing_file_path).unwrap();
+        let args = Args::parse_from(vec![
+            "dfget",
+            "http://test.local/existing.txt",
+            "--output",
+            existing_file_path.as_os_str().to_str().unwrap(),
+            "--skip-if-exists",
+        ]);
+
+        let result = validate_args(&args);
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -1599,6 +1640,17 @@ mod tests {
                 Args::parse_from(vec!["dfget", "http://test.local/test.txt", "--output", "/"]),
                 "output path / is not exist".to_string(),
             ),
+            (
+                Args::parse_from(vec![
+                    "dfget",
+                    "http://test.local/test.txt",
+                    "--output",
+                    non_exist_file_path.as_os_str().to_str().unwrap(),
+                    "--overwrite",
+                    "--skip-if-exists",
+                ]),
+                "`--skip-if-exists` cannot be used with `--overwrite=true`".to_string(),
+            ),
         ];
 
         for (args, error_message) in test_cases {
@@ -1609,6 +1661,30 @@ mod tests {
                 Error::ValidationError(error_message).to_string()
             )
         }
+    }
+
+    #[test]
+    fn should_skip_existing_output_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let existing_file_path = tempdir.path().join("test.txt");
+        std::fs::File::create(&existing_file_path).unwrap();
+
+        let args = Args::parse_from(vec![
+            "dfget",
+            "http://test.local/test.txt",
+            "--output",
+            existing_file_path.as_os_str().to_str().unwrap(),
+            "--skip-if-exists",
+        ]);
+        assert!(should_skip_existing_output(&args));
+
+        let args = Args::parse_from(vec![
+            "dfget",
+            "http://test.local/test.txt",
+            "--output",
+            existing_file_path.as_os_str().to_str().unwrap(),
+        ]);
+        assert!(!should_skip_existing_output(&args));
     }
 
     #[test]

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -138,17 +138,9 @@ struct Args {
         long = "overwrite",
         default_value_t = false,
         env = "DFGET_OVERWRITE",
-        help = "Specify whether to overwrite the output file if it already exists. If it is true, dfget will overwrite the output file. If it is false, dfget will return an error if the output file already exists. Cannot be used with `--force-hard-link=true`"
+        help = "Specify whether to overwrite the output file if it already exists. If it is true, dfget will overwrite the output file. If it is false, dfget will skip the download and return success when the output file already exists. Cannot be used with `--force-hard-link=true`"
     )]
     overwrite: bool,
-
-    #[arg(
-        long = "skip-if-exists",
-        default_value_t = false,
-        env = "DFGET_SKIP_IF_EXISTS",
-        help = "Specify whether to skip the download and return success if the output file already exists. For recursive downloads, existing files will be skipped. Cannot be used with `--overwrite=true`"
-    )]
-    skip_if_exists: bool,
 
     #[arg(
         long = "force-hard-link",
@@ -1384,12 +1376,6 @@ fn convert_args(mut args: Args) -> Args {
 /// The validation prevents common user errors and potential security issues before
 /// starting the download process.
 fn validate_args(args: &Args) -> Result<()> {
-    if args.overwrite && args.skip_if_exists {
-        return Err(Error::ValidationError(
-            "`--skip-if-exists` cannot be used with `--overwrite=true`".to_string(),
-        ));
-    }
-
     // If the URL is a directory, the output path should be a directory.
     if args.url.path().ends_with('/') && !args.output.is_dir() {
         return Err(Error::ValidationError(format!(
@@ -1417,13 +1403,6 @@ fn validate_args(args: &Args) -> Result<()> {
                     args.output.to_string_lossy()
                 )));
             }
-        }
-
-        if !args.overwrite && !args.skip_if_exists && absolute_path.exists() {
-            return Err(Error::ValidationError(format!(
-                "output path {} is already exist",
-                args.output.to_string_lossy()
-            )));
         }
     }
 
@@ -1459,7 +1438,7 @@ fn validate_args(args: &Args) -> Result<()> {
 }
 
 fn should_skip_existing_output(args: &Args) -> bool {
-    !args.url.path().ends_with('/') && args.skip_if_exists && args.output.exists()
+    !args.url.path().ends_with('/') && !args.overwrite && args.output.exists()
 }
 
 /// Validates that a path string is a normal relative path without unsafe components.
@@ -1569,7 +1548,7 @@ mod tests {
         let result = validate_args(&args);
         assert!(result.is_ok());
 
-        // Skip download when the output file already exists.
+        // Existing file is allowed and will be skipped at runtime by default.
         let existing_file_path = tempdir.path().join("existing.txt");
         std::fs::File::create(&existing_file_path).unwrap();
         let args = Args::parse_from(vec![
@@ -1577,7 +1556,6 @@ mod tests {
             "http://test.local/existing.txt",
             "--output",
             existing_file_path.as_os_str().to_str().unwrap(),
-            "--skip-if-exists",
         ]);
 
         let result = validate_args(&args);
@@ -1620,15 +1598,6 @@ mod tests {
                     "dfget",
                     "http://test.local/test.txt",
                     "--output",
-                    file_path.as_os_str().to_str().unwrap(),
-                ]),
-                format!("output path {} is already exist", file_path.display()),
-            ),
-            (
-                Args::parse_from(vec![
-                    "dfget",
-                    "http://test.local/test.txt",
-                    "--output",
                     non_exist_file_path.as_os_str().to_str().unwrap(),
                 ]),
                 format!(
@@ -1639,17 +1608,6 @@ mod tests {
             (
                 Args::parse_from(vec!["dfget", "http://test.local/test.txt", "--output", "/"]),
                 "output path / is not exist".to_string(),
-            ),
-            (
-                Args::parse_from(vec![
-                    "dfget",
-                    "http://test.local/test.txt",
-                    "--output",
-                    non_exist_file_path.as_os_str().to_str().unwrap(),
-                    "--overwrite",
-                    "--skip-if-exists",
-                ]),
-                "`--skip-if-exists` cannot be used with `--overwrite=true`".to_string(),
             ),
         ];
 
@@ -1674,7 +1632,6 @@ mod tests {
             "http://test.local/test.txt",
             "--output",
             existing_file_path.as_os_str().to_str().unwrap(),
-            "--skip-if-exists",
         ]);
         assert!(should_skip_existing_output(&args));
 
@@ -1683,6 +1640,7 @@ mod tests {
             "http://test.local/test.txt",
             "--output",
             existing_file_path.as_os_str().to_str().unwrap(),
+            "--overwrite",
         ]);
         assert!(!should_skip_existing_output(&args));
     }


### PR DESCRIPTION
## Background / Motivation

When running `dfget` repeatedly in batch jobs, retry workflows, or model synchronization tasks,
users often expect idempotent behavior when the output file already exists.

Previously, `dfget` had only two behaviors for existing output files:

- overwrite the file when `--overwrite` is enabled
- return an error when `--overwrite` is not enabled

Based on review feedback, there is no need to introduce a new CLI option for this case.
Instead, when `--overwrite=false`, `dfget` should skip existing files by default and return success.

## What’s in this PR

Update `dfget` existing-file behavior without adding a new option:

- `--overwrite=true`: overwrite the existing output file
- `--overwrite=false` (default): skip the download and return success if the output file already exists

Additional changes:

- remove the previously introduced `--skip-if-exists` option
- update argument help text to reflect the new default behavior
- apply the skip behavior before starting a single-file download
- make recursive downloads skip existing files file-by-file through the same logic
- update unit tests accordingly

## Usage

Skip existing files by default:

```bash
dfget modelscope://Qwen/Qwen3-8B -O ./Qwen3-8B -r
```

Overwrite existing files explicitly:

```bash
dfget modelscope://Qwen/Qwen3-8B -O ./Qwen3-8B -r --overwrite
```

## Compatibility

- this change modifies the default behavior when the output file already exists
- previously, `--overwrite=false` returned an error
- now, `--overwrite=false` skips the existing file and returns success
- `--overwrite=true` behavior remains unchanged

## Testing

Local validation:

```bash
cargo fmt --all -- --check
cargo clippy --all --all-targets -- -D warnings
cargo test -p dragonfly-client --bin dfget
```

Runtime verification:

- download to an existing output path without `--overwrite`
- confirm the command exits successfully and does not overwrite the file
- download to the same path with `--overwrite`
- confirm the existing file is overwritten