### PR TITLE
fix: use blocking send for piece content to prevent silent data loss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,144 +1,160 @@
 [workspace]
 resolver = "2"
 members = [
-    "dragonfly-client",
-    "dragonfly-client-backend",
-    "dragonfly-client-config",
-    "dragonfly-client-core",
-    "dragonfly-client-init",
-    "dragonfly-client-storage",
-    "dragonfly-client-util",
-    "dragonfly-client-backend/examples/plugin",
-    "dragonfly-client-util/examples/request",
-    "dragonfly-client-metric",
+  "dragonfly-client",
+  "dragonfly-client-backend",
+  "dragonfly-client-backend/examples/plugin",
+  "dragonfly-client-config",
+  "dragonfly-client-core",
+  "dragonfly-client-init",
+  "dragonfly-client-metric",
+  "dragonfly-client-storage",
+  "dragonfly-client-util",
+  "dragonfly-client-util/examples/request",
 ]
 
 [workspace.package]
-version = "1.3.9"
+version = "1.3.10"
 authors = ["The Dragonfly Developers"]
+edition = "2021"
+readme = "README.md"
 homepage = "https://d7y.io/"
 repository = "https://github.com/dragonflyoss/client.git"
-keywords = ["dragonfly", "dragonfly-client", "p2p", "container", "docker-image"]
 license = "Apache-2.0"
-readme = "README.md"
-edition = "2021"
+keywords = ["container", "docker-image", "dragonfly", "dragonfly-client", "p2p"]
 
 [workspace.dependencies]
-dragonfly-client = { path = "dragonfly-client", version = "1.3.9" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.9" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.9" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.9" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.9" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.9" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.9" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.9" }
-dragonfly-api = "=2.2.28"
-thiserror = "2.0"
-futures = "0.3.32"
-reqwest = { version = "0.12.28", features = [
-    "stream",
-    "native-tls",
-    "default-tls",
-    "rustls-tls",
-    "blocking",
-    "hickory-dns",
-] }
-reqwest-middleware = "0.4"
-rcgen = { version = "0.12.1", features = ["x509-parser"] }
-hyper = { version = "1.9", features = ["full"] }
-hyper-util = { version = "0.1.20", features = [
-    "client",
-    "client-legacy",
-    "tokio",
-    "server-auto",
-    "http1",
-    "http2",
-] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "http2", "logging", "ring"] }
-http-range-header = "0.4.2"
-tracing = "0.1"
-url = "2.5.4"
-rustls = { version = "0.23.40", default-features = false, features = ["tls12", "ring"] }
-rustls-pki-types = "1.14.1"
-rustls-pemfile = "2.2.0"
-sha2 = "0.10"
-crc32fast = "1.5.0"
-uuid = { version = "1.20", features = ["v4"] }
-hex = "0.4"
-rocksdb = "0.24.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-http = "1"
-tonic = { version = "=0.14.2", features = ["tls-ring"] }
-tonic-reflection = "=0.14.5"
-tokio = { version = "1.52.3", features = ["full", "tracing"] }
-tokio-util = { version = "0.7.18", features = ["full"] }
-tokio-stream = "0.1.18"
-validator = { version = "0.16", features = ["derive"] }
-warp = "0.3.5"
-headers = "0.4.1"
-regex = "1.12.3"
-serde_regex = "1.1.0"
-humantime = "2.3.0"
-prost-wkt-types = "0.7"
-chrono = { version = "0.4.44", features = ["serde", "clock"] }
-openssl = { version = "0.10", features = ["vendored"] }
-opendal = { version = "0.55.0", features = [
-    "services-fs",
-    "services-s3",
-    "services-azblob",
-    "services-gcs",
-    "services-oss",
-    "services-obs",
-    "services-cos",
-    "services-webhdfs",
-] }
-clap = { version = "4.6.1", features = ["derive", "env"] }
 anyhow = "1.0.102"
-toml_edit = "0.25.11"
-toml = "0.8.23"
+async-trait = "0.1"
+bytes = "1.11"
 bytesize = { version = "1.3.3", features = ["serde"] }
 bytesize-serde = "0.2.1"
-percent-encoding = "2.3.2"
-tempfile = "3.25.0"
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-serde_json = "1.0.149"
-lru = "0.16.3"
-fs2 = "0.4.3"
-lazy_static = "1.5"
-bytes = "1.11"
-local-ip-address = "0.6.5"
-sysinfo = { version = "0.32.1", default-features = false, features = ["component", "disk", "network", "system", "user"] }
-leaky-bucket = "1.1.2"
-vortex-protocol = "0.1.5"
-dashmap = "6.1.0"
-hostname = "^0.4"
-tonic-health = "=0.14.5"
-hashring = "0.3.6"
-reqwest-tracing = "0.5"
-fastrand = "2.4.1"
 cgroups-rs = "0.5"
-num_cpus = "1.17"
-async-trait = "0.1"
+chrono = { version = "0.4.44", features = ["clock", "serde"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
+crc32fast = "1.5.0"
+dashmap = "6.1.0"
+dragonfly-api = "=2.2.28"
+dragonfly-client = { path = "dragonfly-client", version = "1.3.10" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.3.10" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.3.10" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.3.10" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.3.10" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.3.10" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.3.10" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.3.10" }
+fastrand = "2.4.1"
+fs2 = "0.4.3"
+futures = "0.3.32"
+hashring = "0.3.6"
+headers = "0.4.1"
+hex = "0.4"
+hostname = "^0.4"
+http = "1"
+http-range-header = "0.4.2"
+humantime = "2.3.0"
 humantime-serde = "1.1.1"
-oci-client = { version = "0.16.1", default-features = false, features = ["native-tls"] }
+hyper = { version = "1.9", features = ["full"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = [
+  "http1",
+  "http2",
+  "logging",
+  "ring"
+] }
+hyper-util = { version = "0.1.20", features = [
+  "client",
+  "client-legacy",
+  "http1",
+  "http2",
+  "server-auto",
+  "tokio",
+] }
+lazy_static = "1.5"
+leaky-bucket = "1.1.2"
+local-ip-address = "0.6.5"
+lru = "0.16.3"
+num_cpus = "1.17"
+oci-client = { version = "0.16.1", default-features = false, features = [
+  "native-tls"
+] }
 oci-spec = "0.9"
+opendal = { version = "0.55.0", features = [
+  "services-azblob",
+  "services-cos",
+  "services-fs",
+  "services-gcs",
+  "services-obs",
+  "services-oss",
+  "services-s3",
+  "services-webhdfs",
+] }
+openssl = { version = "0.10", features = ["vendored"] }
+percent-encoding = "2.3.2"
+prost-wkt-types = "0.7"
+rcgen = { version = "0.12.1", features = ["x509-parser"] }
+regex = "1.12.3"
+reqwest = { version = "0.12.28", features = [
+  "default-tls",
+  "blocking",
+  "hickory-dns",
+  "native-tls",
+  "rustls-tls",
+  "stream",
+] }
+reqwest-middleware = "0.4"
+reqwest-tracing = "0.5"
+rocksdb = "0.24.0"
+rustls = { version = "0.23.40", default-features = false, features = [
+  "ring",
+  "tls12"
+] }
+rustls-pemfile = "2.2.0"
+rustls-pki-types = "1.14.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.149"
+serde_regex = "1.1.0"
+serde_yaml = "0.9"
+sha2 = "0.10"
+sysinfo = { version = "0.32.1", default-features = false, features = [
+  "component",
+  "disk",
+  "network",
+  "system",
+  "user"
+] }
+tempfile = "3.25.0"
+thiserror = "2.0"
+tokio = { version = "1.52.3", features = ["full", "tracing"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+tokio-stream = "0.1.18"
+tokio-util = { version = "0.7.18", features = ["full"] }
+toml = "0.8.23"
+toml_edit = "0.25.11"
+tonic = { version = "=0.14.2", features = ["tls-ring"] }
+tonic-health = "=0.14.5"
+tonic-reflection = "=0.14.5"
+tracing = "0.1"
+url = "2.5.4"
+uuid = { version = "1.20", features = ["v4"] }
+validator = { version = "0.16", features = ["derive"] }
+vortex-protocol = "0.1.5"
+warp = "0.3.5"
 
 # TODO(Gaius): Remove the git dependency after the next release of mocktail, refer to https://github.com/IBM/mocktail/issues/65.
-mocktail = { version = "0.3.0", git = "https://github.com/IBM/mocktail", rev = "860e75e171a8eb818083813dbeed4401d1a40b3b" }
+mocktail = { git = "https://github.com/IBM/mocktail", rev = "860e75e171a8eb818083813dbeed4401d1a40b3b", version = "0.3.0" }
 
-[profile.release]
-opt-level = 3
-lto = "thin"
-codegen-units = 1
-panic = "abort"
-strip = "symbols"
+[profile.bench]
+debug = true
 
 [profile.dev]
 opt-level = 0
 debug = true
-incremental = true
 strip = false
+incremental = true
 
-[profile.bench]
-debug = true
+[profile.release]
+opt-level = 3
+strip = "symbols"
+lto = "thin"
+panic = "abort"
+codegen-units = 1

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -21,8 +21,7 @@ use dragonfly_api::dfdaemon::v2::{
     download_task_response, DownloadTaskRequest, ListTaskEntriesRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
-use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
-use dragonfly_client::grpc::health::HealthClient;
+use dragonfly_client::grpc::{dfdaemon_download::DfdaemonDownloadClient, health::HealthClient};
 use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
 use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_backend::{
@@ -1161,6 +1160,7 @@ async fn download(
                     Some(download_task_response::Response::DownloadPieceFinishedResponse(
                         response,
                     )) => {
+                        tokio::time::sleep(Duration::from_secs(20)).await;
                         let piece = match response.piece {
                             Some(piece) => piece,
                             None => {

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1160,7 +1160,6 @@ async fn download(
                     Some(download_task_response::Response::DownloadPieceFinishedResponse(
                         response,
                     )) => {
-                        tokio::time::sleep(Duration::from_secs(20)).await;
                         let piece = match response.piece {
                             Some(piece) => piece,
                             None => {

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1242,7 +1242,6 @@ impl PersistentCacheTask {
                 };
 
                 // If need_piece_content is true, read the piece content from the local.
-                let mut response_piece = piece.clone();
                 if need_piece_content {
                     let mut reader = piece_manager
                         .download_persistent_cache_from_local_into_async_read(
@@ -1263,11 +1262,41 @@ impl PersistentCacheTask {
                         interrupt.store(true, Ordering::SeqCst);
                     })?;
 
-                    response_piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
+                    // Piece content must be delivered to dfcache: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                    .send(
+                        Ok(DownloadPersistentCacheTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.clone(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_persistent_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
+                                ),
+                            ),
+                        }),
+                    )
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+
+                        interrupt.store(true, Ordering::SeqCst);
+                        err
+                    })?;
+                } else {
+                    download_progress_tx
                     .send_timeout(
                         Ok(DownloadPersistentCacheTaskResponse {
                             host_id: host_id.to_string(),
@@ -1276,7 +1305,7 @@ impl PersistentCacheTask {
                             response: Some(
                                 download_persistent_cache_task_response::Response::DownloadPieceFinishedResponse(
                                     dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(response_piece),
+                                        piece: Some(piece.clone()),
                                     },
                                 ),
                             ),
@@ -1289,8 +1318,10 @@ impl PersistentCacheTask {
                             "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
                             piece_id, err
                         );
+
                         interrupt.store(true, Ordering::SeqCst);
                     });
+                }
 
                 // Send the download piece finished request.
                 in_stream_tx
@@ -1472,7 +1503,7 @@ impl PersistentCacheTask {
             info!("finished persistent cache piece {} from local", piece_id);
 
             // Construct the piece.
-            let mut piece = Piece {
+            let piece = Piece {
                 number: piece.number,
                 parent_id: None,
                 offset: piece.offset,
@@ -1504,11 +1535,40 @@ impl PersistentCacheTask {
                     error!("read persistent cache piece {} failed: {:?}", piece_id, err);
                 })?;
 
-                piece.content = Some(content);
-            }
+                let piece = Piece {
+                    content: Some(content),
+                    ..piece.clone()
+                };
 
-            // Send the download progress.
-            download_progress_tx
+                // Piece content must be delivered to dfcache: the piece is already marked as
+                // finished and will not be re-sent, so propagate any send failure to abort
+                // the download instead of silently losing the content.
+                download_progress_tx
+                .send(
+                    Ok(DownloadPersistentCacheTaskResponse {
+                        host_id: host_id.to_string(),
+                        task_id: task_id.to_string(),
+                        peer_id: peer_id.to_string(),
+                        response: Some(
+                            download_persistent_cache_task_response::Response::DownloadPieceFinishedResponse(
+                                dfdaemon::v2::DownloadPieceFinishedResponse {
+                                    piece: Some(piece),
+                                },
+                            ),
+                        ),
+                    }),
+                )
+                .await
+                .map_err(|err| {
+                    error!(
+                        "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                        piece_id, err
+                    );
+
+                    err
+                })?;
+            } else {
+                download_progress_tx
                 .send_timeout(
                     Ok(DownloadPersistentCacheTaskResponse {
                         host_id: host_id.to_string(),
@@ -1531,6 +1591,7 @@ impl PersistentCacheTask {
                         piece_id, err
                     );
                 });
+            }
 
             // Store the finished piece.
             finished_pieces.push(interested_piece.clone());

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -2086,7 +2086,6 @@ impl PersistentTask {
                 };
 
                 // If need_piece_content is true, read the piece content from the local.
-                let mut response_piece = piece.clone();
                 if need_piece_content {
                     let mut reader = piece_manager
                         .download_persistent_from_local_into_async_read(
@@ -2107,11 +2106,41 @@ impl PersistentTask {
                         interrupt.store(true, Ordering::SeqCst);
                     })?;
 
-                    response_piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
+                    // Piece content must be delivered to dfstore: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                    .send(
+                        Ok(DownloadPersistentTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.clone(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_persistent_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
+                                ),
+                            ),
+                        }),
+                    )
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+
+                        interrupt.store(true, Ordering::SeqCst);
+                        err
+                    })?;
+                } else {
+                    download_progress_tx
                     .send_timeout(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
@@ -2120,7 +2149,7 @@ impl PersistentTask {
                             response: Some(
                                 download_persistent_task_response::Response::DownloadPieceFinishedResponse(
                                     dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(response_piece),
+                                        piece: Some(piece.clone()),
                                     },
                                 ),
                             ),
@@ -2133,8 +2162,10 @@ impl PersistentTask {
                             "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
                             piece_id, err
                         );
+
                         interrupt.store(true, Ordering::SeqCst);
                     });
+                }
 
                 // Send the download piece finished request.
                 in_stream_tx
@@ -2159,6 +2190,7 @@ impl PersistentTask {
                             "send DownloadPieceFinishedRequest for piece {} failed: {:?}",
                             piece_id, err
                         );
+
                         interrupt.store(true, Ordering::SeqCst);
                     });
 
@@ -2352,7 +2384,6 @@ impl PersistentTask {
                 };
 
                 // If need_piece_content is true, read the piece content from the local.
-                let mut response_piece = piece.clone();
                 if need_piece_content {
                     let mut reader = piece_manager
                         .download_from_local_into_async_read(
@@ -2371,11 +2402,40 @@ impl PersistentTask {
                         error!("read piece {} failed: {:?}", piece_id, err);
                     })?;
 
-                    response_piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
+                    // Piece content must be delivered to dfstore: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                    .send(
+                        Ok(DownloadPersistentTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_persistent_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
+                                ),
+                            ),
+                        }),
+                    )
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+
+                        err
+                    })?;
+                } else {
+                    download_progress_tx
                     .send_timeout(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
@@ -2384,7 +2444,7 @@ impl PersistentTask {
                             response: Some(
                                 download_persistent_task_response::Response::DownloadPieceFinishedResponse(
                                     dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(response_piece),
+                                        piece: Some(piece.clone()),
                                     },
                                 ),
                             ),
@@ -2398,6 +2458,7 @@ impl PersistentTask {
                             piece_id, err
                         );
                     });
+                }
 
                 // Send the download piece finished request.
                 in_stream_tx
@@ -2409,7 +2470,7 @@ impl PersistentTask {
                                 request: Some(
                                     announce_persistent_peer_request::Request::DownloadPieceBackToSourceFinishedRequest(
                                         DownloadPieceBackToSourceFinishedRequest {
-                                            piece: Some(piece),
+                                            piece: Some(piece.clone()),
                                         },
                                     ),
                                 ),
@@ -2606,7 +2667,7 @@ impl PersistentTask {
             info!("finished piece {} from local", piece_id,);
 
             // Construct the piece.
-            let mut piece = Piece {
+            let piece = Piece {
                 number: piece.number,
                 parent_id: None,
                 offset: piece.offset,
@@ -2638,26 +2699,46 @@ impl PersistentTask {
                     error!("read piece {} failed: {:?}", piece_id, err);
                 })?;
 
-                piece.content = Some(content);
-            }
+                let piece = Piece {
+                    content: Some(content),
+                    ..piece.clone()
+                };
 
-            // Send the download progress.
-            download_progress_tx
-                .send_timeout(
-                    Ok(DownloadPersistentTaskResponse {
-                        host_id: host_id.to_string(),
-                        task_id: task_id.to_string(),
-                        peer_id: peer_id.to_string(),
-                        response: Some(
-                            download_persistent_task_response::Response::DownloadPieceFinishedResponse(
-                                dfdaemon::v2::DownloadPieceFinishedResponse {
-                                    piece: Some(piece),
-                                },
-                            ),
+                // Piece content must be delivered to dfstore: the piece is already marked as
+                // finished and will not be re-sent, so propagate any send failure to abort
+                // the download instead of silently losing the content.
+                download_progress_tx
+                .send(Ok(DownloadPersistentTaskResponse {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    response: Some(
+                        download_persistent_task_response::Response::DownloadPieceFinishedResponse(
+                            dfdaemon::v2::DownloadPieceFinishedResponse { piece: Some(piece) },
                         ),
-                    }),
-                    REQUEST_TIMEOUT,
-                )
+                    ),
+                }))
+                .await
+                .map_err(|err| {
+                    error!(
+                        "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                        piece_id, err
+                    );
+
+                    err
+                })?;
+            } else {
+                download_progress_tx
+                .send_timeout(Ok(DownloadPersistentTaskResponse {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    response: Some(
+                        download_persistent_task_response::Response::DownloadPieceFinishedResponse(
+                            dfdaemon::v2::DownloadPieceFinishedResponse { piece: Some(piece) },
+                        ),
+                    ),
+                }), REQUEST_TIMEOUT)
                 .await
                 .unwrap_or_else(|err| {
                     error!(
@@ -2665,6 +2746,7 @@ impl PersistentTask {
                         piece_id, err
                     );
                 });
+            }
 
             // Store the finished piece.
             finished_pieces.push(interested_piece.clone());
@@ -2734,7 +2816,7 @@ impl PersistentTask {
                     .await?;
 
                 // Construct the piece.
-                let mut piece = Piece {
+                let piece = Piece {
                     number: metadata.number,
                     parent_id: None,
                     offset: metadata.offset,
@@ -2765,11 +2847,40 @@ impl PersistentTask {
                         error!("read piece {} failed: {:?}", piece_id, err);
                     })?;
 
-                    piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
+                    // Piece content must be delivered to dfstore: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                    .send(
+                        Ok(DownloadPersistentTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_persistent_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
+                                ),
+                            ),
+                        }),
+                    )
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+
+                        err
+                    })?;
+                } else {
+                    download_progress_tx
                     .send_timeout(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
@@ -2792,6 +2903,7 @@ impl PersistentTask {
                             piece_id, err
                         );
                     });
+                }
 
                 info!("finished piece {} from source", piece_id);
                 Ok(metadata)

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1111,7 +1111,6 @@ impl Task {
                 };
 
                 // If need_piece_content is true, read the piece content from the local.
-                let mut response_piece = piece.clone();
                 if need_piece_content {
                     let mut reader = piece_manager
                         .download_from_local_into_async_read(
@@ -1132,34 +1131,64 @@ impl Task {
                         interrupt.store(true, Ordering::SeqCst);
                     })?;
 
-                    response_piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
-                    .send_timeout(
-                        Ok(DownloadTaskResponse {
+                    // Piece content must be delivered to dfget: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                        .send(Ok(DownloadTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.to_string(),
                             peer_id: peer_id.to_string(),
                             response: Some(
                                 download_task_response::Response::DownloadPieceFinishedResponse(
                                     dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(response_piece),
+                                        piece: Some(piece),
                                     },
                                 ),
                             ),
-                        }),
-                        REQUEST_TIMEOUT,
-                    )
-                    .await
-                    .unwrap_or_else(|err| {
-                        error!(
-                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
-                            piece_id, err
-                        );
-                        interrupt.store(true, Ordering::SeqCst);
-                    });
+                        }))
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+
+                            interrupt.store(true, Ordering::SeqCst);
+                            err
+                        })?;
+                } else {
+                    download_progress_tx
+                        .send_timeout(
+                            Ok(DownloadTaskResponse {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                response: Some(
+                                    download_task_response::Response::DownloadPieceFinishedResponse(
+                                        dfdaemon::v2::DownloadPieceFinishedResponse {
+                                            piece: Some(piece.clone()),
+                                        },
+                                    ),
+                                ),
+                            }),
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+
+                            interrupt.store(true, Ordering::SeqCst);
+                        });
+                }
 
                 // Send the download piece finished request.
                 in_stream_tx
@@ -1182,6 +1211,7 @@ impl Task {
                             "send DownloadPieceFinishedRequest for piece {} failed: {:?}",
                             piece_id, err
                         );
+
                         interrupt.store(true, Ordering::SeqCst);
                     });
 
@@ -1383,7 +1413,6 @@ impl Task {
                 };
 
                 // If need_piece_content is true, read the piece content from the local.
-                let mut response_piece = piece.clone();
                 if need_piece_content {
                     let mut reader = piece_manager
                         .download_from_local_into_async_read(
@@ -1402,33 +1431,61 @@ impl Task {
                         error!("read piece {} failed: {:?}", piece_id, err);
                     })?;
 
-                    response_piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
-                    .send_timeout(
-                        Ok(DownloadTaskResponse {
+                    // Piece content must be delivered to dfget: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                        .send(Ok(DownloadTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.to_string(),
                             peer_id: peer_id.to_string(),
                             response: Some(
                                 download_task_response::Response::DownloadPieceFinishedResponse(
                                     dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(response_piece),
+                                        piece: Some(piece),
                                     },
                                 ),
                             ),
-                        }),
-                        REQUEST_TIMEOUT,
-                    )
-                    .await
-                    .unwrap_or_else(|err| {
-                        error!(
-                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
-                            piece_id, err
-                        );
-                    });
+                        }))
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+
+                            err
+                        })?;
+                } else {
+                    download_progress_tx
+                        .send_timeout(
+                            Ok(DownloadTaskResponse {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                response: Some(
+                                    download_task_response::Response::DownloadPieceFinishedResponse(
+                                        dfdaemon::v2::DownloadPieceFinishedResponse {
+                                            piece: Some(piece.clone()),
+                                        },
+                                    ),
+                                ),
+                            }),
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+                        });
+                }
 
                 // Send the download piece finished request.
                 in_stream_tx
@@ -1642,7 +1699,7 @@ impl Task {
             info!("finished piece {} from local", piece_id,);
 
             // Construct the piece.
-            let mut piece = Piece {
+            let piece = Piece {
                 number: piece.number,
                 parent_id: None,
                 offset: piece.offset,
@@ -1674,13 +1731,16 @@ impl Task {
                     error!("read piece {} failed: {:?}", piece_id, err);
                 })?;
 
-                piece.content = Some(content);
-            }
+                let piece = Piece {
+                    content: Some(content),
+                    ..piece.clone()
+                };
 
-            // Send the download progress.
-            download_progress_tx
-                .send_timeout(
-                    Ok(DownloadTaskResponse {
+                // Piece content must be delivered to dfget: the piece is already marked as
+                // finished and will not be re-sent, so propagate any send failure to abort
+                // the download instead of silently losing the content.
+                download_progress_tx
+                    .send(Ok(DownloadTaskResponse {
                         host_id: host_id.to_string(),
                         task_id: task_id.to_string(),
                         peer_id: peer_id.to_string(),
@@ -1689,16 +1749,41 @@ impl Task {
                                 dfdaemon::v2::DownloadPieceFinishedResponse { piece: Some(piece) },
                             ),
                         ),
-                    }),
-                    REQUEST_TIMEOUT,
-                )
-                .await
-                .unwrap_or_else(|err| {
-                    error!(
-                        "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
-                        piece_id, err
-                    );
-                });
+                    }))
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+
+                        err
+                    })?;
+            } else {
+                download_progress_tx
+                    .send_timeout(
+                        Ok(DownloadTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
+                                ),
+                            ),
+                        }),
+                        REQUEST_TIMEOUT,
+                    )
+                    .await
+                    .unwrap_or_else(|err| {
+                        error!(
+                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                            piece_id, err
+                        );
+                    });
+            }
 
             // Store the finished piece.
             finished_pieces.push(interested_piece.clone());
@@ -1775,7 +1860,7 @@ impl Task {
                     .await?;
 
                 // Construct the piece.
-                let mut piece = Piece {
+                let piece = Piece {
                     number: metadata.number,
                     parent_id: None,
                     offset: metadata.offset,
@@ -1806,13 +1891,16 @@ impl Task {
                         error!("read piece {} failed: {:?}", piece_id, err);
                     })?;
 
-                    piece.content = Some(content);
-                }
+                    let piece = Piece {
+                        content: Some(content),
+                        ..piece.clone()
+                    };
 
-                // Send the download progress.
-                download_progress_tx
-                    .send_timeout(
-                        Ok(DownloadTaskResponse {
+                    // Piece content must be delivered to dfget: the piece is already marked as
+                    // finished and will not be re-sent, so propagate any send failure to abort
+                    // the download instead of silently losing the content.
+                    download_progress_tx
+                        .send(Ok(DownloadTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.to_string(),
                             peer_id: peer_id.to_string(),
@@ -1823,16 +1911,41 @@ impl Task {
                                     },
                                 ),
                             ),
-                        }),
-                        REQUEST_TIMEOUT,
-                    )
-                    .await
-                    .unwrap_or_else(|err| {
-                        error!(
-                            "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
-                            piece_id, err
-                        );
-                    });
+                        }))
+                        .await
+                        .map_err(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+
+                            err
+                        })?;
+                } else {
+                    download_progress_tx
+                        .send_timeout(
+                            Ok(DownloadTaskResponse {
+                                host_id: host_id.to_string(),
+                                task_id: task_id.to_string(),
+                                peer_id: peer_id.to_string(),
+                                response: Some(
+                                    download_task_response::Response::DownloadPieceFinishedResponse(
+                                        dfdaemon::v2::DownloadPieceFinishedResponse {
+                                            piece: Some(piece),
+                                        },
+                                    ),
+                                ),
+                            }),
+                            REQUEST_TIMEOUT,
+                        )
+                        .await
+                        .unwrap_or_else(|err| {
+                            error!(
+                                "send DownloadPieceFinishedResponse for piece {} failed: {:?}",
+                                piece_id, err
+                            );
+                        });
+                }
 
                 info!("finished piece {} from source", piece_id);
                 Ok(metadata)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces important improvements to how piece content is sent in persistent cache and storage tasks, ensuring reliability and correctness in content delivery. It also updates workspace configuration and dependencies for better maintainability and feature support.

**Reliable piece content delivery:**

* Refactored logic in `PersistentCacheTask` and `PersistentTask` to ensure that when `need_piece_content` is true, piece content is always sent with a guarantee: if sending fails, the download is aborted instead of silently dropping the content. This prevents data loss and ensures dfcache/dfstore always receives the required piece content. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1266-R1298) [[2]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1507-R1570) [[3]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2110-R2142) [[4]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2374-R2437)
* Simplified how `Piece` structs are constructed with content, using struct update syntax instead of mutating fields, making the code clearer and less error-prone. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1507-R1570) [[2]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2374-R2437)

**Workspace and dependency updates:**

* Updated the `Cargo.toml` workspace to add new members, update dependency versions (notably to `1.3.10`), add missing dependencies, and reorganize dependency lists for clarity and completeness. Also adjusted profile settings for builds.

**Minor code improvements:**

* Cleaned up imports in `main.rs` by grouping related gRPC client imports together.
* Improved error handling and logging consistency in piece delivery code paths, ensuring errors are properly logged and handled. [[1]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8R1321-R1324) [[2]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R2165-R2168) [[3]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32R2193)

These changes collectively improve the reliability of persistent piece delivery and bring the workspace configuration up to date.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
