### PR TITLE
build(ci): upgrade alpine to 3.23.4 and golang to 1.25.5 in Dockerfiles

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -50,7 +50,7 @@ RUN case "${TARGETPLATFORM}" in \
 
 RUN cargo install tokio-console --version 0.1.13 --locked --root /usr/local
 
-FROM alpine:3.20 AS health
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS health
 
 ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
 
@@ -63,7 +63,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi && \
     chmod +x /bin/grpc_health_probe
 
-FROM golang:1.24.0-alpine3.20 AS pprof
+FROM golang:1.25.5-alpine3.23@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS pprof
 
 RUN go install github.com/google/pprof@v0.0.0-20251114195745-4902fdda35c8
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest

--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -52,7 +52,7 @@ RUN cargo install flamegraph --version 0.6.8 --root /usr/local
 RUN cargo install bottom --version 0.11.0 --locked --root /usr/local
 RUN cargo install tokio-console --version 0.1.13 --locked --root /usr/local
 
-FROM alpine:3.20 AS health
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS health
 
 ENV GRPC_HEALTH_PROBE_VERSION=v0.4.24
 
@@ -65,7 +65,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi && \
     chmod +x /bin/grpc_health_probe
 
-FROM golang:1.24.0-alpine3.20 AS pprof
+FROM golang:1.25.5-alpine3.23@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS pprof
 
 RUN go install github.com/google/pprof@v0.0.0-20251114195745-4902fdda35c8
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the base images used in both `ci/Dockerfile` and `ci/Dockerfile.debug` to newer versions with pinned digests. This ensures more secure and reproducible Docker builds by using specific image versions and their associated SHA256 digests. The updates affect both the `health` and `pprof` build stages, and also update the Go version used for the `pprof` stage.

**Base image updates for improved security and reproducibility:**

* Updated the `health` stage to use `alpine:3.23.4` with a specific SHA256 digest instead of `alpine:3.20`, in both `ci/Dockerfile` and `ci/Dockerfile.debug`. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL53-R53) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L55-R55)
* Updated the `pprof` stage to use `golang:1.25.5-alpine3.23` with a specific SHA256 digest instead of `golang:1.24.0-alpine3.20`, in both `ci/Dockerfile` and `ci/Dockerfile.debug`. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecL66-R66) [[2]](diffhunk://#diff-13f9c6664d42189b9dcb3443624a438ddd6ed0cab1893f225226779346027944L68-R68)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
