### PR TITLE
fix(backend): use full error chain in stream read failures

### DIFF
--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -696,7 +696,7 @@ impl Backend for HTTP {
                     source = err.source();
                 }
 
-                IOError::new(ErrorKind::Other, err)
+                IOError::new(ErrorKind::Other, chain)
             },
         )));
 

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -646,7 +646,7 @@ impl Backend for HuggingFace {
                     source = err.source();
                 }
 
-                IOError::new(ErrorKind::Other, err)
+                IOError::new(ErrorKind::Other, chain)
             },
         )));
 

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -618,7 +618,7 @@ impl Backend for ModelScope {
                     source = err.source();
                 }
 
-                IOError::new(ErrorKind::Other, err)
+                IOError::new(ErrorKind::Other, chain)
             },
         )));
 


### PR DESCRIPTION
## Description

The `map_err` closures in `get()` across all three backends walk the error source chain into a `chain` string but then pass the original `err` to `IOError::new()` instead of `chain`. The full error context gets computed and thrown away.

Fixes http, hugging_face, and model_scope backends.

## Motivation and Context

When a stream read fails mid-download, the IOError only contains the top-level message. Nested causes (DNS, TLS, connection reset, etc.) are lost. This makes debugging download failures harder than it needs to be.