### PR TITLE
fix(proxy): return 206 Partial Content for range requests via dfdaemon

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -844,7 +844,14 @@ async fn proxy_via_dfdaemon(
         config.host.ip.unwrap(),
         download_task_started_response.clone(),
     )?;
-    *response.status_mut() = http::StatusCode::OK;
+    // Return 206 Partial Content for range requests to match the Content-Range header set by
+    // make_response_headers. Returning 200 for a partial body breaks range-aware clients (e.g. the
+    // containerd stargz-snapshotter), which then read the partial body as the full object.
+    *response.status_mut() = if download_task_started_response.range.is_some() {
+        http::StatusCode::PARTIAL_CONTENT
+    } else {
+        http::StatusCode::OK
+    };
 
     // Return the response if the client return the first piece.
     let mut initialized = false;


### PR DESCRIPTION
`proxy_via_dfdaemon` sets a `Content-Range` header on range responses but always returns `200 OK`. Per RFC 7233 a partial body has to be `206 Partial Content` — a `200` carrying `Content-Range` is self-contradictory, and any range-aware client reads the body as if it were the whole object.

We hit this running the containerd [stargz-snapshotter](https://github.com/containerd/stargz-snapshotter) through Dragonfly. The snapshotter range-reads the eStargz footer/TOC, gets `200` back, takes its non-partial path, and parses the footer at offset 0 → `failed to get root node`, so the layer never FUSE-mounts and the pull falls back to a full pull.

The HTTP and HTTPS proxy paths already forward the upstream status; only the dfdaemon path hardcodes `OK`. The fix keys the status on the same `range` field that already decides whether to emit `Content-Range`:

```rust
*response.status_mut() = if download_task_started_response.range.is_some() {
    http::StatusCode::PARTIAL_CONTENT
} else {
    http::StatusCode::OK
};
```

<details>
<summary>Setup where we hit it</summary>

- dragonfly client / dfdaemon **v1.3.8** (also reproduces on `main`)
- manager + scheduler v2.4.4-rc.1 (helm chart `dragonfly-1.6.27`)
- containerd **stargz-snapshotter v0.16.3** as a containerd proxy snapshotter
- containerd 2.x, Amazon Linux 2023
- eStargz images in a private ECR; dfdaemon configured as the snapshotter's registry mirror
</details>

<details>
<summary>Repro</summary>

Just the proxy — any blob reachable via dfdaemon, asked for a byte range:

```console
$ curl -si -H 'Range: bytes=0-1023' http://127.0.0.1:4001/v2/<repo>/blobs/<digest> | head
HTTP/1.1 200 OK                          # <- should be 206 Partial Content
Content-Range: bytes 0-1023/<size>
Content-Length: 1024
```

End to end:
1. Point the snapshotter's `resolver.host."<registry>".mirrors` at the dfdaemon proxy.
2. Pull an eStargz image. The snapshotter logs `failed to get root node` / `unexpected status code 200` and the layer fails to mount.
</details>

<details>
<summary>Our stopgap (dropped once this lands)</summary>

We run a tiny node-local reverse proxy between the snapshotter and dfdaemon that rewrites `200` → `206` whenever a `Content-Range` header is present. It works, but it's an extra hop on every node we'd rather not maintain.
</details>

<details>
<summary>Example snapshotter mirror config</summary>

```toml
# /etc/containerd-stargz-grpc/config.toml
[[resolver.host."<registry>".mirrors]]
host = "127.0.0.1:4001"   # dfdaemon proxy
insecure = true
```
</details>
