### PR TITLE
perf: add BufWriter and increase gRPC stream buffer for file transfer

### DIFF
--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -1531,7 +1531,7 @@ mod tests {
         let tag = "slow-upload-tag";
         let app = "slow-upload-app";
         let small_size = 512 * 1024;
-        let slow_duration = Duration::from_millis(600);
+        let slow_duration = Duration::from_millis(1000);
         collect_upload_task_started_metrics(1, tag, app);
 
         let histogram_before = UPLOAD_TASK_DURATION

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use std::{cmp::min, fmt::Write};
 use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tracing::{debug, error, info};
 
 use super::*;
@@ -139,6 +139,10 @@ pub struct ExportCommand {
     )]
     console: bool,
 }
+
+/// The buffer size used for transferring data from dfdaemon to dfget when
+/// `--transfer-from-dfdaemon` is enabled.
+const TRANSFER_WRITE_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
 /// Implement the execute for ExportCommand.
 impl ExportCommand {
@@ -509,7 +513,7 @@ impl ExportCommand {
                     error!("open file {:?} failed: {}", self.output, err);
                 })?;
 
-            Some(f)
+            Some(BufWriter::with_capacity(TRANSFER_WRITE_BUFFER_SIZE, f))
         } else {
             None
         };
@@ -543,7 +547,7 @@ impl ExportCommand {
                             response,
                         )) => {
                             if let Some(f) = &f {
-                                if let Err(err) = fallocate(f, response.content_length).await {
+                                if let Err(err) = fallocate(f.get_ref(), response.content_length).await {
                                     error!("fallocate {:?} failed: {}", self.output, err);
                                     fs::remove_file(&self.output).await.inspect_err(|err| {
                                         error!("remove file {:?} failed: {}", self.output, err);

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -47,7 +47,7 @@ use std::time::Duration;
 use std::{cmp::min, fmt::Write};
 use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn, Instrument, Level};
@@ -424,6 +424,10 @@ struct Args {
     )]
     version: bool,
 }
+
+/// The buffer size used for transferring data from dfdaemon to dfget when
+/// `--transfer-from-dfdaemon` is enabled.
+const TRANSFER_WRITE_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -1133,7 +1137,7 @@ async fn download(
                 error!("open file {:?} failed: {}", args.output, err);
             })?;
 
-        Some(f)
+        Some(BufWriter::with_capacity(TRANSFER_WRITE_BUFFER_SIZE, f))
     } else {
         None
     };
@@ -1163,7 +1167,8 @@ async fn download(
                         response,
                     )) => {
                         if let Some(f) = &f {
-                            if let Err(err) = fallocate(f, response.content_length).await {
+                            if let Err(err) = fallocate(f.get_ref(), response.content_length).await
+                            {
                                 error!("fallocate {:?} failed: {}", args.output, err);
                                 fs::remove_file(&args.output).await.inspect_err(|err| {
                                     error!("remove file {:?} failed: {}", args.output, err);

--- a/dragonfly-client/src/bin/dfstore/export.rs
+++ b/dragonfly-client/src/bin/dfstore/export.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use std::{cmp::min, fmt::Write};
 use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -191,6 +191,10 @@ pub struct ExportCommand {
     )]
     console: bool,
 }
+
+/// The buffer size used for transferring data from dfdaemon to dfget when
+/// `--transfer-from-dfdaemon` is enabled.
+const TRANSFER_WRITE_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
 /// Implement the execute for ExportCommand.
 impl ExportCommand {
@@ -570,7 +574,7 @@ impl ExportCommand {
                     error!("open file {:?} failed: {}", self.output, err);
                 })?;
 
-            Some(f)
+            Some(BufWriter::with_capacity(TRANSFER_WRITE_BUFFER_SIZE, f))
         } else {
             None
         };
@@ -604,7 +608,7 @@ impl ExportCommand {
                             response,
                         )) => {
                             if let Some(f) = &f {
-                                if let Err(err) = fallocate(f, response.content_length).await {
+                                if let Err(err) = fallocate(f.get_ref(), response.content_length).await {
                                     error!("fallocate {:?} failed: {}", self.output, err);
                                     fs::remove_file(&self.output).await.inspect_err(|err| {
                                         error!("remove file {:?} failed: {}", self.output, err);

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -501,7 +501,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         let download_clone = download.clone();
         let task_manager_clone = self.task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(
@@ -1295,7 +1295,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         let request_clone = request.clone();
         let task_manager_clone = self.persistent_task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(
@@ -1849,7 +1849,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         let request_clone = request.clone();
         let task_manager_clone = self.persistent_cache_task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -452,7 +452,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let download_clone = download.clone();
         let task_manager_clone = self.task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(
@@ -1371,7 +1371,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let request_clone = request.clone();
         let task_manager_clone = self.persistent_task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(
@@ -1972,7 +1972,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         let request_clone = request.clone();
         let task_manager_clone = self.persistent_cache_task.clone();
         let task_clone = task.clone();
-        let (out_stream_tx, out_stream_rx) = mpsc::channel(4);
+        let (out_stream_tx, out_stream_rx) = mpsc::channel(super::DOWNLOAD_STREAM_BUFFER_SIZE);
 
         // Define the error handler to send the error to the stream.
         async fn handle_error(

--- a/dragonfly-client/src/grpc/health.rs
+++ b/dragonfly-client/src/grpc/health.rs
@@ -84,6 +84,11 @@ impl HealthClient {
         // Ignore the uri because it is not used.
         let channel = Endpoint::try_from("http://[::]:50051")
             .unwrap()
+            .connect_timeout(super::CONNECT_TIMEOUT)
+            .timeout(super::REQUEST_TIMEOUT)
+            .tcp_keepalive(Some(super::TCP_KEEPALIVE))
+            .http2_keep_alive_interval(super::HTTP2_KEEP_ALIVE_INTERVAL)
+            .keep_alive_timeout(super::HTTP2_KEEP_ALIVE_TIMEOUT)
             .connect_with_connector(service_fn(move |_: Uri| {
                 let socket_path = socket_path.clone();
                 async move {

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -34,7 +34,7 @@ pub mod middleware;
 pub mod scheduler;
 
 /// CONNECT_TIMEOUT is the timeout for GRPC connection.
-pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// REQUEST_TIMEOUT is the timeout for GRPC requests, default is 10 second.
 ///
@@ -70,6 +70,9 @@ pub const INITIAL_WINDOW_SIZE: u32 = 512 * 1024;
 
 /// INITIAL_CONNECTION_WINDOW_SIZE is the initial connection window size for GRPC, default is 4MiB.
 pub const INITIAL_CONNECTION_WINDOW_SIZE: u32 = 4 * 1024 * 1024;
+
+/// DOWNLOAD_STREAM_BUFFER_SIZE is the buffer size for download gRPC stream messages.
+pub const DOWNLOAD_STREAM_BUFFER_SIZE: usize = 12;
 
 /// prefetch_task prefetches the task if prefetch flag is true.
 #[instrument(skip_all)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request improves the performance and reliability of file transfers and gRPC streaming in the Dragonfly client by introducing buffered file writes and configurable stream buffer sizes. It also adjusts several gRPC timeout and keepalive settings for better connection stability.

**File Transfer Buffering Enhancements:**
- Introduced a constant `TRANSFER_WRITE_BUFFER_SIZE` (8 MiB) and now wrap output files with `BufWriter` during export and download operations in `dfcache`, `dfget`, and `dfstore`, improving write efficiency for large file transfers. [[1]](diffhunk://#diff-34df97fe46fe447ea9afb67277f138cd7783e36994926db7200374d1a80cbea8L34-R34) [[2]](diffhunk://#diff-34df97fe46fe447ea9afb67277f138cd7783e36994926db7200374d1a80cbea8R143-R146) [[3]](diffhunk://#diff-34df97fe46fe447ea9afb67277f138cd7783e36994926db7200374d1a80cbea8L512-R516) [[4]](diffhunk://#diff-e777585743ced60ee982e1cfa97f5a7f2e344f649494261fab3e7b4b19c1760dL50-R50) [[5]](diffhunk://#diff-e777585743ced60ee982e1cfa97f5a7f2e344f649494261fab3e7b4b19c1760dR428-R431) [[6]](diffhunk://#diff-e777585743ced60ee982e1cfa97f5a7f2e344f649494261fab3e7b4b19c1760dL1136-R1140) [[7]](diffhunk://#diff-184f12a3714d49072811cf56a8b57ba5884a8b148b620a8dae4a6fecac8fa81fL36-R36) [[8]](diffhunk://#diff-184f12a3714d49072811cf56a8b57ba5884a8b148b620a8dae4a6fecac8fa81fR195-R198) [[9]](diffhunk://#diff-184f12a3714d49072811cf56a8b57ba5884a8b148b620a8dae4a6fecac8fa81fL573-R577)

- Updated calls to `fallocate` to use the underlying file from `BufWriter` by calling `.get_ref()`, ensuring preallocation is performed on the actual file descriptor. [[1]](diffhunk://#diff-34df97fe46fe447ea9afb67277f138cd7783e36994926db7200374d1a80cbea8L546-R550) [[2]](diffhunk://#diff-e777585743ced60ee982e1cfa97f5a7f2e344f649494261fab3e7b4b19c1760dL1166-R1171) [[3]](diffhunk://#diff-184f12a3714d49072811cf56a8b57ba5884a8b148b620a8dae4a6fecac8fa81fL607-R611)

**gRPC Stream Buffering and Configuration:**
- Added a new constant `DOWNLOAD_STREAM_BUFFER_SIZE` (12) and updated all gRPC download and upload handlers to use this buffer size instead of a hardcoded value, allowing more concurrent messages in the stream. [[1]](diffhunk://#diff-d859a94a5da0dde503031572af96e4c4e81cf8b4d702db0b332d8d4bf6153356R74-R76) [[2]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL504-R504) [[3]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL1298-R1298) [[4]](diffhunk://#diff-303fb9e5802b43f6e4657a81ed3ea511a911a64d8bf32abb0d1bea5cc127498dL1852-R1852) [[5]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L455-R455) [[6]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1374-R1374) [[7]](diffhunk://#diff-ee96a329b9be744aa8bbeb4c7c8936c29ba529c4a4e51778ca7bfd31684c26a1L1975-R1975)

**gRPC Connection Settings:**
- Increased the gRPC `CONNECT_TIMEOUT` from 2 to 3 seconds to reduce connection failures in slow network environments.
- Enhanced the gRPC health client by setting connection timeouts, request timeouts, TCP and HTTP2 keepalive intervals, and timeouts for improved connection robustness.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
