### PR TITLE
fix(config): reduce default rate limits and enable BBR adaptive limit

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -69,15 +69,15 @@ fn default_download_protocol() -> String {
 }
 
 /// default_download_request_rate_limit is the default rate limit of the download request in the
-/// download grpc server, default is 4000 req/s.
+/// download grpc server, default is 400 req/s.
 pub fn default_download_request_rate_limit() -> u64 {
-    4000
+    400
 }
 
 // default_download_request_buffer_size is the default buffer size for download request channel,
-// default is 1000.
+// default is 50.
 pub fn default_download_request_buffer_size() -> usize {
-    1000
+    50
 }
 
 /// default_host_hostname is the default hostname of the host.
@@ -105,15 +105,15 @@ fn default_upload_grpc_server_port() -> u16 {
 }
 
 /// default_upload_request_rate_limit is the default rate limit of the upload request in the
-/// upload grpc server, default is 4000 req/s.
+/// upload grpc server, default is 400 req/s.
 pub fn default_upload_request_rate_limit() -> u64 {
-    4000
+    400
 }
 
 /// default_upload_request_buffer_size is the default buffer size for upload request channel,
-/// default is 1000.
+/// default is 50.
 pub fn default_upload_request_buffer_size() -> usize {
-    1000
+    50
 }
 
 /// default_upload_bandwidth_limit is the default rate limit of the upload speed in GB/MB/KB per second, default is 50GB/s.
@@ -423,7 +423,7 @@ impl Default for Server {
         Server {
             plugin_dir: default_dfdaemon_plugin_dir(),
             cache_dir: default_dfdaemon_cache_dir(),
-            adaptive_rate_limit: None,
+            adaptive_rate_limit: Some(BBRConfig::default()),
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates several default configuration values in the `dfdaemon` component, primarily reducing the default rate limits and buffer sizes for download and upload requests. It also changes the default behavior for adaptive rate limiting by enabling it with a default configuration.

Configuration defaults adjustments:

* Reduced the default download and upload request rate limits from 4000 req/s to 400 req/s in `dfdaemon.rs`. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL72-R80) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL108-R116)
* Reduced the default buffer sizes for download and upload request channels from 1000 to 50 in `dfdaemon.rs`. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL72-R80) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL108-R116)

Adaptive rate limiting:

* Changed the default for `adaptive_rate_limit` in the `Server` struct to enable it by default using `BBRConfig::default()`, instead of leaving it as `None`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
