### PR TITLE
build(ci): add graphviz to debug Docker image dependencies

### DIFF
--- a/ci/Dockerfile.debug
+++ b/ci/Dockerfile.debug
@@ -78,7 +78,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends iperf3 iperf fio curl infiniband-diags ibverbs-utils \
     iotop sysstat bash-completion procps apache2-utils ca-certificates binutils bpfcc-tools linux-libc-dev libc6-dev \
     nvme-cli smartmontools dnsutils iputils-ping vim linux-perf llvm lsof socat strace dstat net-tools bpftrace \
-    libbpf-tools \
+    libbpf-tools graphviz \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/client/target/debug/dfget /usr/local/bin/dfget


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add `graphviz` package to the debug Docker image
- Enables graph visualization tools (e.g., `dot`) in debug environments

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
