### PR TITLE
Optimize buffer sizes, logging levels, and piece reading logic

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -265,16 +265,16 @@ fn default_storage_write_piece_timeout() -> Duration {
     Duration::from_secs(360)
 }
 
-/// Returns the default buffer size for writing piece to disk, default is 1MiB.
+/// Returns the default buffer size for writing piece to disk, default is 512KiB.
 #[inline]
 fn default_storage_write_buffer_size() -> usize {
-    1024 * 1024
+    512 * 1024
 }
 
-/// Returns the default buffer size for reading piece from disk, default is 1MiB.
+/// Returns the default buffer size for reading piece from disk, default is 512KiB.
 #[inline]
 fn default_storage_read_buffer_size() -> usize {
-    1024 * 1024
+    512 * 1024
 }
 
 /// Returns the default cache capacity for the storage server, default is
@@ -338,10 +338,10 @@ pub fn default_proxy_request_rate_limit() -> u64 {
     4000
 }
 
-/// Returns the default buffer size for reading piece, default is 1MiB.
+/// Returns the default buffer size for reading piece, default is 512KiB.
 #[inline]
 pub fn default_proxy_read_buffer_size() -> usize {
-    1024 * 1024
+    512 * 1024
 }
 
 /// Returns the default rate limit of the prefetch speed in GB/MB/KB per second, default is 10GB/s. The prefetch request

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -265,16 +265,16 @@ fn default_storage_write_piece_timeout() -> Duration {
     Duration::from_secs(360)
 }
 
-/// Returns the default buffer size for writing piece to disk, default is 4MB.
+/// Returns the default buffer size for writing piece to disk, default is 1MiB.
 #[inline]
 fn default_storage_write_buffer_size() -> usize {
-    4 * 1024 * 1024
+    1024 * 1024
 }
 
-/// Returns the default buffer size for reading piece from disk, default is 4MB.
+/// Returns the default buffer size for reading piece from disk, default is 1MiB.
 #[inline]
 fn default_storage_read_buffer_size() -> usize {
-    4 * 1024 * 1024
+    1024 * 1024
 }
 
 /// Returns the default cache capacity for the storage server, default is
@@ -338,10 +338,10 @@ pub fn default_proxy_request_rate_limit() -> u64 {
     4000
 }
 
-/// Returns the default buffer size for reading piece, default is 4MB.
+/// Returns the default buffer size for reading piece, default is 1MiB.
 #[inline]
 pub fn default_proxy_read_buffer_size() -> usize {
-    4 * 1024 * 1024
+    1024 * 1024
 }
 
 /// Returns the default rate limit of the prefetch speed in GB/MB/KB per second, default is 10GB/s. The prefetch request
@@ -980,7 +980,7 @@ pub struct Storage {
     /// Larger buffers improve read throughput by reducing I/O system calls and better
     /// utilizing disk sequential read performance, but increase memory consumption.
     /// Smaller buffers reduce memory footprint but may cause more frequent I/O operations.
-    /// Default is 4MiB. Tune based on your access patterns and memory constraints.
+    /// Default is 1MiB. Tune based on your access patterns and memory constraints.
     #[serde(default = "default_storage_read_buffer_size")]
     pub read_buffer_size: usize,
 
@@ -1361,7 +1361,7 @@ pub struct Proxy {
     /// Specifies the buffer size for reading piece data from disk.
     /// Larger buffers can improve throughput for sequential reads but consume more memory.
     /// Smaller buffers reduce memory usage but may increase I/O overhead.
-    /// Default value is 1KB. Adjust based on your disk I/O characteristics and memory constraints.
+    /// Default value is 1MiB. Adjust based on your disk I/O characteristics and memory constraints.
     #[serde(default = "default_proxy_read_buffer_size")]
     pub read_buffer_size: usize,
 }

--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::io::AsyncRead;
+use tokio::io::AsyncBufRead;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
@@ -138,7 +138,7 @@ impl Cache {
         piece_id: &str,
         piece: super::metadata::Piece,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let mut tasks = self.tasks.write().await;
         let Some(task) = tasks.get(task_id) else {
             return Err(Error::TaskNotFound(task_id.to_string()));

--- a/dragonfly-client-storage/src/cache/mod.rs
+++ b/dragonfly-client-storage/src/cache/mod.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::io::{AsyncRead, BufReader};
+use tokio::io::AsyncRead;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
@@ -107,9 +107,6 @@ impl Task {
 /// Task is the metadata of the task.
 #[derive(Clone)]
 pub struct Cache {
-    /// The configuration of the dfdaemon.
-    config: Arc<Config>,
-
     /// The size of the cache in bytes.
     size: Arc<AtomicU64>,
 
@@ -125,7 +122,6 @@ impl Cache {
     /// Creates a new cache with the specified capacity.
     pub fn new(config: Arc<Config>) -> Self {
         Cache {
-            config: config.clone(),
             size: Arc::new(AtomicU64::new(0)),
             capacity: config.storage.cache_capacity.as_u64(),
             // LRU cache capacity is set to usize::MAX to avoid evicting tasks. LRU cache will evict tasks
@@ -184,9 +180,7 @@ impl Cache {
         }
 
         let content = piece_content.slice(begin..end);
-        let reader =
-            BufReader::with_capacity(self.config.storage.read_buffer_size, Cursor::new(content));
-        Ok(reader)
+        Ok(Cursor::new(content))
     }
 
     /// Writes the piece content to the cache.

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -59,7 +59,7 @@ impl QUICClient {
     ///
     /// This is the main entry point for downloading a piece. It applies
     /// a timeout based on the configuration and handles connection timeouts gracefully.
-    #[instrument(skip_all, fields(parent_addr))]
+    #[instrument(level = "debug", skip_all, fields(parent_addr))]
     pub async fn download_piece(
         &self,
         number: u32,
@@ -83,7 +83,7 @@ impl QUICClient {
     /// 2. Establishes QUIC connection and sends the request.
     /// 3. Reads and validates the response header.
     /// 4. Processes the piece content based on the response type.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_piece(
         &self,
         number: u32,
@@ -117,7 +117,7 @@ impl QUICClient {
     /// Downloads a persistent piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_piece(
         &self,
         number: u32,
@@ -137,7 +137,7 @@ impl QUICClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent specific request/response types.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_persistent_piece(
         &self,
         number: u32,
@@ -174,7 +174,7 @@ impl QUICClient {
     /// Downloads a persistent cache piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_cache_piece(
         &self,
         number: u32,
@@ -194,7 +194,7 @@ impl QUICClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent cache specific request/response types.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_persistent_cache_piece(
         &self,
         number: u32,
@@ -230,7 +230,7 @@ impl QUICClient {
     /// This is a low-level utility function that handles the QUIC connection
     /// lifecycle and request transmission. It ensures proper error handling
     /// and connection cleanup.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn connect_and_write_request(
         &self,
         request: Bytes,
@@ -292,7 +292,7 @@ impl QUICClient {
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_header(&self, reader: &mut RecvStream) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
@@ -310,7 +310,7 @@ impl QUICClient {
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_piece_content<T>(
         &self,
         reader: &mut RecvStream,
@@ -347,7 +347,7 @@ impl QUICClient {
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_error(&self, reader: &mut RecvStream, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -54,7 +54,7 @@ impl TCPClient {
     ///
     /// This is the main entry point for downloading a piece. It applies
     /// a timeout based on the configuration and handles connection timeouts gracefully.
-    #[instrument(skip_all, fields(parent_addr))]
+    #[instrument(level = "debug", skip_all, fields(parent_addr))]
     pub async fn download_piece(
         &self,
         number: u32,
@@ -78,7 +78,7 @@ impl TCPClient {
     /// 2. Establishes TCP connection and sends the request.
     /// 3. Reads and validates the response header.
     /// 4. Processes the piece content based on the response type.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_piece(
         &self,
         number: u32,
@@ -113,7 +113,7 @@ impl TCPClient {
     /// Downloads a persistent piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_piece(
         &self,
         number: u32,
@@ -133,7 +133,7 @@ impl TCPClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent specific request/response types.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_persistent_piece(
         &self,
         number: u32,
@@ -171,7 +171,7 @@ impl TCPClient {
     /// Downloads a persistent cache piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_cache_piece(
         &self,
         number: u32,
@@ -191,7 +191,7 @@ impl TCPClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent cache specific request/response types.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_download_persistent_cache_piece(
         &self,
         number: u32,
@@ -231,7 +231,7 @@ impl TCPClient {
     /// This is a low-level utility function that handles the TCP connection
     /// lifecycle and request transmission. It ensures proper error handling
     /// and connection cleanup.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn connect_and_write_request(
         &self,
         request: Bytes,
@@ -285,7 +285,7 @@ impl TCPClient {
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_header(&self, reader: &mut OwnedReadHalf) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
@@ -304,7 +304,7 @@ impl TCPClient {
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_piece_content<T>(
         &self,
         reader: &mut OwnedReadHalf,
@@ -343,7 +343,7 @@ impl TCPClient {
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn read_error(&self, reader: &mut OwnedReadHalf, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 
+use crate::cache::lru_cache::LruCache;
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::Result;
 use std::cmp::{max, min};
-use std::path::Path;
-use std::sync::Arc;
+use std::fs::File;
+use std::future::Future;
+use std::io;
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{ready, Context, Poll};
+use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
+use tokio::task::JoinHandle;
 
 #[cfg(target_os = "linux")]
 pub type Content = super::content_linux::Content;
@@ -38,6 +47,9 @@ pub const DEFAULT_PERSISTENT_TASK_DIR: &str = "persistent-tasks";
 
 /// The default directory for store persistent cache task.
 pub const DEFAULT_PERSISTENT_CACHE_TASK_DIR: &str = "persistent-cache-tasks";
+
+/// The default capacity of the file descriptor cache.
+pub const DEFAULT_FD_CACHE_CAPACITY: usize = 1024;
 
 /// The response of writing a piece.
 pub struct WritePieceResponse {
@@ -84,9 +96,371 @@ pub fn calculate_piece_range(offset: u64, length: u64, range: Option<Range>) -> 
     }
 }
 
+/// FDCache caches opened file descriptors by path with LRU eviction, so repeated
+/// piece reads of the same task reuse one descriptor instead of reopening the
+/// file every time. The cached descriptors are only used for positional reads,
+/// which never move the file cursor, so one descriptor is safely shared by
+/// concurrent readers.
+pub struct FDCache {
+    /// The opened file descriptors by path.
+    fds: Mutex<LruCache<PathBuf, Arc<File>>>,
+}
+
+/// Implements the file descriptor cache.
+impl FDCache {
+    /// Creates a new FDCache with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            fds: Mutex::new(LruCache::new(capacity)),
+        }
+    }
+
+    /// Returns the cached file descriptor of the path, opening and caching it if
+    /// it is absent. Concurrent misses may open the file more than once, the last
+    /// inserted descriptor wins and the others are closed when their readers finish.
+    pub async fn open(&self, path: &Path) -> io::Result<Arc<File>> {
+        if let Some(fd) = self.fds.lock().unwrap().get(path) {
+            return Ok(fd.clone());
+        }
+
+        let path = path.to_path_buf();
+        let fd = Arc::new(
+            tokio::task::spawn_blocking({
+                let path = path.clone();
+                move || File::open(path)
+            })
+            .await
+            .map_err(io::Error::other)??,
+        );
+
+        self.fds.lock().unwrap().put(path, fd.clone());
+        Ok(fd)
+    }
+
+    /// Removes the cached file descriptor of the path. It needs to be called when
+    /// the content is deleted, so a recreated task will not read the stale file.
+    pub fn remove(&self, path: &Path) {
+        self.fds.lock().unwrap().pop(path);
+    }
+}
+
+/// The state of the in-flight read of the RangeReader.
+enum RangeReaderState {
+    /// No read is in flight, the buffer may hold unread data.
+    Idle,
+
+    /// A positional read is running on the blocking thread pool, owning the
+    /// buffer until it completes.
+    Reading(JoinHandle<io::Result<(Vec<u8>, usize)>>),
+}
+
+/// RangeReader reads a fixed range of a file with positional reads on a shared
+/// file descriptor. It never seeks the descriptor and fills a single reusable
+/// buffer sized to the range, instead of allocating a full read buffer and
+/// seeking for every piece.
+pub struct RangeReader {
+    /// The shared file descriptor to read from.
+    fd: Arc<File>,
+
+    /// The offset of the next positional read.
+    offset: u64,
+
+    /// The remaining length of the range.
+    remaining: u64,
+
+    /// The reusable read buffer, moved into the blocking task while reading.
+    buf: Vec<u8>,
+
+    /// The consumed position of the buffer.
+    pos: usize,
+
+    /// The filled length of the buffer.
+    filled: usize,
+
+    /// The state of the in-flight read.
+    state: RangeReaderState,
+}
+
+/// Implements the range reader.
+impl RangeReader {
+    /// Creates a new RangeReader reading `length` bytes starting at `offset`.
+    pub fn new(fd: Arc<File>, offset: u64, length: u64, buffer_size: usize) -> Self {
+        let capacity = min(max(buffer_size, 1) as u64, length) as usize;
+        Self {
+            fd,
+            offset,
+            remaining: length,
+            buf: vec![0u8; capacity],
+            pos: 0,
+            filled: 0,
+            state: RangeReaderState::Idle,
+        }
+    }
+}
+
+/// Implements the buffered read for the RangeReader.
+impl AsyncBufRead for RangeReader {
+    /// Polls the buffer to fill it with more data, returning a slice of the filled
+    /// buffer. The buffer is filled with a positional read on the blocking thread pool, and the
+    /// buffer is reused for subsequent reads.
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        loop {
+            match &mut this.state {
+                RangeReaderState::Idle => {
+                    if this.pos < this.filled || this.remaining == 0 {
+                        break;
+                    }
+
+                    let len = min(this.buf.len() as u64, this.remaining) as usize;
+                    let mut buf = std::mem::take(&mut this.buf);
+                    let fd = this.fd.clone();
+                    let offset = this.offset;
+                    this.state =
+                        RangeReaderState::Reading(tokio::task::spawn_blocking(move || {
+                            let n = fd.read_at(&mut buf[..len], offset)?;
+                            Ok((buf, n))
+                        }));
+                }
+                RangeReaderState::Reading(handle) => {
+                    let (buf, n) =
+                        ready!(Pin::new(handle).poll(cx)).map_err(io::Error::other)??;
+                    this.buf = buf;
+                    this.pos = 0;
+                    this.filled = n;
+                    this.offset += n as u64;
+
+                    // Stop at the end of the file even if the range is longer.
+                    this.remaining = if n == 0 { 0 } else { this.remaining - n as u64 };
+                    this.state = RangeReaderState::Idle;
+                }
+            }
+        }
+
+        Poll::Ready(Ok(&this.buf[this.pos..this.filled]))
+    }
+
+    /// Consumes `amt` bytes from the buffer, advancing the position.
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        this.pos = min(this.pos + amt, this.filled);
+    }
+}
+
+/// Implements the read for the RangeReader.
+impl AsyncRead for RangeReader {
+    /// Polls the read to fill the provided buffer with data from the range. It uses
+    /// the buffered read to fill the buffer, and consumes the filled bytes.
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let inner = ready!(self.as_mut().poll_fill_buf(cx))?;
+        let amt = min(inner.len(), buf.remaining());
+        buf.put_slice(&inner[..amt]);
+        self.consume(amt);
+        Poll::Ready(Ok(()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+
+    fn pattern(length: usize) -> Vec<u8> {
+        (0..length).map(|i| (i % 251) as u8).collect()
+    }
+
+    #[tokio::test]
+    async fn test_fd_cache() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+
+        let cache = FDCache::new(DEFAULT_FD_CACHE_CAPACITY);
+        let first = cache.open(&path).await.unwrap();
+        let second = cache.open(&path).await.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+
+        cache.remove(&path);
+        let third = cache.open(&path).await.unwrap();
+        assert!(!Arc::ptr_eq(&first, &third));
+
+        cache.remove(&path);
+        tokio::fs::remove_file(&path).await.unwrap();
+        assert!(cache.open(&path).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_range_reader() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd.clone(), 0, 13, 512);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, b"hello, world!");
+
+        let mut reader = RangeReader::new(fd.clone(), 7, 5, 2);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, b"world");
+
+        let mut reader = RangeReader::new(fd.clone(), 7, 100, 512);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, b"world!");
+
+        let mut reader = RangeReader::new(fd, 0, 0, 512);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_multiple_fills() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        let data = pattern(256 * 1024);
+        tokio::fs::write(&path, &data).await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd.clone(), 0, data.len() as u64, 4 * 1024);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, data);
+
+        let mut reader = RangeReader::new(fd, 12_345, 30_000, 4 * 1024);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, &data[12_345..42_345]);
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_fill_buf_and_consume() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd, 0, 13, 5);
+        assert_eq!(reader.fill_buf().await.unwrap(), b"hello");
+
+        reader.consume(2);
+        assert_eq!(reader.fill_buf().await.unwrap(), b"llo");
+
+        reader.consume(3);
+        assert_eq!(reader.fill_buf().await.unwrap(), b", wor");
+
+        reader.consume(5);
+        assert_eq!(reader.fill_buf().await.unwrap(), b"ld!");
+
+        reader.consume(100);
+        assert!(reader.fill_buf().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_copy_buf() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        let data = pattern(64 * 1024);
+        tokio::fs::write(&path, &data).await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd, 1_000, 50_000, 8 * 1024);
+        let mut writer = Cursor::new(Vec::new());
+        let copied = tokio::io::copy_buf(&mut reader, &mut writer).await.unwrap();
+        assert_eq!(copied, 50_000);
+        assert_eq!(writer.into_inner(), &data[1_000..51_000]);
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_concurrent_readers() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        let data = pattern(64 * 1024);
+        tokio::fs::write(&path, &data).await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let range_length: u64 = 8 * 1024;
+        let handles: Vec<_> = (0..8u64)
+            .map(|i| {
+                let fd = fd.clone();
+                tokio::spawn(async move {
+                    let mut reader = RangeReader::new(fd, i * range_length, range_length, 1024);
+                    let mut buffer = Vec::new();
+                    reader.read_to_end(&mut buffer).await.unwrap();
+                    (i, buffer)
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let (i, buffer) = handle.await.unwrap();
+            let start = (i * range_length) as usize;
+            assert_eq!(buffer, &data[start..start + range_length as usize]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_buffer_sizes() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        for buffer_size in [13, 512, 1, 0] {
+            let mut reader = RangeReader::new(fd.clone(), 0, 13, buffer_size);
+            let mut buffer = Vec::new();
+            reader.read_to_end(&mut buffer).await.unwrap();
+            assert_eq!(buffer, b"hello, world!");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_offset_beyond_eof() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd.clone(), 13, 5, 512);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert!(buffer.is_empty());
+
+        let mut reader = RangeReader::new(fd, 100, 5, 512);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_range_reader_small_chunk_reads() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        tokio::fs::write(&path, b"hello, world!").await.unwrap();
+        let fd = Arc::new(File::open(&path).unwrap());
+
+        let mut reader = RangeReader::new(fd, 0, 13, 512);
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 3];
+        loop {
+            let n = reader.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..n]);
+        }
+
+        assert_eq!(buffer, b"hello, world!");
+    }
 
     #[tokio::test]
     async fn test_calculate_piece_range() {

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -22,10 +22,9 @@ use dragonfly_client_util::fs::fallocate;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::fs::{self, File, OpenOptions};
+use tokio::fs::{self, OpenOptions};
 use tokio::io::{
-    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter,
-    SeekFrom,
+    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom,
 };
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
@@ -38,6 +37,9 @@ pub struct Content {
 
     /// The directory to store content.
     pub dir: PathBuf,
+
+    /// The cache of the opened file descriptors for reading pieces.
+    fd_cache: super::content::FDCache,
 }
 
 /// Implements the content storage.
@@ -57,7 +59,11 @@ impl Content {
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_TASK_DIR)).await?;
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_CACHE_TASK_DIR)).await?;
         info!("content initialized directory: {:?}", dir);
-        Ok(Content { config, dir })
+        Ok(Content {
+            config,
+            dir,
+            fd_cache: super::content::FDCache::new(super::content::DEFAULT_FD_CACHE_CAPACITY),
+        })
     }
 
     /// Returns the available space of the disk.
@@ -206,6 +212,8 @@ impl Content {
     pub async fn delete_task(&self, task_id: &str) -> Result<()> {
         info!("delete task content: {}", task_id);
         let task_path = self.get_task_path(task_id);
+
+        self.fd_cache.remove(&task_path);
         fs::remove_file(task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -229,19 +237,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
@@ -453,19 +460,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the persistent piece to the content and
@@ -529,6 +535,8 @@ impl Content {
     pub async fn delete_persistent_task(&self, task_id: &str) -> Result<()> {
         info!("delete persistent task content: {}", task_id);
         let persistent_task_path = self.get_persistent_task_path(task_id);
+
+        self.fd_cache.remove(&persistent_task_path);
         fs::remove_file(persistent_task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -697,19 +705,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the persistent cache piece to the content and
@@ -773,6 +780,8 @@ impl Content {
     pub async fn delete_persistent_cache_task(&self, task_id: &str) -> Result<()> {
         info!("delete persistent cache task content: {}", task_id);
         let persistent_cache_task_path = self.get_persistent_cache_task_path(task_id);
+
+        self.fd_cache.remove(&persistent_cache_task_path);
         fs::remove_file(persistent_cache_task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -1222,7 +1231,7 @@ mod tests {
             .join(content::DEFAULT_CONTENT_DIR)
             .join(content::DEFAULT_TASK_DIR)
             .join("1mib");
-        let mut file = File::create(&file_path).await.unwrap();
+        let mut file = fs::File::create(&file_path).await.unwrap();
         let buffer = vec![0u8; ByteSize::mib(1).as_u64() as usize];
         file.write_all(&buffer).await.unwrap();
         file.flush().await.unwrap();

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -243,52 +243,6 @@ impl Content {
         Ok(f_reader.take(target_length))
     }
 
-    /// Returns two readers, one is the range reader, and the other is the
-    /// full reader of the piece. It is used for cache the piece content to the proxy cache.
-    #[instrument(skip_all)]
-    pub async fn read_piece_with_dual_read(
-        &self,
-        task_id: &str,
-        offset: u64,
-        length: u64,
-        range: Option<Range>,
-    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
-        let task_path = self.get_task_path(task_id);
-
-        // Calculate the target offset and length based on the range.
-        let (target_offset, target_length) =
-            super::content::calculate_piece_range(offset, length, range);
-
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_range_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_range_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let range_reader = f_range_reader.take(target_length);
-
-        // Create full reader of the piece.
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_reader
-            .seek(SeekFrom::Start(offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let reader = f_reader.take(length);
-
-        Ok((range_reader, reader))
-    }
-
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
     #[instrument(skip_all)]
     pub async fn write_piece<R: AsyncRead + Unpin + ?Sized>(
@@ -314,7 +268,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.
@@ -540,7 +493,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.
@@ -785,7 +737,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -214,7 +214,7 @@ impl Content {
     }
 
     /// Reads the piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_piece(
         &self,
         task_id: &str,
@@ -244,7 +244,7 @@ impl Content {
     }
 
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,
@@ -438,7 +438,7 @@ impl Content {
     }
 
     /// Reads the persistent piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_persistent_piece(
         &self,
         task_id: &str,
@@ -469,7 +469,7 @@ impl Content {
 
     /// Writes the persistent piece to the content and
     /// calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_persistent_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,
@@ -682,7 +682,7 @@ impl Content {
     }
 
     /// Reads the persistent cache piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_persistent_cache_piece(
         &self,
         task_id: &str,
@@ -713,7 +713,7 @@ impl Content {
 
     /// Writes the persistent cache piece to the content and
     /// calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_persistent_cache_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -24,7 +24,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{
-    self, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter, SeekFrom,
+    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter,
+    SeekFrom,
 };
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
@@ -221,7 +222,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_task_path(task_id);
 
         // Calculate the target offset and length based on the range.
@@ -445,7 +446,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_persistent_task_path(task_id);
 
         // Calculate the target offset and length based on the range.
@@ -689,7 +690,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_persistent_cache_task_path(task_id);
 
         // Calculate the target offset and length based on the range.

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -22,10 +22,9 @@ use dragonfly_client_util::fs::fallocate;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::fs::{self, File, OpenOptions};
+use tokio::fs::{self, OpenOptions};
 use tokio::io::{
-    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter,
-    SeekFrom,
+    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom,
 };
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
@@ -38,6 +37,9 @@ pub struct Content {
 
     /// The directory to store content.
     pub dir: PathBuf,
+
+    /// The cache of the opened file descriptors for reading pieces.
+    fd_cache: super::content::FDCache,
 }
 
 /// Implements the content storage.
@@ -57,7 +59,11 @@ impl Content {
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_TASK_DIR)).await?;
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_CACHE_TASK_DIR)).await?;
         info!("content initialized directory: {:?}", dir);
-        Ok(Content { config, dir })
+        Ok(Content {
+            config,
+            dir,
+            fd_cache: super::content::FDCache::new(super::content::DEFAULT_FD_CACHE_CAPACITY),
+        })
     }
 
     /// Returns the available space of the disk.
@@ -234,6 +240,8 @@ impl Content {
     pub async fn delete_task(&self, task_id: &str) -> Result<()> {
         info!("delete task content: {}", task_id);
         let task_path = self.get_task_path(task_id);
+
+        self.fd_cache.remove(&task_path);
         fs::remove_file(task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -257,19 +265,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
@@ -317,8 +324,7 @@ impl Content {
 
         if length != expected_length {
             return Err(Error::Unknown(format!(
-                "expected length {} but got {}",
-                expected_length, length
+                "expected length {expected_length} but got {length}"
             )));
         }
 
@@ -482,19 +488,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the persistent piece to the content and
@@ -543,8 +548,7 @@ impl Content {
 
         if length != expected_length {
             return Err(Error::Unknown(format!(
-                "expected length {} but got {}",
-                expected_length, length
+                "expected length {expected_length} but got {length}"
             )));
         }
 
@@ -559,6 +563,8 @@ impl Content {
     pub async fn delete_persistent_task(&self, task_id: &str) -> Result<()> {
         info!("delete persistent task content: {}", task_id);
         let persistent_task_path = self.get_persistent_task_path(task_id);
+
+        self.fd_cache.remove(&persistent_task_path);
         fs::remove_file(persistent_task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -727,19 +733,18 @@ impl Content {
         let (target_offset, target_length) =
             super::content::calculate_piece_range(offset, length, range);
 
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
+        // Read the piece with positional reads on the cached file descriptor,
+        // avoiding reopening and seeking the file for every piece.
+        let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
 
-        f_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-
-        Ok(f_reader.take(target_length))
+        Ok(super::content::RangeReader::new(
+            fd,
+            target_offset,
+            target_length,
+            self.config.storage.read_buffer_size,
+        ))
     }
 
     /// Writes the persistent cache piece to the content and
@@ -788,8 +793,7 @@ impl Content {
 
         if length != expected_length {
             return Err(Error::Unknown(format!(
-                "expected length {} but got {}",
-                expected_length, length
+                "expected length {expected_length} but got {length}"
             )));
         }
 
@@ -804,6 +808,8 @@ impl Content {
     pub async fn delete_persistent_cache_task(&self, task_id: &str) -> Result<()> {
         info!("delete persistent cache task content: {}", task_id);
         let persistent_cache_task_path = self.get_persistent_cache_task_path(task_id);
+
+        self.fd_cache.remove(&persistent_cache_task_path);
         fs::remove_file(persistent_cache_task_path.as_path())
             .await
             .inspect_err(|err| {
@@ -1253,7 +1259,7 @@ mod tests {
             .join(content::DEFAULT_CONTENT_DIR)
             .join(content::DEFAULT_TASK_DIR)
             .join("1mib");
-        let mut file = File::create(&file_path).await.unwrap();
+        let mut file = fs::File::create(&file_path).await.unwrap();
         let buffer = vec![0u8; ByteSize::mib(1).as_u64() as usize];
         file.write_all(&buffer).await.unwrap();
         file.flush().await.unwrap();

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -24,7 +24,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{
-    self, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter, SeekFrom,
+    self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter,
+    SeekFrom,
 };
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
@@ -249,7 +250,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_task_path(task_id);
 
         // Calculate the target offset and length based on the range.
@@ -474,7 +475,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_persistent_task_path(task_id);
 
         // Calculate the target offset and length based on the range.
@@ -719,7 +720,7 @@ impl Content {
         offset: u64,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         let task_path = self.get_persistent_cache_task_path(task_id);
 
         // Calculate the target offset and length based on the range.

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -271,52 +271,6 @@ impl Content {
         Ok(f_reader.take(target_length))
     }
 
-    /// Returns two readers, one is the range reader, and the other is the
-    /// full reader of the piece. It is used for cache the piece content to the proxy cache.
-    #[instrument(skip_all)]
-    pub async fn read_piece_with_dual_read(
-        &self,
-        task_id: &str,
-        offset: u64,
-        length: u64,
-        range: Option<Range>,
-    ) -> Result<(impl AsyncRead, impl AsyncRead)> {
-        let task_path = self.get_task_path(task_id);
-
-        // Calculate the target offset and length based on the range.
-        let (target_offset, target_length) =
-            super::content::calculate_piece_range(offset, length, range);
-
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_range_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_range_reader
-            .seek(SeekFrom::Start(target_offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let range_reader = f_range_reader.take(target_length);
-
-        // Create full reader of the piece.
-        let f = File::open(task_path.as_path()).await.inspect_err(|err| {
-            error!("open {:?} failed: {}", task_path, err);
-        })?;
-        let mut f_reader = BufReader::with_capacity(self.config.storage.read_buffer_size, f);
-
-        f_reader
-            .seek(SeekFrom::Start(offset))
-            .await
-            .inspect_err(|err| {
-                error!("seek {:?} failed: {}", task_path, err);
-            })?;
-        let reader = f_reader.take(length);
-
-        Ok((range_reader, reader))
-    }
-
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
     #[instrument(skip_all)]
     pub async fn write_piece<R: AsyncRead + Unpin + ?Sized>(
@@ -342,7 +296,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.
@@ -569,7 +522,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.
@@ -815,7 +767,6 @@ impl Content {
         })?;
 
         let reader = reader.take(expected_length);
-        let reader = BufReader::with_capacity(self.config.storage.write_buffer_size, reader);
         let mut writer = BufWriter::with_capacity(self.config.storage.write_buffer_size, f);
 
         // Copy the piece to the file while updating the CRC32 value.

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -242,7 +242,7 @@ impl Content {
     }
 
     /// Reads the piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_piece(
         &self,
         task_id: &str,
@@ -272,7 +272,7 @@ impl Content {
     }
 
     /// Writes the piece to the content and calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,
@@ -467,7 +467,7 @@ impl Content {
     }
 
     /// Reads the persistent piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_persistent_piece(
         &self,
         task_id: &str,
@@ -498,7 +498,7 @@ impl Content {
 
     /// Writes the persistent piece to the content and
     /// calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_persistent_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,
@@ -712,7 +712,7 @@ impl Content {
     }
 
     /// Reads the persistent cache piece from the content.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn read_persistent_cache_piece(
         &self,
         task_id: &str,
@@ -743,7 +743,7 @@ impl Content {
 
     /// Writes the persistent cache piece to the content and
     /// calculates the hash of the piece by crc32.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn write_persistent_cache_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         task_id: &str,

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -29,7 +29,6 @@ use tokio::{
     io::{AsyncBufRead, AsyncRead, AsyncReadExt},
     time::sleep,
 };
-use tokio_util::either::Either;
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -877,54 +876,22 @@ impl Storage {
         task_id: &str,
         range: Option<Range>,
     ) -> Result<impl AsyncBufRead> {
-        // Wait for the piece to be finished.
-        self.wait_for_piece_finished(piece_id).await?;
+        // Wait for the piece to be finished and get the piece metadata.
+        let piece = self.wait_for_piece_finished(piece_id).await?;
 
         // Start uploading the task.
         self.metadata.upload_task_started(task_id)?;
 
-        // Get the piece metadata and return the content of the piece.
-        match self.metadata.get_piece(piece_id) {
-            Ok(Some(piece)) => {
-                if self.cache.contains_piece(task_id, piece_id).await {
-                    match self
-                        .cache
-                        .read_piece(task_id, piece_id, piece.clone(), range)
-                        .await
-                    {
-                        Ok(reader) => {
-                            // Finish uploading the task.
-                            self.metadata.upload_task_finished(task_id)?;
-                            debug!("get piece from cache: {}", piece_id);
-                            return Ok(Either::Left(reader));
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                }
-
-                match self
-                    .content
-                    .read_piece(task_id, piece.offset, piece.length, range)
-                    .await
-                {
-                    Ok(reader) => {
-                        // Finish uploading the task.
-                        self.metadata.upload_task_finished(task_id)?;
-                        Ok(Either::Right(reader))
-                    }
-                    Err(err) => {
-                        // Failed uploading the task.
-                        self.metadata.upload_task_failed(task_id)?;
-                        Err(err)
-                    }
-                }
-            }
-            Ok(None) => {
-                // Failed uploading the task.
-                self.metadata.upload_task_failed(task_id)?;
-                Err(Error::PieceNotFound(piece_id.to_string()))
+        // Return the content of the piece.
+        match self
+            .content
+            .read_piece(task_id, piece.offset, piece.length, range)
+            .await
+        {
+            Ok(reader) => {
+                // Finish uploading the task.
+                self.metadata.upload_task_finished(task_id)?;
+                Ok(reader)
             }
             Err(err) => {
                 // Failed uploading the task.
@@ -1078,36 +1045,22 @@ impl Storage {
         task_id: &str,
         range: Option<Range>,
     ) -> Result<impl AsyncBufRead> {
-        // Wait for the persistent piece to be finished.
-        self.wait_for_persistent_piece_finished(piece_id).await?;
+        // Wait for the persistent piece to be finished and get the piece metadata.
+        let piece = self.wait_for_persistent_piece_finished(piece_id).await?;
 
         // Start uploading the persistent task.
         self.metadata.upload_persistent_task_started(task_id)?;
 
-        // Get the persistent piece metadata and return the content of the persistent piece.
-        match self.metadata.get_piece(piece_id) {
-            Ok(Some(piece)) => {
-                match self
-                    .content
-                    .read_persistent_piece(task_id, piece.offset, piece.length, range)
-                    .await
-                {
-                    Ok(reader) => {
-                        // Finish uploading the persistent task.
-                        self.metadata.upload_persistent_task_finished(task_id)?;
-                        Ok(reader)
-                    }
-                    Err(err) => {
-                        // Failed uploading the persistent task.
-                        self.metadata.upload_persistent_task_failed(task_id)?;
-                        Err(err)
-                    }
-                }
-            }
-            Ok(None) => {
-                // Failed uploading the persistent task.
-                self.metadata.upload_persistent_task_failed(task_id)?;
-                Err(Error::PieceNotFound(piece_id.to_string()))
+        // Return the content of the persistent piece.
+        match self
+            .content
+            .read_persistent_piece(task_id, piece.offset, piece.length, range)
+            .await
+        {
+            Ok(reader) => {
+                // Finish uploading the persistent task.
+                self.metadata.upload_persistent_task_finished(task_id)?;
+                Ok(reader)
             }
             Err(err) => {
                 // Failed uploading the persistent task.
@@ -1219,39 +1172,26 @@ impl Storage {
         task_id: &str,
         range: Option<Range>,
     ) -> Result<impl AsyncBufRead> {
-        // Wait for the persistent cache piece to be finished.
-        self.wait_for_persistent_cache_piece_finished(piece_id)
+        // Wait for the persistent cache piece to be finished and get the piece.
+        let piece = self
+            .wait_for_persistent_cache_piece_finished(piece_id)
             .await?;
 
         // Start uploading the persistent cache task.
         self.metadata
             .upload_persistent_cache_task_started(task_id)?;
 
-        // Get the persistent cache piece metadata and return the content of the persistent cache piece.
-        match self.metadata.get_piece(piece_id) {
-            Ok(Some(piece)) => {
-                match self
-                    .content
-                    .read_persistent_cache_piece(task_id, piece.offset, piece.length, range)
-                    .await
-                {
-                    Ok(reader) => {
-                        // Finish uploading the persistent cache task.
-                        self.metadata
-                            .upload_persistent_cache_task_finished(task_id)?;
-                        Ok(reader)
-                    }
-                    Err(err) => {
-                        // Failed uploading the persistent cache task.
-                        self.metadata.upload_persistent_cache_task_failed(task_id)?;
-                        Err(err)
-                    }
-                }
-            }
-            Ok(None) => {
-                // Failed uploading the persistent cache task.
-                self.metadata.upload_persistent_cache_task_failed(task_id)?;
-                Err(Error::PieceNotFound(piece_id.to_string()))
+        // Return the content of the persistent cache piece.
+        match self
+            .content
+            .read_persistent_cache_piece(task_id, piece.offset, piece.length, range)
+            .await
+        {
+            Ok(reader) => {
+                // Finish uploading the persistent cache task.
+                self.metadata
+                    .upload_persistent_cache_task_finished(task_id)?;
+                Ok(reader)
             }
             Err(err) => {
                 // Failed uploading the persistent cache task.
@@ -1571,49 +1511,31 @@ impl Storage {
         task_id: &str,
         range: Option<Range>,
     ) -> Result<impl AsyncBufRead> {
-        // Wait for the cache piece to be finished.
-        self.wait_for_cache_piece_finished(piece_id).await?;
+        // Wait for the cache piece to be finished and get the piece metadata.
+        let piece = self.wait_for_cache_piece_finished(piece_id).await?;
 
         // Start uploading the task.
         self.metadata.upload_cache_task_started(task_id)?;
 
-        // Get the piece metadata and return the content of the piece.
-        match self.metadata.get_piece(piece_id) {
-            Ok(Some(piece)) => {
-                if self.cache.contains_piece(task_id, piece_id).await {
-                    match self
-                        .cache
-                        .read_piece(task_id, piece_id, piece.clone(), range)
-                        .await
-                    {
-                        Ok(reader) => {
-                            // Finish uploading the task.
-                            self.metadata.upload_cache_task_finished(task_id)?;
-                            debug!("get piece from cache: {}", piece_id);
-                            Ok(reader)
-                        }
-                        Err(err) => {
-                            // Failed uploading the cache task.
-                            self.metadata.upload_cache_task_failed(task_id)?;
-                            Err(err)
-                        }
-                    }
-                } else {
+        // Return the content of the cache piece.
+        if self.cache.contains_piece(task_id, piece_id).await {
+            match self.cache.read_piece(task_id, piece_id, piece, range).await {
+                Ok(reader) => {
+                    // Finish uploading the task.
+                    self.metadata.upload_cache_task_finished(task_id)?;
+                    debug!("get piece from cache: {}", piece_id);
+                    Ok(reader)
+                }
+                Err(err) => {
                     // Failed uploading the cache task.
                     self.metadata.upload_cache_task_failed(task_id)?;
-                    Err(Error::PieceNotFound(piece_id.to_string()))
+                    Err(err)
                 }
             }
-            Ok(None) => {
-                // Failed uploading the cache task.
-                self.metadata.upload_cache_task_failed(task_id)?;
-                Err(Error::PieceNotFound(piece_id.to_string()))
-            }
-            Err(err) => {
-                // Failed uploading the cache task.
-                self.metadata.upload_cache_task_failed(task_id)?;
-                Err(err)
-            }
+        } else {
+            // Failed uploading the cache task.
+            self.metadata.upload_cache_task_failed(task_id)?;
+            Err(Error::PieceNotFound(piece_id.to_string()))
         }
     }
 

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::{
     fs,
-    io::{AsyncRead, AsyncReadExt},
+    io::{AsyncBufRead, AsyncRead, AsyncReadExt},
     time::sleep,
 };
 use tokio_util::either::Either;
@@ -876,7 +876,7 @@ impl Storage {
         piece_id: &str,
         task_id: &str,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Wait for the piece to be finished.
         self.wait_for_piece_finished(piece_id).await?;
 
@@ -1077,7 +1077,7 @@ impl Storage {
         piece_id: &str,
         task_id: &str,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Wait for the persistent piece to be finished.
         self.wait_for_persistent_piece_finished(piece_id).await?;
 
@@ -1218,7 +1218,7 @@ impl Storage {
         piece_id: &str,
         task_id: &str,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Wait for the persistent cache piece to be finished.
         self.wait_for_persistent_cache_piece_finished(piece_id)
             .await?;
@@ -1570,7 +1570,7 @@ impl Storage {
         piece_id: &str,
         task_id: &str,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Wait for the cache piece to be finished.
         self.wait_for_cache_piece_finished(piece_id).await?;
 

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -1433,7 +1433,9 @@ impl Storage {
         let mut tee = InspectReader::new(reader, |bytes| {
             hasher.update(bytes);
         });
-        tee.read_buf(&mut content).await?;
+
+        // Keep reading until EOF to avoid truncating the piece content.
+        while tee.read_buf(&mut content).await? > 0 {}
 
         self.cache
             .write_piece(task_id, piece_id, content.freeze())
@@ -1492,7 +1494,9 @@ impl Storage {
         let mut tee = InspectReader::new(reader, |bytes| {
             hasher.update(bytes);
         });
-        tee.read_buf(&mut content).await?;
+
+        // Keep reading until EOF to avoid truncating the piece content.
+        while tee.read_buf(&mut content).await? > 0 {}
 
         self.cache
             .write_piece(task_id, piece_id, content.freeze())

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -639,7 +639,7 @@ impl Storage {
     }
 
     /// Creates a new persistent piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_persistent_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -668,7 +668,7 @@ impl Storage {
     /// Used when creating a hardlink from persistent to storage. Since the piece
     /// content is accessed via hardlink, digest calculation is deferred until another
     /// peer downloads the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn register_persistent_piece(
         &self,
         piece_id: &str,
@@ -686,7 +686,7 @@ impl Storage {
     }
 
     /// Creates a new persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_persistent_cache_piece<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -715,7 +715,7 @@ impl Storage {
     /// Used when creating a hardlink from persistent cache to storage. Since the piece
     /// content is accessed via hardlink, digest calculation is deferred until another
     /// peer downloads the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn register_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -734,7 +734,7 @@ impl Storage {
 
     /// Updates the metadata of the piece and writes
     /// the data of piece to file when the piece downloads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_piece_started(
         &self,
         piece_id: &str,
@@ -750,7 +750,7 @@ impl Storage {
 
     /// Used for downloading piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -797,7 +797,7 @@ impl Storage {
 
     /// Used for downloading piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -821,7 +821,7 @@ impl Storage {
 
     // handle_downloaded_piece_from_parent_finished handles the downloaded piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_downloaded_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -863,14 +863,14 @@ impl Storage {
     }
 
     /// Updates the metadata of the piece when the piece downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_piece_failed(&self, piece_id: &str) -> Result<()> {
         self.metadata.download_piece_failed(piece_id)
     }
 
     /// Updates the metadata of the piece and
     /// returns the data of the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn upload_piece(
         &self,
         piece_id: &str,
@@ -940,13 +940,13 @@ impl Storage {
     }
 
     /// Returns whether the piece exists.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn is_piece_exists(&self, piece_id: &str) -> Result<bool> {
         self.metadata.is_piece_exists(piece_id)
     }
 
     /// Returns the piece metadatas.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_pieces(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
         self.metadata.get_pieces(task_id)
     }
@@ -959,7 +959,7 @@ impl Storage {
 
     /// Updates the metadata of the persistent piece and writes
     /// the data of piece to file when the persistent piece downloads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_piece_started(
         &self,
         piece_id: &str,
@@ -975,7 +975,7 @@ impl Storage {
 
     /// Used for downloading persistent piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1018,7 +1018,7 @@ impl Storage {
 
     /// Used for downloading piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1064,14 +1064,14 @@ impl Storage {
     }
 
     /// Updates the metadata of the persistent piece when the persistent piece downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_piece_failed(&self, piece_id: &str) -> Result<()> {
         self.metadata.download_piece_failed(piece_id)
     }
 
     /// Updates the metadata of the piece and_then
     /// returns the data of the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn upload_persistent_piece(
         &self,
         piece_id: &str,
@@ -1118,13 +1118,13 @@ impl Storage {
     }
 
     /// Returns the persistent piece metadata.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent_piece(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.metadata.get_piece(piece_id)
     }
 
     /// Returns whether the persistent piece exists.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn is_persistent_piece_exists(&self, piece_id: &str) -> Result<bool> {
         self.metadata.is_piece_exists(piece_id)
     }
@@ -1142,7 +1142,7 @@ impl Storage {
 
     /// Updates the metadata of the persistent cache piece and writes
     /// the data of piece to file when the persistent cache piece downloads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_cache_piece_started(
         &self,
         piece_id: &str,
@@ -1161,7 +1161,7 @@ impl Storage {
 
     /// Used for downloading persistent cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_persistent_cache_piece_from_parent_finished<
         R: AsyncRead + Unpin + ?Sized,
     >(
@@ -1205,14 +1205,14 @@ impl Storage {
     }
 
     /// Updates the metadata of the persistent cache piece when the persistent cache piece downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_cache_piece_failed(&self, piece_id: &str) -> Result<()> {
         self.metadata.download_piece_failed(piece_id)
     }
 
     /// Updates the metadata of the piece and_then
     /// returns the data of the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn upload_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -1262,13 +1262,13 @@ impl Storage {
     }
 
     /// Returns the persistent cache piece metadata.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent_cache_piece(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.metadata.get_piece(piece_id)
     }
 
     /// Returns whether the persistent cache piece exists.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn is_persistent_cache_piece_exists(&self, piece_id: &str) -> Result<bool> {
         self.metadata.is_piece_exists(piece_id)
     }
@@ -1285,7 +1285,7 @@ impl Storage {
     }
 
     /// Waits for the piece to be finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn wait_for_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
@@ -1316,7 +1316,7 @@ impl Storage {
     }
 
     /// Waits for the persistent piece to be finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn wait_for_persistent_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
@@ -1347,7 +1347,7 @@ impl Storage {
     }
 
     /// Waits for the persistent cache piece to be finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn wait_for_persistent_cache_piece_finished(
         &self,
         piece_id: &str,
@@ -1382,7 +1382,7 @@ impl Storage {
 
     /// Updates the metadata of the cache piece and writes
     /// the data of cache piece to file when the cache piece downloads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_cache_piece_started(
         &self,
         piece_id: &str,
@@ -1398,7 +1398,7 @@ impl Storage {
 
     /// Used for downloading cache piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1419,7 +1419,7 @@ impl Storage {
     }
 
     // handle_downloaded_cache_piece_from_source_finished handles the downloaded cache piece from source.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_downloaded_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1454,7 +1454,7 @@ impl Storage {
 
     /// Used for downloading cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1478,7 +1478,7 @@ impl Storage {
 
     // handle_downloaded_cache_piece_from_parent_finished handles the downloaded cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_downloaded_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1527,14 +1527,14 @@ impl Storage {
         )
     }
     /// Updates the metadata of the cache piece when the cache piece downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_cache_piece_failed(&self, piece_id: &str) -> Result<()> {
         self.metadata.download_piece_failed(piece_id)
     }
 
     /// Updates the metadata of the piece and
     /// returns the data of the piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn upload_cache_piece(
         &self,
         piece_id: &str,
@@ -1593,13 +1593,13 @@ impl Storage {
     }
 
     /// Returns whether the cache piece exists.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn is_cache_piece_exists(&self, piece_id: &str) -> Result<bool> {
         self.metadata.is_piece_exists(piece_id)
     }
 
     /// Returns the cache piece metadatas.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_cache_pieces(&self, task_id: &str) -> Result<Vec<metadata::Piece>> {
         self.metadata.get_pieces(task_id)
     }
@@ -1611,7 +1611,7 @@ impl Storage {
     }
 
     /// Waits for the cache piece to be finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn wait_for_cache_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -1287,6 +1287,16 @@ impl Storage {
     /// Waits for the piece to be finished.
     #[instrument(level = "debug", skip_all)]
     async fn wait_for_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
+        // Fast path: the piece is usually already finished when the upload
+        // starts, so check once before setting up the timers.
+        let piece = self
+            .get_piece(piece_id)?
+            .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+        if piece.is_finished() {
+            return Ok(piece);
+        }
+
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
@@ -1318,6 +1328,16 @@ impl Storage {
     /// Waits for the persistent piece to be finished.
     #[instrument(level = "debug", skip_all)]
     async fn wait_for_persistent_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
+        // Fast path: the piece is usually already finished when the upload
+        // starts, so check once before setting up the timers.
+        let piece = self
+            .get_persistent_piece(piece_id)?
+            .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+        if piece.is_finished() {
+            return Ok(piece);
+        }
+
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
@@ -1352,6 +1372,16 @@ impl Storage {
         &self,
         piece_id: &str,
     ) -> Result<metadata::Piece> {
+        // Fast path: the piece is usually already finished when the upload
+        // starts, so check once before setting up the timers.
+        let piece = self
+            .get_persistent_cache_piece(piece_id)?
+            .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+        if piece.is_finished() {
+            return Ok(piece);
+        }
+
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
@@ -1613,6 +1643,15 @@ impl Storage {
     /// Waits for the cache piece to be finished.
     #[instrument(level = "debug", skip_all)]
     async fn wait_for_cache_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
+        // Fast path: the piece is usually already finished when the upload
+        // starts, so check once before setting up the timers.
+        let piece = self
+            .get_cache_piece(piece_id)?
+            .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+        if piece.is_finished() {
+            return Ok(piece);
+        }
+
         // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -680,7 +680,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the task when task uploads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn upload_task_started(&self, id: &str) -> Result<Task> {
         let task = match self.db.get::<Task>(id.as_bytes())? {
             Some(mut task) => {
@@ -696,7 +696,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the task when task uploads finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn upload_task_finished(&self, id: &str) -> Result<Task> {
         let task = match self.db.get::<Task>(id.as_bytes())? {
             Some(mut task) => {
@@ -713,7 +713,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the task when the task uploads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn upload_task_failed(&self, id: &str) -> Result<Task> {
         let task = match self.db.get::<Task>(id.as_bytes())? {
             Some(mut task) => {
@@ -1356,7 +1356,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
 
     /// Creates a new persistent piece, which is imported by
     /// local.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn create_persistent_piece(
         &self,
         piece_id: &str,
@@ -1387,7 +1387,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
 
     /// Creates a new persistent cache piece, which is imported by
     /// local.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn create_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -1417,7 +1417,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the piece when the piece downloads started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_piece_started(&self, piece_id: &str, number: u32) -> Result<Piece> {
         // Construct the piece metadata.
         let piece = Piece {
@@ -1433,7 +1433,7 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the piece when the piece downloads finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_piece_finished(
         &self,
         piece_id: &str,
@@ -1460,13 +1460,13 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Updates the metadata of the piece when the piece downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_piece_failed(&self, piece_id: &str) -> Result<()> {
         self.delete_piece(piece_id)
     }
 
     /// Waits for the piece to be finished or failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn wait_for_piece_finished_failed(&self, piece_id: &str) -> Result<()> {
         self.delete_piece(piece_id)
     }
@@ -1477,13 +1477,13 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Checks if the piece exists.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn is_piece_exists(&self, piece_id: &str) -> Result<bool> {
         self.db.exists::<Piece>(piece_id.as_bytes())
     }
 
     /// Gets the piece metadatas.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_pieces(&self, task_id: &str) -> Result<Vec<Piece>> {
         let pieces = self
             .db
@@ -1501,14 +1501,14 @@ impl<E: StorageEngineOwned> Metadata<E> {
     }
 
     /// Deletes the piece metadata.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn delete_piece(&self, piece_id: &str) -> Result<()> {
         info!("delete piece metadata {}", piece_id);
         self.db.delete::<Piece>(piece_id.as_bytes())
     }
 
     /// Deletes the piece metadatas.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn delete_pieces(&self, task_id: &str) -> Result<()> {
         let piece_ids = self
             .db

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -150,7 +150,7 @@ pub struct QUICServerHandler {
 /// Implements the request handler.
 impl QUICServerHandler {
     /// Handles a single QUIC connection.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle(
         &self,
         connection: quinn::Connection,
@@ -191,7 +191,11 @@ impl QUICServerHandler {
     /// It reads the protocol header to determine the request type and dispatches
     /// to the appropriate handler. Supports both regular piece downloads and
     /// persistent cache piece downloads with proper request/response framing.
-    #[instrument(skip_all, fields(host_id, remote_address, task_id, piece_id))]
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(host_id, remote_address, task_id, piece_id)
+    )]
     async fn handle_stream(
         &self,
         mut reader: quinn::RecvStream,
@@ -491,7 +495,7 @@ impl QUICServerHandler {
     /// upload rate limiting, and prepares both the piece metadata and
     /// content stream for transmission. It's the core handler for regular
     /// piece download requests in the P2P network.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_piece(
         &self,
         piece_id: &str,
@@ -555,7 +559,7 @@ impl QUICServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent layer.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_persistent_piece(
         &self,
         piece_id: &str,
@@ -619,7 +623,7 @@ impl QUICServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent cache layer.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -724,7 +728,7 @@ impl QUICServerHandler {
     /// This function sends the provided bytes as a response and ensures
     /// all data is flushed to the underlying transport. This is typically
     /// used for sending headers and small payloads in a single operation.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn write_response(
         &self,
         request: Bytes,
@@ -745,7 +749,7 @@ impl QUICServerHandler {
     /// to the QUIC connection using tokio's copy utility. It's designed for
     /// streaming large piece content without loading everything into memory.
     /// The operation is flushed to ensure data delivery.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn write_stream<R: AsyncRead + Unpin + ?Sized>(
         &self,
         stream: &mut R,

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -32,7 +32,7 @@ use leaky_bucket::RateLimiter;
 use quinn::{congestion::BbrConfig, AckFrequencyConfig, Endpoint, ServerConfig, TransportConfig};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::io::{copy, AsyncRead};
+use tokio::io::{copy_buf, AsyncBufRead};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, instrument, Span};
 use vortex_protocol::{
@@ -500,7 +500,7 @@ impl QUICServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -564,7 +564,7 @@ impl QUICServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PersistentPieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PersistentPieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_persistent_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -628,7 +628,7 @@ impl QUICServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PersistentCachePieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PersistentCachePieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_persistent_cache_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -746,16 +746,17 @@ impl QUICServerHandler {
     /// Streams data from a reader directly to the QUIC writer.
     ///
     /// This function efficiently copies all data from the provided stream
-    /// to the QUIC connection using tokio's copy utility. It's designed for
-    /// streaming large piece content without loading everything into memory.
-    /// The operation is flushed to ensure data delivery.
+    /// to the QUIC connection using tokio's copy_buf utility, which writes the
+    /// reader's internal buffer directly without an intermediate copy buffer.
+    /// It's designed for streaming large piece content without loading
+    /// everything into memory. The operation is flushed to ensure data delivery.
     #[instrument(level = "debug", skip_all)]
-    async fn write_stream<R: AsyncRead + Unpin + ?Sized>(
+    async fn write_stream<R: AsyncBufRead + Unpin + ?Sized>(
         &self,
         stream: &mut R,
         writer: &mut quinn::SendStream,
     ) -> ClientResult<()> {
-        copy(stream, writer)
+        copy_buf(stream, writer)
             .await
             .inspect_err(|err| error!("copy failed: {}", err))?;
 

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -184,7 +184,11 @@ impl TCPServerHandler {
     /// It reads the protocol header to determine the request type and dispatches
     /// to the appropriate handler. Supports both regular piece downloads and
     /// persistent cache piece downloads with proper request/response framing.
-    #[instrument(skip_all, fields(host_id, remote_address, task_id, piece_id))]
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(host_id, remote_address, task_id, piece_id)
+    )]
     async fn handle(&self, stream: TcpStream, remote_address: String) -> ClientResult<()> {
         let (mut reader, mut writer) = stream.into_split();
         let header = self.read_header(&mut reader).await?;
@@ -447,7 +451,7 @@ impl TCPServerHandler {
     /// upload rate limiting, and prepares both the piece metadata and
     /// content stream for transmission. It's the core handler for regular
     /// piece download requests in the P2P network.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_piece(
         &self,
         piece_id: &str,
@@ -511,7 +515,7 @@ impl TCPServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent layer.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_persistent_piece(
         &self,
         piece_id: &str,
@@ -575,7 +579,7 @@ impl TCPServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent cache layer.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn handle_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -682,7 +686,7 @@ impl TCPServerHandler {
     /// This function sends the provided bytes as a response and ensures
     /// all data is flushed to the underlying transport. This is typically
     /// used for sending headers and small payloads in a single operation.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn write_response(
         &self,
         request: Bytes,
@@ -705,7 +709,7 @@ impl TCPServerHandler {
     /// to the TCP connection using tokio's copy utility. It's designed for
     /// streaming large piece content without loading everything into memory.
     /// The operation is flushed to ensure data delivery.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     async fn write_stream<R: AsyncRead + Unpin + ?Sized>(
         &self,
         stream: &mut R,

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -28,7 +28,7 @@ use leaky_bucket::RateLimiter;
 use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::io::{copy, AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{copy_buf, AsyncBufRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{
     tcp::{OwnedReadHalf, OwnedWriteHalf},
     TcpListener, TcpStream,
@@ -456,7 +456,7 @@ impl TCPServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -520,7 +520,7 @@ impl TCPServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PersistentPieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PersistentPieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_persistent_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -584,7 +584,7 @@ impl TCPServerHandler {
         &self,
         piece_id: &str,
         task_id: &str,
-    ) -> Result<(PersistentCachePieceContent, impl AsyncRead), Error> {
+    ) -> Result<(PersistentCachePieceContent, impl AsyncBufRead), Error> {
         // Get the piece metadata from the local storage.
         let piece = match self.storage.get_persistent_cache_piece(piece_id) {
             Ok(Some(piece)) => piece,
@@ -706,17 +706,18 @@ impl TCPServerHandler {
     /// Streams data from a reader directly to the TCP writer.
     ///
     /// This function efficiently copies all data from the provided stream
-    /// to the TCP connection using tokio's copy utility. It's designed for
-    /// streaming large piece content without loading everything into memory.
-    /// The operation is flushed to ensure data delivery.
+    /// to the TCP connection using tokio's copy_buf utility, which writes the
+    /// reader's internal buffer directly without an intermediate copy buffer.
+    /// It's designed for streaming large piece content without loading
+    /// everything into memory. The operation is flushed to ensure data delivery.
     #[instrument(level = "debug", skip_all)]
-    async fn write_stream<R: AsyncRead + Unpin + ?Sized>(
+    async fn write_stream<R: AsyncBufRead + Unpin + ?Sized>(
         &self,
         stream: &mut R,
         writer: &mut OwnedWriteHalf,
     ) -> ClientResult<()> {
         debug!("start to write stream to tcp writer");
-        copy(stream, writer).await.inspect_err(|err| {
+        copy_buf(stream, writer).await.inspect_err(|err| {
             error!("copy failed: {}", err);
         })?;
 

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -125,12 +125,17 @@ impl IDGenerator {
             } => {
                 // Filter the query parameters.
                 let url = Url::parse(url.as_str()).or_err(ErrorType::ParseError)?;
-                let query = url
+                let mut query = url
                     .query_pairs()
-                    .filter(|(k, _)| !filtered_query_params.contains(&k.to_string()));
+                    .filter(|(k, _)| {
+                        !filtered_query_params
+                            .iter()
+                            .any(|param| param.as_str() == k.as_ref())
+                    })
+                    .peekable();
 
                 let mut artifact_url = url.clone();
-                if query.clone().count() == 0 {
+                if query.peek().is_none() {
                     artifact_url.set_query(None);
                 } else {
                     artifact_url.query_pairs_mut().clear().extend_pairs(query);

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -62,7 +62,7 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
-    http::{get_range, hashmap_to_headermap, headermap_to_hashmap},
+    http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
     id_generator::{PersistentCacheTaskIDParameter, PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
     shutdown,
@@ -449,51 +449,43 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         // If download protocol is http, use the range of the request header.
         // If download protocol is not http, use the range of the download.
         if download.range.is_none() {
-            // Convert the header.
-            let request_header = match hashmap_to_headermap(&download.request_header) {
-                Ok(header) => header,
-                Err(err) => {
-                    // Download task failed.
-                    self.task
-                        .download_failed(task_id.as_str())
-                        .await
-                        .unwrap_or_else(|err| error!("download task failed: {}", err));
+            // Look up the range header directly instead of converting the whole
+            // request header hashmap into a HeaderMap.
+            let range_header = download
+                .request_header
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(reqwest::header::RANGE.as_str()))
+                .map(|(_, value)| value.as_str());
 
-                    // Collect download task failure metrics.
-                    collect_download_task_failure_metrics(
-                        download.r#type,
-                        download.tag.clone().unwrap_or_default().as_str(),
-                        download.application.clone().unwrap_or_default().as_str(),
-                        download.priority.to_string().as_str(),
-                    );
+            download.range = match range_header {
+                Some(range_header) => {
+                    match parse_range_header(
+                        range_header,
+                        task.content_length().unwrap_or_default(),
+                    ) {
+                        Ok(range) => Some(range),
+                        Err(err) => {
+                            // Download task failed.
+                            self.task
+                                .download_failed(task_id.as_str())
+                                .await
+                                .unwrap_or_else(|err| error!("download task failed: {}", err));
 
-                    error!("convert header: {}", err);
-                    return Err(Status::invalid_argument(err.to_string()));
-                }
-            };
+                            // Collect download task failure metrics.
+                            collect_download_task_failure_metrics(
+                                download.r#type,
+                                download.tag.clone().unwrap_or_default().as_str(),
+                                download.application.clone().unwrap_or_default().as_str(),
+                                download.priority.to_string().as_str(),
+                            );
 
-            download.range =
-                match get_range(&request_header, task.content_length().unwrap_or_default()) {
-                    Ok(range) => range,
-                    Err(err) => {
-                        // Download task failed.
-                        self.task
-                            .download_failed(task_id.as_str())
-                            .await
-                            .unwrap_or_else(|err| error!("download task failed: {}", err));
-
-                        // Collect download task failure metrics.
-                        collect_download_task_failure_metrics(
-                            download.r#type,
-                            download.tag.clone().unwrap_or_default().as_str(),
-                            download.application.clone().unwrap_or_default().as_str(),
-                            download.priority.to_string().as_str(),
-                        );
-
-                        error!("get range failed: {}", err);
-                        return Err(Status::failed_precondition(err.to_string()));
+                            error!("get range failed: {}", err);
+                            return Err(Status::failed_precondition(err.to_string()));
+                        }
                     }
-                };
+                }
+                None => None,
+            };
         }
 
         // Initialize stream channel.

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -53,7 +53,7 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
-    http::{get_range, hashmap_to_headermap, headermap_to_hashmap},
+    http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
     id_generator::{PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
     shutdown,
@@ -401,51 +401,43 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         // If download protocol is http, use the range of the request header.
         // If download protocol is not http, use the range of the download.
         if download.range.is_none() {
-            // Convert the header.
-            let request_header = match hashmap_to_headermap(&download.request_header) {
-                Ok(header) => header,
-                Err(err) => {
-                    // Download task failed.
-                    self.task
-                        .download_failed(task_id.as_str())
-                        .await
-                        .unwrap_or_else(|err| error!("download task failed: {}", err));
+            // Look up the range header directly instead of converting the whole
+            // request header hashmap into a HeaderMap.
+            let range_header = download
+                .request_header
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(reqwest::header::RANGE.as_str()))
+                .map(|(_, value)| value.as_str());
 
-                    // Collect download task failure metrics.
-                    collect_download_task_failure_metrics(
-                        download.r#type,
-                        download.tag.clone().unwrap_or_default().as_str(),
-                        download.application.clone().unwrap_or_default().as_str(),
-                        download.priority.to_string().as_str(),
-                    );
+            download.range = match range_header {
+                Some(range_header) => {
+                    match parse_range_header(
+                        range_header,
+                        task.content_length().unwrap_or_default(),
+                    ) {
+                        Ok(range) => Some(range),
+                        Err(err) => {
+                            // Download task failed.
+                            self.task
+                                .download_failed(task_id.as_str())
+                                .await
+                                .unwrap_or_else(|err| error!("download task failed: {}", err));
 
-                    error!("convert header: {}", err);
-                    return Err(Status::invalid_argument(err.to_string()));
-                }
-            };
+                            // Collect download task failure metrics.
+                            collect_download_task_failure_metrics(
+                                download.r#type,
+                                download.tag.clone().unwrap_or_default().as_str(),
+                                download.application.clone().unwrap_or_default().as_str(),
+                                download.priority.to_string().as_str(),
+                            );
 
-            download.range =
-                match get_range(&request_header, task.content_length().unwrap_or_default()) {
-                    Ok(range) => range,
-                    Err(err) => {
-                        // Download task failed.
-                        self.task
-                            .download_failed(task_id.as_str())
-                            .await
-                            .unwrap_or_else(|err| error!("download task failed: {}", err));
-
-                        // Collect download task failure metrics.
-                        collect_download_task_failure_metrics(
-                            download.r#type,
-                            download.tag.clone().unwrap_or_default().as_str(),
-                            download.application.clone().unwrap_or_default().as_str(),
-                            download.priority.to_string().as_str(),
-                        );
-
-                        error!("get range failed: {}", err);
-                        return Err(Status::failed_precondition(err.to_string()));
+                            error!("get range failed: {}", err);
+                            return Err(Status::failed_precondition(err.to_string()));
+                        }
                     }
-                };
+                }
+                None => None,
+            };
         }
 
         // Initialize stream channel.

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -927,7 +927,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
     /// Sync pieces provides the piece metadata for parent. If the per-piece collection timeout is exceeded,
     /// the stream will be closed.
-    #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
+    #[instrument(level = "debug", skip_all, fields(host_id, remote_host_id, task_id))]
     async fn sync_pieces(
         &self,
         request: Request<SyncPiecesRequest>,
@@ -1666,7 +1666,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
     type SyncPersistentPiecesStream = ReceiverStream<Result<SyncPersistentPiecesResponse, Status>>;
 
     /// Sync perisstent pieces provides the persistent piece metadata for parent.
-    #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
+    #[instrument(level = "debug", skip_all, fields(host_id, remote_host_id, task_id))]
     async fn sync_persistent_pieces(
         &self,
         request: Request<SyncPersistentPiecesRequest>,
@@ -2248,7 +2248,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
     /// Sync persistent cache pieces provides the persistent cache piece metadata for parent.
     /// If the per-piece collection timeout is exceeded, the stream will be closed.
-    #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
+    #[instrument(level = "debug", skip_all, fields(host_id, remote_host_id, task_id))]
     async fn sync_persistent_cache_pieces(
         &self,
         request: Request<SyncPersistentCachePiecesRequest>,
@@ -2472,7 +2472,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
     type SyncCachePiecesStream = ReceiverStream<Result<SyncCachePiecesResponse, Status>>;
 
     /// Sync cache pieces provides the cache piece metadata for parent.
-    #[instrument(skip_all, fields(host_id, remote_host_id, task_id))]
+    #[instrument(level = "debug", skip_all, fields(host_id, remote_host_id, task_id))]
     async fn sync_cache_pieces(
         &self,
         _request: Request<SyncCachePiecesRequest>,
@@ -2482,6 +2482,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
 
     /// Downloads the cache piece content for parent.
     #[instrument(
+        level = "debug",
         skip_all,
         fields(host_id, remote_host_id, task_id, piece_id, piece_length)
     )]
@@ -2623,7 +2624,7 @@ impl DfdaemonUploadClient {
 
     /// Sync pieces provides the piece metadata for parent. If the per-piece collection timeout is exceeded,
     /// the stream will be closed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn sync_pieces(
         &self,
         request: SyncPiecesRequest,
@@ -2698,7 +2699,7 @@ impl DfdaemonUploadClient {
     }
 
     /// Sync perisstent pieces provides the persistent piece metadata for parent.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn sync_persistent_pieces(
         &self,
         request: SyncPersistentPiecesRequest,
@@ -2769,7 +2770,7 @@ impl DfdaemonUploadClient {
 
     /// Sync persistent cache pieces provides the persistent cache piece metadata for parent.
     /// If the per-piece collection timeout is exceeded, the stream will be closed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn sync_persistent_cache_pieces(
         &self,
         request: SyncPersistentCachePiecesRequest,

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -481,7 +481,7 @@ pub async fn https_handler(
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
 ) -> ClientResult<Response> {
-    info!("handle HTTPS request: {:?}", request);
+    debug!("handle HTTPS request: {:?}", request);
 
     // Proxy the request directly  to the remote server.
     if let Some(host) = request.uri().host() {
@@ -869,7 +869,7 @@ async fn proxy_via_dfdaemon(
                 );
             }
             // If the task is already prefetched, ignore the error.
-            Err(ClientError::InvalidState(_)) => info!("task is already prefetched"),
+            Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
             Err(err) => {
                 error!("prefetch task started: {}", err);
             }
@@ -1020,7 +1020,7 @@ async fn proxy_via_dfdaemon(
                         }
                     }
                     None => {
-                        info!("message is none");
+                        debug!("message is none");
                         if let Err(err) = writer.flush().await {
                             error!("writer flush error: {}", err);
                         }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -997,8 +997,11 @@ async fn proxy_via_dfdaemon(
                                 };
 
                                 debug!("copy piece {} to stream", need_piece_number);
+                                // copy_buf writes the piece reader's internal buffer to the
+                                // pipe directly, skipping tokio::io::copy's intermediate 8KiB
+                                // copy buffer.
                                 if let Err(err) =
-                                    tokio::io::copy(&mut piece_range_reader, &mut writer).await
+                                    tokio::io::copy_buf(&mut piece_range_reader, &mut writer).await
                                 {
                                     error!("download piece reader error: {}", err);
                                     if let Err(err) = writer.shutdown().await {

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -56,7 +56,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, Barrier};
@@ -882,9 +882,9 @@ async fn proxy_via_dfdaemon(
     // Get the read buffer size from the config.
     let read_buffer_size = config.proxy.read_buffer_size;
 
-    // Write the task data to the reader.
-    let (reader, writer) = tokio::io::duplex(read_buffer_size);
-    let mut writer = BufWriter::with_capacity(read_buffer_size, writer);
+    // Write the task data to the reader. The duplex pipe buffers the data
+    // itself, so no extra BufWriter is needed.
+    let (reader, mut writer) = tokio::io::duplex(read_buffer_size);
     let reader_stream = ReaderStream::with_capacity(reader, read_buffer_size);
 
     // Construct the response body.
@@ -914,8 +914,11 @@ async fn proxy_via_dfdaemon(
     // shutdown the writer.
     tokio::spawn(
         async move {
-            // Initialize the hashmap of the finished piece readers and pieces.
-            let mut finished_piece_readers = HashMap::new();
+            // Initialize the hashmap of the finished piece lengths, keyed by
+            // piece number. Readers are opened lazily when a piece is written
+            // in order, so out-of-order pieces do not hold buffers or file
+            // descriptors while waiting.
+            let mut finished_pieces = HashMap::new();
 
             // Get the first piece number from the started response.
             let Some(first_piece) = download_task_started_response.pieces.first() else {
@@ -965,38 +968,34 @@ async fn proxy_via_dfdaemon(
                                 return;
                             };
 
-                            let piece_range_reader = match task
-                                .piece
-                                .download_from_local_into_async_read(
-                                    task.piece
-                                        .id(message.task_id.as_str(), piece.number)
-                                        .as_str(),
-                                    message.task_id.as_str(),
-                                    piece.length,
-                                    download_task_started_response.range,
-                                )
-                                .await
-                            {
-                                Ok(piece_range_reader) => piece_range_reader,
-                                Err(err) => {
-                                    error!("download piece reader error: {}", err);
-                                    if let Err(err) = writer.shutdown().await {
-                                        error!("writer shutdown error: {}", err);
-                                    }
-
-                                    return;
-                                }
-                            };
-
-                            // Use a buffer to read the piece.
-                            let piece_range_reader =
-                                BufReader::with_capacity(read_buffer_size, piece_range_reader);
-
                             // Write the piece data to the pipe in order.
-                            finished_piece_readers.insert(piece.number, piece_range_reader);
-                            while let Some(mut piece_range_reader) =
-                                finished_piece_readers.remove(&need_piece_number)
+                            finished_pieces.insert(piece.number, piece.length);
+                            while let Some(piece_length) =
+                                finished_pieces.remove(&need_piece_number)
                             {
+                                let mut piece_range_reader = match task
+                                    .piece
+                                    .download_from_local_into_async_read(
+                                        task.piece
+                                            .id(message.task_id.as_str(), need_piece_number)
+                                            .as_str(),
+                                        message.task_id.as_str(),
+                                        piece_length,
+                                        download_task_started_response.range,
+                                    )
+                                    .await
+                                {
+                                    Ok(piece_range_reader) => piece_range_reader,
+                                    Err(err) => {
+                                        error!("download piece reader error: {}", err);
+                                        if let Err(err) = writer.shutdown().await {
+                                            error!("writer shutdown error: {}", err);
+                                        }
+
+                                        return;
+                                    }
+                                };
+
                                 debug!("copy piece {} to stream", need_piece_number);
                                 if let Err(err) =
                                     tokio::io::copy(&mut piece_range_reader, &mut writer).await

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -30,7 +30,7 @@ use dragonfly_client_metric::{
 };
 use dragonfly_client_util::{
     digest::is_blob_url,
-    http::{get_range, hashmap_to_headermap, headermap_to_hashmap},
+    http::{headermap_to_hashmap, parse_range_header},
     id_generator::TaskIDParameter,
     types::redacted::RedactedDownload,
 };
@@ -174,50 +174,39 @@ pub async fn download(
     // If download protocol is http, use the range of the request header.
     // If download protocol is not http, use the range of the download.
     if download.range.is_none() {
-        // Convert the header.
-        let request_header = match hashmap_to_headermap(&download.request_header) {
-            Ok(header) => header,
-            Err(err) => {
-                // Download task failed.
-                task_manager
-                    .download_failed(task_id.as_str())
-                    .await
-                    .unwrap_or_else(|err| error!("download task failed: {}", err));
+        // Look up the range header directly instead of converting the whole
+        // request header hashmap into a HeaderMap.
+        let range_header = download
+            .request_header
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(reqwest::header::RANGE.as_str()))
+            .map(|(_, value)| value.as_str());
 
-                // Collect download task failure metrics.
-                collect_download_task_failure_metrics(
-                    download.r#type,
-                    download.tag.clone().unwrap_or_default().as_str(),
-                    download.application.clone().unwrap_or_default().as_str(),
-                    download.priority.to_string().as_str(),
-                );
+        download.range = match range_header {
+            Some(range_header) => {
+                match parse_range_header(range_header, task.content_length().unwrap_or_default()) {
+                    Ok(range) => Some(range),
+                    Err(err) => {
+                        // Download task failed.
+                        task_manager
+                            .download_failed(task_id.as_str())
+                            .await
+                            .unwrap_or_else(|err| error!("download task failed: {}", err));
 
-                error!("convert header: {}", err);
-                return Err(err);
+                        // Collect download task failure metrics.
+                        collect_download_task_failure_metrics(
+                            download.r#type,
+                            download.tag.clone().unwrap_or_default().as_str(),
+                            download.application.clone().unwrap_or_default().as_str(),
+                            download.priority.to_string().as_str(),
+                        );
+
+                        error!("get range failed: {}", err);
+                        return Err(err);
+                    }
+                }
             }
-        };
-
-        download.range = match get_range(&request_header, task.content_length().unwrap_or_default())
-        {
-            Ok(range) => range,
-            Err(err) => {
-                // Download task failed.
-                task_manager
-                    .download_failed(task_id.as_str())
-                    .await
-                    .unwrap_or_else(|err| error!("download task failed: {}", err));
-
-                // Collect download task failure metrics.
-                collect_download_task_failure_metrics(
-                    download.r#type,
-                    download.tag.clone().unwrap_or_default().as_str(),
-                    download.application.clone().unwrap_or_default().as_str(),
-                    download.priority.to_string().as_str(),
-                );
-
-                error!("get range failed: {}", err);
-                return Err(err);
-            }
+            None => None,
         };
     }
 

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1198,7 +1198,7 @@ impl PersistentCacheTask {
                 let piece_id = piece_manager.persistent_cache_id(task_id.as_str(), number);
                 let parent = parent_selector.select(parents);
 
-                info!(
+                debug!(
                     "start to download persistent cache piece {} from parent {:?}",
                     piece_id,
                     parent.id.clone()

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -2040,7 +2040,7 @@ impl PersistentTask {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 let parent = parent_selector.select(parents);
 
-                info!(
+                debug!(
                     "start to download persistent piece {} from parent {:?}",
                     piece_id,
                     parent.id.clone()
@@ -2349,7 +2349,7 @@ impl PersistentTask {
                 model_scope: Option<ModelScope>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
-                info!("start to download piece {} from source", piece_id);
+                debug!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
                     .download_persistent_from_source(
@@ -2794,7 +2794,7 @@ impl PersistentTask {
                 model_scope: Option<ModelScope>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
-                info!("start to download piece {} from source", piece_id);
+                debug!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
                     .download_persistent_from_source(

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -34,7 +34,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tracing::{error, info, instrument, warn, Span};
+use tracing::{debug, error, instrument, warn, Span};
 
 /// The maximum piece count. If the piece count is upper
 /// than MAX_PIECE_COUNT, the piece length will be optimized by the file length.
@@ -183,7 +183,7 @@ impl Piece {
                 number += 1;
             }
 
-            info!(
+            debug!(
                 "calculate interested pieces by range {:?}, content length: {:?}, piece length: {:?}, pieces: count {}, range [{}, {}]",
                 range,
                 content_length,
@@ -232,7 +232,7 @@ impl Piece {
             number += 1;
         }
 
-        info!(
+        debug!(
             "calculate interested pieces by content length: {:?}, piece length: {:?}, pieces: count {}, range [{}, {}]",
             content_length,
             piece_length,
@@ -364,7 +364,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
-            info!("finished piece {} from local", piece_id);
+            debug!("finished piece {} from local", piece_id);
             scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
@@ -494,7 +494,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
-            info!("finished piece {} from local", piece_id);
+            debug!("finished piece {} from local", piece_id);
             scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
@@ -725,7 +725,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
-            info!("finished persistent piece {} from local", piece_id);
+            debug!("finished persistent piece {} from local", piece_id);
             scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
@@ -847,7 +847,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
-            info!("finished piece {} from local", piece_id);
+            debug!("finished piece {} from local", piece_id);
             scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
@@ -1070,7 +1070,7 @@ impl Piece {
         // If the piece is downloaded by the other thread,
         // return the piece directly.
         if piece.is_finished() {
-            info!("finished persistent cache piece {} from local", piece_id);
+            debug!("finished persistent cache piece {} from local", piece_id);
             scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -33,7 +33,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 use tracing::{debug, error, instrument, warn, Span};
 
 /// The maximum piece count. If the piece count is upper
@@ -315,7 +315,7 @@ impl Piece {
         task_id: &str,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
@@ -666,7 +666,7 @@ impl Piece {
         task_id: &str,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
@@ -1011,7 +1011,7 @@ impl Piece {
         task_id: &str,
         length: u64,
         range: Option<Range>,
-    ) -> Result<impl AsyncRead> {
+    ) -> Result<impl AsyncBufRead> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -184,14 +184,13 @@ impl Piece {
             }
 
             info!(
-                "calculate interested pieces by range {:?}, content length: {:?}, piece length: {:?}, pieces: {:?}",
+                "calculate interested pieces by range {:?}, content length: {:?}, piece length: {:?}, pieces: count {}, range [{}, {}]",
                 range,
                 content_length,
                 piece_length,
-                pieces
-                    .iter()
-                    .map(|piece| piece.number)
-                    .collect::<Vec<u32>>()
+                pieces.len(),
+                pieces.first().map(|piece| piece.number).unwrap_or_default(),
+                pieces.last().map(|piece| piece.number).unwrap_or_default()
             );
             return Ok(pieces);
         }
@@ -234,19 +233,18 @@ impl Piece {
         }
 
         info!(
-            "calculate interested pieces by content length: {:?}, piece length: {:?}, pieces: {:?}",
+            "calculate interested pieces by content length: {:?}, piece length: {:?}, pieces: count {}, range [{}, {}]",
             content_length,
             piece_length,
-            pieces
-                .iter()
-                .map(|piece| piece.number)
-                .collect::<Vec<u32>>()
+            pieces.len(),
+            pieces.first().map(|piece| piece.number).unwrap_or_default(),
+            pieces.last().map(|piece| piece.number).unwrap_or_default()
         );
         Ok(pieces)
     }
 
     /// Removes the finished pieces from interested pieces.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn remove_finished_from_interested(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -264,7 +262,7 @@ impl Piece {
     }
 
     /// Merges the finished pieces and has finished pieces.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn merge_finished_pieces(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -310,7 +308,7 @@ impl Piece {
     }
 
     /// Downloads a single piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -328,14 +326,14 @@ impl Piece {
 
     /// Downloads a single piece from local cache. Fake the download piece
     /// from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a single piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_from_parent(
         &self,
         piece_id: &str,
@@ -460,7 +458,7 @@ impl Piece {
 
     /// Downloads a single piece from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_from_source(
         &self,
         piece_id: &str,
@@ -626,13 +624,13 @@ impl Piece {
     }
 
     /// Gets a persistent piece from the local storage.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_piece(piece_id)
     }
 
     /// Creates a new persistent piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_persistent<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -648,7 +646,7 @@ impl Piece {
     }
 
     /// Registers a new persistent piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn register_persistent(
         &self,
         piece_id: &str,
@@ -661,7 +659,7 @@ impl Piece {
     }
 
     /// Downloads a persistent piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -681,14 +679,14 @@ impl Piece {
 
     /// Downloads a persistent piece from local cache. Fake the download
     /// persistent piece from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a persistent piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_from_parent(
         &self,
         piece_id: &str,
@@ -810,7 +808,7 @@ impl Piece {
 
     /// Downloads a single persistent piece from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_from_source(
         &self,
         piece_id: &str,
@@ -971,13 +969,13 @@ impl Piece {
     }
 
     /// Gets a persistent cache piece from the local storage.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent_cache(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_cache_piece(piece_id)
     }
 
     /// Creates a new persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_persistent_cache<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -993,7 +991,7 @@ impl Piece {
     }
 
     /// Registers a new persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn register_persistent_cache(
         &self,
         piece_id: &str,
@@ -1006,7 +1004,7 @@ impl Piece {
     }
 
     /// Downloads a persistent cache piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_cache_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -1026,14 +1024,14 @@ impl Piece {
 
     /// Downloads a persistent cache piece from local cache. Fake the download
     /// persistent cache piece from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_cache_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a persistent cache piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_cache_from_parent(
         &self,
         piece_id: &str,

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1214,7 +1214,7 @@ impl Task {
                         interrupt.store(true, Ordering::SeqCst);
                     });
 
-                info!(
+                debug!(
                     "finished piece {} from parent {:?} using protocol {}",
                     piece_id, metadata.parent_id, protocol,
                 );
@@ -1507,7 +1507,7 @@ impl Task {
                             error!("send DownloadPieceBackToSourceFinishedRequest for piece {} failed: {:?}", piece_id, err);
                         });
 
-                info!("finished piece {} from source", piece_id);
+                debug!("finished piece {} from source", piece_id);
                 Ok(metadata)
             }
 
@@ -1695,7 +1695,7 @@ impl Task {
 
             // Fake the download from the local.
             self.piece.download_from_local(piece.length);
-            info!("finished piece {} from local", piece_id,);
+            debug!("finished piece {} from local", piece_id,);
 
             // Construct the piece.
             let piece = Piece {
@@ -1946,7 +1946,7 @@ impl Task {
                         });
                 }
 
-                info!("finished piece {} from source", piece_id);
+                debug!("finished piece {} from source", piece_id);
                 Ok(metadata)
             }
 

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1066,7 +1066,7 @@ impl Task {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 let parent = parent_selector.select(parents);
 
-                info!(
+                debug!(
                     "start to download piece {} from parent {:?}",
                     piece_id,
                     parent.id.clone()
@@ -1379,7 +1379,7 @@ impl Task {
                 model_scope: Option<ModelScope>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
-                info!("start to download piece {} from source", piece_id);
+                debug!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
                     .download_from_source(
@@ -1839,7 +1839,7 @@ impl Task {
                 model_scope: Option<ModelScope>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
-                info!("start to download piece {} from source", piece_id);
+                debug!("start to download piece {} from source", piece_id);
 
                 let metadata = piece_manager
                     .download_from_source(

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -29,7 +29,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
     filter::LevelFilter,
-    fmt::{time::ChronoLocal, Layer},
+    fmt::{time::SystemTime, Layer},
     prelude::*,
     EnvFilter, Registry,
 };
@@ -66,12 +66,13 @@ pub fn init_tracing(
     };
     let stdout_logging_layer = Layer::new()
         .with_writer(stdout_writer)
+        .with_ansi(false)
         .with_file(true)
         .with_line_number(true)
         .with_target(false)
         .with_thread_names(false)
         .with_thread_ids(false)
-        .with_timer(ChronoLocal::rfc_3339())
+        .with_timer(SystemTime)
         .with_filter(stdout_filter);
 
     // Setup file layer.
@@ -94,7 +95,7 @@ pub fn init_tracing(
         .with_target(false)
         .with_thread_names(false)
         .with_thread_ids(false)
-        .with_timer(ChronoLocal::rfc_3339())
+        .with_timer(SystemTime)
         .compact();
 
     // Setup env filter for log level.
@@ -241,7 +242,7 @@ pub fn init_command_tracing(log_level: Level, console: bool) -> Vec<WorkerGuard>
         .with_target(false)
         .with_thread_names(false)
         .with_thread_ids(false)
-        .with_timer(ChronoLocal::rfc_3339())
+        .with_timer(SystemTime)
         .with_filter(stdout_filter);
 
     // Setup env filter for log level.

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -72,7 +72,6 @@ pub fn init_tracing(
         .with_thread_names(false)
         .with_thread_ids(false)
         .with_timer(ChronoLocal::rfc_3339())
-        .pretty()
         .with_filter(stdout_filter);
 
     // Setup file layer.
@@ -243,7 +242,6 @@ pub fn init_command_tracing(log_level: Level, console: bool) -> Vec<WorkerGuard>
         .with_thread_names(false)
         .with_thread_ids(false)
         .with_timer(ChronoLocal::rfc_3339())
-        .pretty()
         .with_filter(stdout_filter);
 
     // Setup env filter for log level.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes several significant changes to buffer size defaults, logging verbosity, and cache/file handling in the client storage and configuration modules. The main goals are to reduce default buffer sizes for memory efficiency, increase debug visibility for network operations, and clean up cache management code.

**Configuration and Buffer Size Updates:**

* Reduced the default buffer sizes for reading and writing pieces from 4MB to 512KiB in `dragonfly-client-config/src/dfdaemon.rs`, and updated documentation to reflect these new defaults. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL268-R277) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL341-R344)
* Updated struct documentation to state the new buffer size defaults (e.g., `read_buffer_size` now defaults to 1MiB instead of 4MiB/1KiB as previously documented). [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL983-R983) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddL1364-R1364)

**Logging and Instrumentation Improvements:**

* Increased the verbosity of tracing for all major QUIC and TCP client methods by setting the `tracing::instrument` level to `debug`, aiding in more detailed diagnostics during piece downloads and protocol handling. [[1]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L62-R62) [[2]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L86-R86) [[3]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L120-R120) [[4]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L140-R140) [[5]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L177-R177) [[6]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L197-R197) [[7]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L233-R233) [[8]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L295-R295) [[9]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L313-R313) [[10]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L350-R350) [[11]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL57-R57) [[12]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL81-R81) [[13]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL116-R116) [[14]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL136-R136) [[15]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL174-R174) [[16]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL194-R194) [[17]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL234-R234) [[18]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL288-R288) [[19]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL307-R307) [[20]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL346-R346)

**Cache and File Handling Refactoring:**

* Removed the redundant `config` field from the `Cache` struct and its constructor, simplifying cache state management. [[1]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL110-L112) [[2]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL128)
* Changed the cache read interface to return an `AsyncBufRead` instead of `AsyncRead`, and removed the use of `BufReader` (now returning a plain `Cursor`), streamlining the async read path. [[1]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL145-R141) [[2]](diffhunk://#diff-51f0ccb672e36dc2c15f60176ef4f9c63eae4bbf665b32f3a1ad4a5dc8f19f2aL187-R183)
* Added a constant for the default file descriptor cache capacity (`DEFAULT_FD_CACHE_CAPACITY`) in `content.rs` for improved resource management.

**Codebase Modernization:**

* Updated imports in `content.rs` to use more modern and explicit types (e.g., `AsyncBufRead`, `AsyncRead`, `FileExt`) and removed unused ones, preparing for future async and file handling improvements.

These changes collectively improve memory usage, observability, and code maintainability.
<!--- Describe your changes in detail -->

## Screenshots (if appropriate)

Download the same 1 MiB chunk on every request (cache-friendly workload).

### v1.4.0

<img width="300" height="150" alt="heap" src="https://github.com/user-attachments/assets/239a7ca5-15f9-480a-a368-983e4bd43329" />

<img width="1200" height="2102" alt="profile" src="https://github.com/user-attachments/assets/3cad89a2-e3eb-44ad-9fe3-afdf02b3b7f6" />

<img width="2372" height="1106" alt="image" src="https://github.com/user-attachments/assets/20257765-5cc7-4148-bde3-b7d0882c3baf" />

### Optimized

<img width="300" height="150" alt="heap" src="https://github.com/user-attachments/assets/3c1c8d91-11dc-4408-a386-6e4aab810034" />

<img width="1200" height="2102" alt="profile" src="https://github.com/user-attachments/assets/41fd3dbf-f778-42be-9392-d2844243869c" />

<img width="2304" height="1088" alt="image" src="https://github.com/user-attachments/assets/66143bc7-9f2c-4c78-8562-931e2595f44f" />







