### PR TITLE
Enhance local cache handling and announce peer to scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.2.31"
+version = "2.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf76fa86d7330ac30c27189315fe5f4692bfd80c68a7616100f994c6d2699651"
+checksum = "bc9ed8aad2f81594c5ee06929784b976c6346e0eb73a6fb53202c2f9e451ed9f"
 dependencies = [
  "prost 0.14.4",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2631,7 +2631,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2981,7 +2981,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4713,7 +4713,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.9",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4752,7 +4752,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.9",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5279,7 +5279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ dependencies = [
  "security-framework 3.5.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5705,7 +5705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5933,7 +5933,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6999,7 +6999,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
-dragonfly-api = "=2.2.31"
+dragonfly-api = "=2.2.32"
 dragonfly-client = { path = "dragonfly-client", version = "1.4.1" }
 dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.1" }
 dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.1" }

--- a/dragonfly-client-util/src/types/redacted.rs
+++ b/dragonfly-client-util/src/types/redacted.rs
@@ -89,7 +89,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             enable_task_id_based_blob_digest,
             hugging_face,
             model_scope,
-            hit_local_cache,
+            metadata_only,
         } = self.0;
 
         f.debug_struct("Download")
@@ -133,7 +133,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             )
             .field("hugging_face", &scrubbed(hugging_face, scrub_hugging_face))
             .field("model_scope", &scrubbed(model_scope, scrub_model_scope))
-            .field("hit_local_cache", hit_local_cache)
+            .field("metadata_only", metadata_only)
             .finish()
     }
 }

--- a/dragonfly-client-util/src/types/redacted.rs
+++ b/dragonfly-client-util/src/types/redacted.rs
@@ -89,6 +89,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             enable_task_id_based_blob_digest,
             hugging_face,
             model_scope,
+            hit_local_cache,
         } = self.0;
 
         f.debug_struct("Download")
@@ -132,6 +133,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             )
             .field("hugging_face", &scrubbed(hugging_face, scrub_hugging_face))
             .field("model_scope", &scrubbed(model_scope, scrub_model_scope))
+            .field("hit_local_cache", hit_local_cache)
             .finish()
     }
 }

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1108,6 +1108,7 @@ async fn download(
                 actual_content_length: None,
                 actual_piece_count: None,
                 enable_task_id_based_blob_digest: false,
+                hit_local_cache: false,
             }),
         })
         .await

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1108,7 +1108,7 @@ async fn download(
                 actual_content_length: None,
                 actual_piece_count: None,
                 enable_task_id_based_blob_digest: false,
-                hit_local_cache: false,
+                metadata_only: false,
             }),
         })
         .await

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -474,7 +474,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         tokio::spawn(
             async move {
                 match task_manager_clone
-                    .download(
+                    .download_and_ensure_announcement(
                         &task_clone,
                         host_id.as_str(),
                         peer_id.as_str(),

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1275,7 +1275,7 @@ fn make_download_task_request(
                     .registry_mirror
                     .enable_task_id_based_blob_digest,
             ),
-            hit_local_cache: false,
+            metadata_only: false,
         }),
     })
 }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1275,6 +1275,7 @@ fn make_download_task_request(
                     .registry_mirror
                     .enable_task_id_based_blob_digest,
             ),
+            hit_local_cache: false,
         }),
     })
 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -547,6 +547,36 @@ impl Task {
         Ok(())
     }
 
+    /// Downloads a task and announces the peer to the scheduler, even if all pieces are
+    /// hit in the local cache.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn download_and_ensure_announcement(
+        &self,
+        task: &metadata::Task,
+        host_id: &str,
+        peer_id: &str,
+        request: Download,
+        download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
+    ) -> ClientResult<()> {
+        if task.is_finished() {
+            return self
+                .download_partial_with_scheduler_from_local(task, host_id, peer_id, request)
+                .await
+                .inspect_err(|err| {
+                    error!("announce peer with scheduler failed: {:?}", err);
+                });
+        }
+
+        self.download(
+            task,
+            host_id,
+            peer_id,
+            request.clone(),
+            download_progress_tx.clone(),
+        )
+        .await
+    }
+
     /// Downloads a partial task with scheduler.
     #[allow(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all)]
@@ -964,12 +994,146 @@ impl Task {
                     in_stream_tx.closed().await;
                     return Ok(finished_pieces);
                 }
+                announce_peer_response::Response::HitLocalCacheResponse(_) => {
+                    // HitLocalCacheResponse is only sent when the register request has the
+                    // hit_local_cache flag, which is not set in this flow.
+                    error!("receive unexpected HitLocalCacheResponse");
+                    return Err(Error::UnexpectedResponse);
+                }
             }
         }
 
         // If the stream is finished abnormally, return an error.
         error!("stream is finished abnormally");
         Ok(finished_pieces)
+    }
+
+    /// Announces a task that hits the local cache completely with the scheduler. It only
+    /// reports the metadata of the peer to the scheduler by the register request with the
+    /// hit_local_cache flag and the download peer started/finished requests, no pieces need
+    /// to be downloaded. The scheduler registers the peer and can schedule it as a candidate
+    /// parent for other peers.
+    #[instrument(level = "debug", skip_all)]
+    async fn download_partial_with_scheduler_from_local(
+        &self,
+        task: &metadata::Task,
+        host_id: &str,
+        peer_id: &str,
+        request: Download,
+    ) -> ClientResult<()> {
+        // Get the id of the task.
+        let task_id = task.id.as_str();
+
+        // Set the hit_local_cache flag, so the scheduler only needs the metadata report
+        // and does not schedule the peer for downloading pieces.
+        let request = Download {
+            hit_local_cache: true,
+            need_back_to_source: false,
+            ..request
+        };
+
+        // Initialize stream channel.
+        let (in_stream_tx, in_stream_rx) = mpsc::channel(4);
+
+        // Send the register peer request.
+        in_stream_tx
+            .send_timeout(
+                AnnouncePeerRequest {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    request: Some(announce_peer_request::Request::RegisterPeerRequest(
+                        RegisterPeerRequest {
+                            download: Some(request),
+                        },
+                    )),
+                },
+                REQUEST_TIMEOUT,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("send RegisterPeerRequest failed: {:?}", err);
+            })?;
+        debug!("sent RegisterPeerRequest");
+
+        // Initialize the stream.
+        let in_stream = ReceiverStream::new(in_stream_rx);
+        let request_stream = Request::new(in_stream);
+        let response = self
+            .scheduler_client
+            .announce_peer(task_id, peer_id, request_stream)
+            .await
+            .inspect_err(|err| {
+                error!("announce peer failed: {:?}", err);
+            })?;
+        debug!("announced peer has been connected");
+
+        let out_stream = response
+            .into_inner()
+            .timeout(self.config.scheduler.schedule_timeout);
+        tokio::pin!(out_stream);
+
+        // Receive the response of the register peer request, which should be the
+        // hit local cache response.
+        let message = out_stream
+            .try_next()
+            .await
+            .inspect_err(|err| {
+                error!("receive message from scheduler failed: {:?}", err);
+            })?
+            .ok_or_else(|| {
+                error!("stream is finished abnormally");
+                Error::Unknown("stream is finished abnormally".to_string())
+            })?;
+
+        let response = message?.response.ok_or(Error::UnexpectedResponse)?;
+        let announce_peer_response::Response::HitLocalCacheResponse(_) = response else {
+            error!("receive unexpected response: {:?}", response);
+            return Err(Error::UnexpectedResponse);
+        };
+        info!("hit local cache response");
+
+        // Send the download peer started request.
+        in_stream_tx
+            .send_timeout(
+                AnnouncePeerRequest {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    request: Some(announce_peer_request::Request::DownloadPeerStartedRequest(
+                        DownloadPeerStartedRequest {},
+                    )),
+                },
+                REQUEST_TIMEOUT,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("send DownloadPeerStartedRequest failed: {:?}", err);
+            })?;
+        debug!("sent DownloadPeerStartedRequest");
+
+        // Send the download peer finished request.
+        in_stream_tx
+            .send_timeout(
+                AnnouncePeerRequest {
+                    host_id: host_id.to_string(),
+                    task_id: task_id.to_string(),
+                    peer_id: peer_id.to_string(),
+                    request: Some(announce_peer_request::Request::DownloadPeerFinishedRequest(
+                        DownloadPeerFinishedRequest {},
+                    )),
+                },
+                REQUEST_TIMEOUT,
+            )
+            .await
+            .inspect_err(|err| {
+                error!("send DownloadPeerFinishedRequest failed: {:?}", err);
+            })?;
+        debug!("sent DownloadPeerFinishedRequest");
+
+        // Wait for the latest message to be sent.
+        in_stream_tx.closed().await;
+        Ok(())
     }
 
     /// Downloads a partial task with scheduler from a parent.

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -994,10 +994,10 @@ impl Task {
                     in_stream_tx.closed().await;
                     return Ok(finished_pieces);
                 }
-                announce_peer_response::Response::HitLocalCacheResponse(_) => {
-                    // HitLocalCacheResponse is only sent when the register request has the
-                    // hit_local_cache flag, which is not set in this flow.
-                    error!("receive unexpected HitLocalCacheResponse");
+                announce_peer_response::Response::MetadataOnlyResponse(_) => {
+                    // MetadataOnlyResponse is only sent when the register request has the
+                    // metadata_only flag, which is not set in this flow.
+                    error!("receive unexpected MetadataOnlyResponse");
                     return Err(Error::UnexpectedResponse);
                 }
             }
@@ -1010,7 +1010,7 @@ impl Task {
 
     /// Announces a task that hits the local cache completely with the scheduler. It only
     /// reports the metadata of the peer to the scheduler by the register request with the
-    /// hit_local_cache flag and the download peer started/finished requests, no pieces need
+    /// metadata_only flag and the download peer started/finished requests, no pieces need
     /// to be downloaded.
     #[instrument(level = "debug", skip_all)]
     async fn download_partial_with_scheduler_from_local(
@@ -1023,10 +1023,10 @@ impl Task {
         // Get the id of the task.
         let task_id = task.id.as_str();
 
-        // Set the hit_local_cache flag, so the scheduler only needs the metadata report
+        // Set the metadata_only flag, so the scheduler only needs the metadata report
         // and does not schedule the peer for downloading pieces.
         let request = Download {
-            hit_local_cache: true,
+            metadata_only: true,
             need_back_to_source: false,
             ..request
         };
@@ -1086,7 +1086,7 @@ impl Task {
             })?;
 
         let response = message?.response.ok_or(Error::UnexpectedResponse)?;
-        let announce_peer_response::Response::HitLocalCacheResponse(_) = response else {
+        let announce_peer_response::Response::MetadataOnlyResponse(_) = response else {
             error!("receive unexpected response: {:?}", response);
             return Err(Error::UnexpectedResponse);
         };

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1011,8 +1011,7 @@ impl Task {
     /// Announces a task that hits the local cache completely with the scheduler. It only
     /// reports the metadata of the peer to the scheduler by the register request with the
     /// hit_local_cache flag and the download peer started/finished requests, no pieces need
-    /// to be downloaded. The scheduler registers the peer and can schedule it as a candidate
-    /// parent for other peers.
+    /// to be downloaded.
     #[instrument(level = "debug", skip_all)]
     async fn download_partial_with_scheduler_from_local(
         &self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a mechanism to ensure that peers are always announced to the scheduler, even when a download task is fully satisfied by the local cache. This helps maintain accurate peer and task metadata in the scheduler, improving system coordination. The update also adds a new method for this announcement, modifies the download flow to use it, and updates related types and debug output.

**Scheduler Announcement Improvements:**
* Added a new method `download_and_ensure_announcement` to the `Task` struct, which always announces the peer to the scheduler even if the download is a local cache hit. This method first checks if the task is finished and, if so, uses a new flow to announce the peer without downloading any pieces. [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R550-R579) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R1011-R1137)
* Implemented `download_partial_with_scheduler_from_local`, which sends the appropriate register, started, and finished peer requests to the scheduler when all pieces are served from the local cache. This method ensures the scheduler is aware of the peer's state even without network downloads.

**API and Flow Changes:**
* Updated the `DfdaemonUpload` handler to use the new `download_and_ensure_announcement` method instead of the previous `download` method, ensuring the new announcement logic is used throughout the upload flow.
* Set the `hit_local_cache` flag in download requests where appropriate, and handled unexpected `HitLocalCacheResponse` messages for robustness. [[1]](diffhunk://#diff-e777585743ced60ee982e1cfa97f5a7f2e344f649494261fab3e7b4b19c1760dR1111) [[2]](diffhunk://#diff-6421011d65f9faa2a693ea46e321cc00e07b77ef8792a1b795d1db98d9e5ec4cR1278) [[3]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5R997-R1002)

**Type and Debug Output Updates:**
* Added the `hit_local_cache` field to the `Download` type and included it in the `Debug` implementation for `RedactedDownload`, improving observability and debugging. [[1]](diffhunk://#diff-922c000c86268e731af2295b52f9c40f06fe484d1a4c7249e9ba82edd0370966R92) [[2]](diffhunk://#diff-922c000c86268e731af2295b52f9c40f06fe484d1a4c7249e9ba82edd0370966R136)

**Dependency Update:**
* Bumped the `dragonfly-api` crate version from `2.2.31` to `2.2.32` in `Cargo.toml` to ensure compatibility with the latest API changes.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/dragonflyoss/dragonfly/issues/4880
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
