### PR TITLE
Implement PieceNotifier and improve download scheduling logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ scripts/certs
 
 # Ignore .vscode folder
 .vscode
+
+# Cloud files
+.claude
+.claude-analysis

--- a/dragonfly-client-backend/src/hdfs.rs
+++ b/dragonfly-client-backend/src/hdfs.rs
@@ -114,7 +114,7 @@ impl Backend for Hdfs {
     }
 
     /// Stat the metadata from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> ClientResult<StatResponse> {
         debug!(
             "stat request {} {}: {:?}",
@@ -197,7 +197,7 @@ impl Backend for Hdfs {
     }
 
     /// Get the content from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> ClientResult<GetResponse<Body>> {
         debug!(
             "get request {} {}: {:?}",
@@ -269,13 +269,13 @@ impl Backend for Hdfs {
     }
 
     /// Put the content to the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn put(&self, _request: PutRequest) -> ClientResult<PutResponse> {
         unimplemented!()
     }
 
     /// Exists checks whether the file exists in the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> ClientResult<bool> {
         debug!(
             "exist request {} {}: {:?}",

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -75,7 +75,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tokio_util::io::StreamReader;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, instrument};
 use url::Url;
 
 /// The HTTP scheme.
@@ -382,7 +382,7 @@ impl Backend for HTTP {
     }
 
     /// Stat the metadata from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
         debug!(
             "stat request {} {}: {:?}",
@@ -655,7 +655,7 @@ impl Backend for HTTP {
     }
 
     /// Get the content from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
         debug!(
             "get request {} {} {}: {:?}",
@@ -802,7 +802,7 @@ impl Backend for HTTP {
     }
 
     /// Exists checks whether the file exists in the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> Result<bool> {
         debug!(
             "exists request {} {}: {:?}",
@@ -842,7 +842,7 @@ impl Backend for HTTP {
             Ok(response) if response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE => {
                 // For zero-byte files, some servers return 416 Range Not Satisfiable.
                 // Retry with a GET request without the Range header to retrieve headers.
-                info!(
+                debug!(
                     "exists request got 416 Range Not Satisfiable, retrying with HEAD {} {}",
                     request.task_id, request.url
                 );

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -52,7 +52,7 @@ use std::error::Error as _;
 use std::io::Error as IOError;
 use std::sync::Arc;
 use tokio_util::io::StreamReader;
-use tracing::{debug, error};
+use tracing::{debug, error, instrument};
 use url::Url;
 
 /// The URL scheme for Hugging Face backend.

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -359,6 +359,7 @@ impl Backend for HuggingFace {
     }
 
     /// Stat the metadata from the backend.
+    #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
         debug!(
             "stat request {} {}: {:?}",
@@ -569,6 +570,7 @@ impl Backend for HuggingFace {
     }
 
     /// Get the content from the backend.
+    #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
         debug!(
             "get request {} {} {}: {:?}",
@@ -670,6 +672,7 @@ impl Backend for HuggingFace {
     }
 
     /// Exists checks whether the file exists in the backend.
+    #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> Result<bool> {
         debug!(
             "exists request {} {}: {:?}",

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -335,6 +335,7 @@ impl Backend for ModelScope {
     }
 
     /// Stat the metadata from the backend.
+    #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
         debug!(
             "stat request {} {}: {:?}",
@@ -545,7 +546,9 @@ impl Backend for ModelScope {
             }
         }
     }
+
     /// Get the content from the backend.
+    #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
         debug!(
             "get request {} {} {}: {:?}",
@@ -637,11 +640,13 @@ impl Backend for ModelScope {
     }
 
     /// Put the content to the backend.
+    #[instrument(skip_all)]
     async fn put(&self, _request: PutRequest) -> Result<PutResponse> {
         unimplemented!()
     }
 
     /// Exists checks whether the file exists in the backend.
+    #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> Result<bool> {
         debug!(
             "exists request {} {}: {:?}",

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -52,7 +52,7 @@ use std::error::Error as _;
 use std::io::Error as IOError;
 use std::sync::Arc;
 use tokio_util::io::StreamReader;
-use tracing::{debug, error};
+use tracing::{debug, error, instrument};
 use url::Url;
 
 /// The URL scheme for ModelScope backend.

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -608,7 +608,7 @@ impl crate::Backend for ObjectStorage {
     }
 
     /// Stat the metadata from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> ClientResult<StatResponse> {
         debug!(
             "stat request {} {}: {:?}",
@@ -695,7 +695,7 @@ impl crate::Backend for ObjectStorage {
     }
 
     /// Get the content from the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> ClientResult<GetResponse<Body>> {
         debug!(
             "get request {} {}: {:?}",
@@ -773,7 +773,7 @@ impl crate::Backend for ObjectStorage {
     }
 
     /// Put the content to the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn put(&self, request: PutRequest) -> ClientResult<PutResponse> {
         debug!("put request {:?} {}", request.path, request.url);
 
@@ -875,7 +875,7 @@ impl crate::Backend for ObjectStorage {
     }
 
     /// Exists checks whether the file exists in the backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> ClientResult<bool> {
         debug!(
             "exists request {} {}: {:?}",

--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -640,6 +640,7 @@ pub fn collect_upload_task_started_metrics(typ: i32, tag: &str, app: &str) {
 }
 
 /// Collects the upload task finished metrics.
+#[instrument(skip_all)]
 pub fn collect_upload_task_finished_metrics(
     typ: i32,
     tag: &str,
@@ -650,7 +651,7 @@ pub fn collect_upload_task_finished_metrics(
     let task_size = TaskSize::calculate_size_level(content_length);
 
     // Collect the slow upload Level1 task for analysis.
-    if task_size == TaskSize::Level1 && cost > UPLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
+    if task_size == TaskSize::Level2 && cost > UPLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
         warn!(
             "upload task, cost: {:?}, size: {} bytes",
             cost, content_length,
@@ -696,6 +697,7 @@ pub fn collect_download_task_started_metrics(typ: i32, tag: &str, app: &str, pri
 }
 
 /// Collects the download task finished metrics.
+#[instrument(skip_all)]
 pub fn collect_download_task_finished_metrics(
     typ: i32,
     tag: &str,
@@ -714,8 +716,8 @@ pub fn collect_download_task_finished_metrics(
 
     // Nydus will request the small range of the file, so the download task duration
     // should be short. Collect the slow download Level1 task for analysis.
-    if task_size == TaskSize::Level1 && cost > DOWNLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
-        warn!("download task, cost: {:?}, size: {} bytes", cost, size,);
+    if task_size == TaskSize::Level2 && cost > DOWNLOAD_TASK_LEVEL1_DURATION_THRESHOLD {
+        warn!("download task, cost: {:?}, size: {} bytes", cost, size);
     }
 
     let typ = typ.to_string();

--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -59,7 +59,7 @@ impl QUICClient {
     ///
     /// This is the main entry point for downloading a piece. It applies
     /// a timeout based on the configuration and handles connection timeouts gracefully.
-    #[instrument(level = "debug", skip_all, fields(parent_addr))]
+    #[instrument(skip_all, fields(parent_addr))]
     pub async fn download_piece(
         &self,
         number: u32,
@@ -83,7 +83,7 @@ impl QUICClient {
     /// 2. Establishes QUIC connection and sends the request.
     /// 3. Reads and validates the response header.
     /// 4. Processes the piece content based on the response type.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_piece(
         &self,
         number: u32,
@@ -117,7 +117,7 @@ impl QUICClient {
     /// Downloads a persistent piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_piece(
         &self,
         number: u32,
@@ -137,7 +137,7 @@ impl QUICClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent specific request/response types.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_persistent_piece(
         &self,
         number: u32,
@@ -174,7 +174,7 @@ impl QUICClient {
     /// Downloads a persistent cache piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent cache piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_cache_piece(
         &self,
         number: u32,
@@ -194,7 +194,7 @@ impl QUICClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent cache specific request/response types.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_persistent_cache_piece(
         &self,
         number: u32,
@@ -230,7 +230,7 @@ impl QUICClient {
     /// This is a low-level utility function that handles the QUIC connection
     /// lifecycle and request transmission. It ensures proper error handling
     /// and connection cleanup.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn connect_and_write_request(
         &self,
         request: Bytes,
@@ -292,7 +292,7 @@ impl QUICClient {
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_header(&self, reader: &mut RecvStream) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
@@ -310,7 +310,7 @@ impl QUICClient {
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_piece_content<T>(
         &self,
         reader: &mut RecvStream,
@@ -347,7 +347,7 @@ impl QUICClient {
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_error(&self, reader: &mut RecvStream, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -54,7 +54,7 @@ impl TCPClient {
     ///
     /// This is the main entry point for downloading a piece. It applies
     /// a timeout based on the configuration and handles connection timeouts gracefully.
-    #[instrument(level = "debug", skip_all, fields(parent_addr))]
+    #[instrument(skip_all, fields(parent_addr))]
     pub async fn download_piece(
         &self,
         number: u32,
@@ -78,7 +78,7 @@ impl TCPClient {
     /// 2. Establishes TCP connection and sends the request.
     /// 3. Reads and validates the response header.
     /// 4. Processes the piece content based on the response type.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_piece(
         &self,
         number: u32,
@@ -113,7 +113,7 @@ impl TCPClient {
     /// Downloads a persistent piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_piece(
         &self,
         number: u32,
@@ -133,7 +133,7 @@ impl TCPClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent specific request/response types.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_persistent_piece(
         &self,
         number: u32,
@@ -171,7 +171,7 @@ impl TCPClient {
     /// Downloads a persistent cache piece from the server using the vortex protocol.
     ///
     /// Similar to `download_piece` but specifically for persistent cache piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_cache_piece(
         &self,
         number: u32,
@@ -191,7 +191,7 @@ impl TCPClient {
     ///
     /// Implements the same protocol flow as `handle_download_piece` but uses
     /// persistent cache specific request/response types.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_download_persistent_cache_piece(
         &self,
         number: u32,
@@ -231,7 +231,7 @@ impl TCPClient {
     /// This is a low-level utility function that handles the TCP connection
     /// lifecycle and request transmission. It ensures proper error handling
     /// and connection cleanup.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn connect_and_write_request(
         &self,
         request: Bytes,
@@ -285,7 +285,7 @@ impl TCPClient {
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_header(&self, reader: &mut OwnedReadHalf) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
@@ -304,7 +304,7 @@ impl TCPClient {
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_piece_content<T>(
         &self,
         reader: &mut OwnedReadHalf,
@@ -343,7 +343,7 @@ impl TCPClient {
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn read_error(&self, reader: &mut OwnedReadHalf, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -226,7 +226,7 @@ impl Content {
     }
 
     /// Copies the task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
         fs::copy(self.get_task_path(task_id), to).await?;
         info!("copy to {:?} success", to);

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -49,9 +49,6 @@ pub mod metadata;
 pub mod server;
 pub mod storage_engine;
 
-/// The default interval for waiting for the piece to be finished.
-pub const DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL: Duration = Duration::from_millis(100);
-
 /// The fallback interval for re-checking the piece metadata while waiting for an
 /// in-flight piece completion notification, guarding against missed notifications
 /// (e.g. the piece metadata is deleted outside the download flow).

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -20,7 +20,7 @@ use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::digest::{Algorithm, Digest};
-use piece_notifier::PieceNotifier;
+use piece_notifier::{Claim, PieceNotifier};
 use reqwest::header::HeaderMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -729,15 +729,44 @@ impl Storage {
         piece_id: &str,
         number: u32,
     ) -> Result<metadata::Piece> {
-        // Wait for the piece to be finished.
-        match self.wait_for_piece_finished(piece_id).await {
-            Ok(piece) => Ok(piece),
-            // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => {
-                self.piece_notifier.register(piece_id);
-                self.metadata
-                    .download_piece_started(piece_id, number)
-                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+        loop {
+            // Wait for the piece to be finished.
+            match self.wait_for_piece_finished(piece_id).await {
+                Ok(piece) => return Ok(piece),
+                // If piece is not found or wait timeout, claim the download. Exactly
+                // one of the concurrent claimers becomes the downloader, so the same
+                // piece is never downloaded from source or parent twice.
+                Err(_) => match self.piece_notifier.claim(piece_id) {
+                    Claim::Owner => {
+                        match self
+                            .get_piece(piece_id)
+                            .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))?
+                        {
+                            Some(piece) if piece.is_finished() => {
+                                self.piece_notifier.remove_and_notify(piece_id);
+                                return Ok(piece);
+                            }
+                            _ => {
+                                return self
+                                    .metadata
+                                    .download_piece_started(piece_id, number)
+                                    .inspect_err(|_| {
+                                        self.piece_notifier.remove_and_notify(piece_id)
+                                    })
+                            }
+                        }
+                    }
+                    Claim::InFlight(notifier) => {
+                        let notified = notifier.notified();
+                        tokio::pin!(notified);
+                        notified.as_mut().enable();
+
+                        tokio::select! {
+                            _ = notified => {}
+                            _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        }
+                    }
+                },
             }
         }
     }
@@ -942,15 +971,44 @@ impl Storage {
         piece_id: &str,
         number: u32,
     ) -> Result<metadata::Piece> {
-        // Wait for the piece to be finished.
-        match self.wait_for_persistent_piece_finished(piece_id).await {
-            Ok(piece) => Ok(piece),
-            // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => {
-                self.piece_notifier.register(piece_id);
-                self.metadata
-                    .download_piece_started(piece_id, number)
-                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+        loop {
+            // Wait for the piece to be finished.
+            match self.wait_for_persistent_piece_finished(piece_id).await {
+                Ok(piece) => return Ok(piece),
+                // If piece is not found or wait timeout, claim the download. Exactly
+                // one of the concurrent claimers becomes the downloader, so the same
+                // piece is never downloaded from source or parent twice.
+                Err(_) => match self.piece_notifier.claim(piece_id) {
+                    Claim::Owner => {
+                        match self
+                            .get_persistent_piece(piece_id)
+                            .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))?
+                        {
+                            Some(piece) if piece.is_finished() => {
+                                self.piece_notifier.remove_and_notify(piece_id);
+                                return Ok(piece);
+                            }
+                            _ => {
+                                return self
+                                    .metadata
+                                    .download_piece_started(piece_id, number)
+                                    .inspect_err(|_| {
+                                        self.piece_notifier.remove_and_notify(piece_id)
+                                    })
+                            }
+                        }
+                    }
+                    Claim::InFlight(notifier) => {
+                        let notified = notifier.notified();
+                        tokio::pin!(notified);
+                        notified.as_mut().enable();
+
+                        tokio::select! {
+                            _ = notified => {}
+                            _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        }
+                    }
+                },
             }
         }
     }
@@ -1124,18 +1182,47 @@ impl Storage {
         piece_id: &str,
         number: u32,
     ) -> Result<metadata::Piece> {
-        // Wait for the piece to be finished.
-        match self
-            .wait_for_persistent_cache_piece_finished(piece_id)
-            .await
-        {
-            Ok(piece) => Ok(piece),
-            // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => {
-                self.piece_notifier.register(piece_id);
-                self.metadata
-                    .download_piece_started(piece_id, number)
-                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+        loop {
+            // Wait for the piece to be finished.
+            match self
+                .wait_for_persistent_cache_piece_finished(piece_id)
+                .await
+            {
+                Ok(piece) => return Ok(piece),
+                // If piece is not found or wait timeout, claim the download. Exactly
+                // one of the concurrent claimers becomes the downloader, so the same
+                // piece is never downloaded from source or parent twice.
+                Err(_) => match self.piece_notifier.claim(piece_id) {
+                    Claim::Owner => {
+                        match self
+                            .get_persistent_cache_piece(piece_id)
+                            .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))?
+                        {
+                            Some(piece) if piece.is_finished() => {
+                                self.piece_notifier.remove_and_notify(piece_id);
+                                return Ok(piece);
+                            }
+                            _ => {
+                                return self
+                                    .metadata
+                                    .download_piece_started(piece_id, number)
+                                    .inspect_err(|_| {
+                                        self.piece_notifier.remove_and_notify(piece_id)
+                                    })
+                            }
+                        }
+                    }
+                    Claim::InFlight(notifier) => {
+                        let notified = notifier.notified();
+                        tokio::pin!(notified);
+                        notified.as_mut().enable();
+
+                        tokio::select! {
+                            _ = notified => {}
+                            _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        }
+                    }
+                },
             }
         }
     }
@@ -1500,15 +1587,44 @@ impl Storage {
         piece_id: &str,
         number: u32,
     ) -> Result<metadata::Piece> {
-        // Wait for the piece to be finished.
-        match self.wait_for_cache_piece_finished(piece_id).await {
-            Ok(piece) => Ok(piece),
-            // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => {
-                self.piece_notifier.register(piece_id);
-                self.metadata
-                    .download_piece_started(piece_id, number)
-                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+        loop {
+            // Wait for the piece to be finished.
+            match self.wait_for_cache_piece_finished(piece_id).await {
+                Ok(piece) => return Ok(piece),
+                // If piece is not found or wait timeout, claim the download. Exactly
+                // one of the concurrent claimers becomes the downloader, so the same
+                // piece is never downloaded from source or parent twice.
+                Err(_) => match self.piece_notifier.claim(piece_id) {
+                    Claim::Owner => {
+                        match self
+                            .get_cache_piece(piece_id)
+                            .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))?
+                        {
+                            Some(piece) if piece.is_finished() => {
+                                self.piece_notifier.remove_and_notify(piece_id);
+                                return Ok(piece);
+                            }
+                            _ => {
+                                return self
+                                    .metadata
+                                    .download_piece_started(piece_id, number)
+                                    .inspect_err(|_| {
+                                        self.piece_notifier.remove_and_notify(piece_id)
+                                    })
+                            }
+                        }
+                    }
+                    Claim::InFlight(notifier) => {
+                        let notified = notifier.notified();
+                        tokio::pin!(notified);
+                        notified.as_mut().enable();
+
+                        tokio::select! {
+                            _ = notified => {}
+                            _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        }
+                    }
+                },
             }
         }
     }
@@ -1904,6 +2020,65 @@ mod tests {
             elapsed < Duration::from_millis(800),
             "waiter took {elapsed:?}, expected a notification-driven wake"
         );
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_download_piece_started_elects_single_downloader() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "f5add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14c";
+        const CONTENT: &[u8] = b"piece content";
+        storage
+            .download_task_started(TASK_ID, CONTENT.len() as u64, CONTENT.len() as u64, None)
+            .await
+            .unwrap();
+
+        let piece_id = storage.piece_id(TASK_ID, 0);
+        let mut claimers = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let storage = storage.clone();
+            let piece_id = piece_id.clone();
+            claimers.spawn(async move {
+                let piece = storage
+                    .download_piece_started(piece_id.as_str(), 0)
+                    .await
+                    .unwrap();
+                if piece.is_finished() {
+                    return false;
+                }
+
+                let mut reader = CONTENT;
+                storage
+                    .download_piece_from_source_finished(
+                        piece_id.as_str(),
+                        TASK_ID,
+                        0,
+                        CONTENT.len() as u64,
+                        &mut reader,
+                        Duration::from_secs(5),
+                    )
+                    .await
+                    .unwrap();
+                true
+            });
+        }
+
+        let downloaders = claimers
+            .join_all()
+            .await
+            .into_iter()
+            .filter(|downloader| *downloader)
+            .count();
+        assert_eq!(downloaders, 1, "expected exactly one downloader");
         assert!(storage
             .in_flight_piece_notifier(piece_id.as_str())
             .is_none());

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -2008,4 +2008,51 @@ mod tests {
         );
         assert!(storage.get_piece(piece_id.as_str()).unwrap().is_none());
     }
+
+    #[tokio::test]
+    async fn test_download_piece_failed_keeps_finished_piece_serving() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "b7add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14e";
+        const CONTENT: &[u8] = b"piece content";
+        storage
+            .download_task_started(TASK_ID, CONTENT.len() as u64, CONTENT.len() as u64, None)
+            .await
+            .unwrap();
+
+        // The winner downloads and finishes the piece.
+        let piece_id = storage.piece_id(TASK_ID, 0);
+        storage
+            .download_piece_started(piece_id.as_str(), 0)
+            .await
+            .unwrap();
+        let mut reader = CONTENT;
+        storage
+            .download_piece_from_source_finished(
+                piece_id.as_str(),
+                TASK_ID,
+                0,
+                CONTENT.len() as u64,
+                &mut reader,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        // A duplicate downloader failing afterwards must not erase the finished
+        // piece, and serving keeps working.
+        storage.download_piece_failed(piece_id.as_str()).unwrap();
+        let piece = storage.get_piece(piece_id.as_str()).unwrap().unwrap();
+        assert!(piece.is_finished());
+        storage
+            .upload_piece(piece_id.as_str(), TASK_ID, None)
+            .await
+            .unwrap();
+    }
 }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -16,11 +16,11 @@
 
 use bytes::BytesMut;
 use chrono::NaiveDateTime;
-use dashmap::DashMap;
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::digest::{Algorithm, Digest};
+use piece_notifier::PieceNotifier;
 use reqwest::header::HeaderMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -33,6 +33,8 @@ use tokio::{
 };
 use tokio_util::io::InspectReader;
 use tracing::{debug, error, info, instrument, warn};
+
+mod piece_notifier;
 
 #[cfg(target_os = "linux")]
 mod content_linux;
@@ -64,45 +66,6 @@ const DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL: Duration = Duration::fr
 /// hostPath mount point, which prevents hardlinks from being created across different
 /// quota contexts.
 pub const DEFAULT_TMP_DIR: &str = "tmp";
-
-/// PieceNotifier notifies the waiters when an in-flight piece download completes
-/// (finished, failed or its metadata deleted), so the waiters do not need to poll
-/// the piece metadata on an interval.
-///
-/// The notifier is registered just before the piece metadata is created when the
-/// piece download starts, and removed (waking all its waiters) when the download
-/// reaches a terminal state. The piece metadata remains the source of truth:
-/// waiters must re-check it after being notified.
-#[derive(Default)]
-struct PieceNotifier {
-    /// The notifiers of the in-flight pieces, keyed by the piece id.
-    notifiers: DashMap<String, Arc<Notify>>,
-}
-
-impl PieceNotifier {
-    /// Registers the notifier of the piece when its download starts. If the piece
-    /// is already registered by a concurrent download, the existing notifier is
-    /// kept.
-    fn register(&self, piece_id: &str) {
-        self.notifiers.entry(piece_id.to_string()).or_default();
-    }
-
-    /// Returns the notifier of the in-flight piece, or `None` if the piece is not
-    /// being downloaded by this process.
-    fn get(&self, piece_id: &str) -> Option<Arc<Notify>> {
-        self.notifiers
-            .get(piece_id)
-            .map(|notifier| notifier.value().clone())
-    }
-
-    /// Removes the notifier of the piece and wakes all its waiters when the piece
-    /// download completes.
-    fn remove_and_notify(&self, piece_id: &str) {
-        if let Some((_, notifier)) = self.notifiers.remove(piece_id) {
-            notifier.notify_waiters();
-        }
-    }
-}
 
 /// The storage of the task.
 pub struct Storage {
@@ -773,7 +736,12 @@ impl Storage {
         match self.wait_for_piece_finished(piece_id).await {
             Ok(piece) => Ok(piece),
             // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => self.metadata.download_piece_started(piece_id, number),
+            Err(_) => {
+                self.piece_notifier.register(piece_id);
+                self.metadata
+                    .download_piece_started(piece_id, number)
+                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+            }
         }
     }
 
@@ -789,14 +757,17 @@ impl Storage {
         reader: &mut R,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
-        tokio::select! {
+        let piece = tokio::select! {
             piece = self.handle_downloaded_from_source_finished(piece_id, task_id, offset, length, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
                 Err(Error::DownloadPieceFinishedTimeout(piece_id.to_string()))
             }
-        }
+        }?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     // handle_downloaded_from_source_finished handles the downloaded piece from source.
@@ -838,14 +809,17 @@ impl Storage {
         reader: &mut R,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
-        tokio::select! {
+        let piece = tokio::select! {
             piece = self.handle_downloaded_piece_from_parent_finished(piece_id, task_id, offset, length, expected_digest, parent_id, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
                 Err(Error::DownloadPieceFinishedTimeout(piece_id.to_string()))
             }
-        }
+        }?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     // handle_downloaded_piece_from_parent_finished handles the downloaded piece from parent.
@@ -894,7 +868,16 @@ impl Storage {
     /// Updates the metadata of the piece when the piece downloads failed.
     #[instrument(level = "debug", skip_all)]
     pub fn download_piece_failed(&self, piece_id: &str) -> Result<()> {
-        self.metadata.download_piece_failed(piece_id)
+        let result = self.metadata.download_piece_failed(piece_id);
+        self.piece_notifier.remove_and_notify(piece_id);
+        result
+    }
+
+    /// Returns the completion notifier of the in-flight piece, or `None` if the
+    /// piece is not being downloaded by this process. The piece metadata remains
+    /// the source of truth: re-check it after being notified.
+    pub fn in_flight_piece_notifier(&self, piece_id: &str) -> Option<Arc<Notify>> {
+        self.piece_notifier.get(piece_id)
     }
 
     /// Updates the metadata of the piece and
@@ -966,7 +949,12 @@ impl Storage {
         match self.wait_for_persistent_piece_finished(piece_id).await {
             Ok(piece) => Ok(piece),
             // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => self.metadata.download_piece_started(piece_id, number),
+            Err(_) => {
+                self.piece_notifier.register(piece_id);
+                self.metadata
+                    .download_piece_started(piece_id, number)
+                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+            }
         }
     }
 
@@ -1004,13 +992,16 @@ impl Storage {
             ));
         }
 
-        self.metadata.download_piece_finished(
+        let piece = self.metadata.download_piece_finished(
             piece_id,
             offset,
             length,
             digest.to_string().as_str(),
             Some(parent_id.to_string()),
-        )
+        )?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     /// Used for downloading piece from source.
@@ -1025,14 +1016,17 @@ impl Storage {
         reader: &mut R,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
-        tokio::select! {
+        let piece = tokio::select! {
             piece = self.handle_persistent_downloaded_from_source_finished(piece_id, task_id, offset, length, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
                 Err(Error::DownloadPieceFinishedTimeout(piece_id.to_string()))
             }
-        }
+        }?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     // handle_persistent_downloaded_from_source_finished handles the downloaded persistent piece from source.
@@ -1063,7 +1057,9 @@ impl Storage {
     /// Updates the metadata of the persistent piece when the persistent piece downloads failed.
     #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_piece_failed(&self, piece_id: &str) -> Result<()> {
-        self.metadata.download_piece_failed(piece_id)
+        let result = self.metadata.download_piece_failed(piece_id);
+        self.piece_notifier.remove_and_notify(piece_id);
+        result
     }
 
     /// Updates the metadata of the piece and_then
@@ -1138,7 +1134,12 @@ impl Storage {
         {
             Ok(piece) => Ok(piece),
             // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => self.metadata.download_piece_started(piece_id, number),
+            Err(_) => {
+                self.piece_notifier.register(piece_id);
+                self.metadata
+                    .download_piece_started(piece_id, number)
+                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+            }
         }
     }
 
@@ -1178,19 +1179,24 @@ impl Storage {
             ));
         }
 
-        self.metadata.download_piece_finished(
+        let piece = self.metadata.download_piece_finished(
             piece_id,
             offset,
             length,
             digest.to_string().as_str(),
             Some(parent_id.to_string()),
-        )
+        )?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     /// Updates the metadata of the persistent cache piece when the persistent cache piece downloads failed.
     #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_cache_piece_failed(&self, piece_id: &str) -> Result<()> {
-        self.metadata.download_piece_failed(piece_id)
+        let result = self.metadata.download_piece_failed(piece_id);
+        self.piece_notifier.remove_and_notify(piece_id);
+        result
     }
 
     /// Updates the metadata of the piece and_then
@@ -1255,8 +1261,6 @@ impl Storage {
     /// Waits for the piece to be finished.
     #[instrument(level = "debug", skip_all)]
     async fn wait_for_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
-        // Fast path: the piece is usually already finished when the upload
-        // starts, so check once before setting up the timers.
         let piece = self
             .get_piece(piece_id)?
             .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
@@ -1265,29 +1269,68 @@ impl Storage {
             return Ok(piece);
         }
 
-        // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
         );
         tokio::pin!(wait_timeout);
 
-        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
         loop {
-            tokio::select! {
-                _ = interval.tick() => {
+            match self.piece_notifier.get(piece_id) {
+                Some(notifier) => {
+                    let notified = notifier.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+
                     let piece = self
                         .get_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
-                    // If the piece is finished, return.
                     if piece.is_finished() {
                         debug!("wait piece finished success");
                         return Ok(piece);
                     }
+
+                    tokio::select! {
+                        _ = notified => {}
+                        _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        _ = &mut wait_timeout => {
+                            self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                            self.piece_notifier.remove_and_notify(piece_id);
+                            return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                        }
+                    }
                 }
-                _ = &mut wait_timeout => {
-                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
-                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                None => {
+                    let piece = self
+                        .get_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    let piece = self
+                        .get_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    self.metadata
+                        .wait_for_piece_finished_failed(piece_id)
+                        .unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::PieceNotFound(piece_id.to_string()));
                 }
             }
         }
@@ -1296,8 +1339,6 @@ impl Storage {
     /// Waits for the persistent piece to be finished.
     #[instrument(level = "debug", skip_all)]
     async fn wait_for_persistent_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
-        // Fast path: the piece is usually already finished when the upload
-        // starts, so check once before setting up the timers.
         let piece = self
             .get_persistent_piece(piece_id)?
             .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
@@ -1306,29 +1347,68 @@ impl Storage {
             return Ok(piece);
         }
 
-        // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
         );
         tokio::pin!(wait_timeout);
 
-        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
         loop {
-            tokio::select! {
-                _ = interval.tick() => {
+            match self.piece_notifier.get(piece_id) {
+                Some(notifier) => {
+                    let notified = notifier.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+
                     let piece = self
                         .get_persistent_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
-                    // If the piece is finished, return.
                     if piece.is_finished() {
                         debug!("wait piece finished success");
                         return Ok(piece);
                     }
+
+                    tokio::select! {
+                        _ = notified => {}
+                        _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        _ = &mut wait_timeout => {
+                            self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                            self.piece_notifier.remove_and_notify(piece_id);
+                            return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                        }
+                    }
                 }
-                _ = &mut wait_timeout => {
-                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
-                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                None => {
+                    let piece = self
+                        .get_persistent_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    let piece = self
+                        .get_persistent_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    self.metadata
+                        .wait_for_piece_finished_failed(piece_id)
+                        .unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::PieceNotFound(piece_id.to_string()));
                 }
             }
         }
@@ -1340,8 +1420,6 @@ impl Storage {
         &self,
         piece_id: &str,
     ) -> Result<metadata::Piece> {
-        // Fast path: the piece is usually already finished when the upload
-        // starts, so check once before setting up the timers.
         let piece = self
             .get_persistent_cache_piece(piece_id)?
             .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
@@ -1350,29 +1428,68 @@ impl Storage {
             return Ok(piece);
         }
 
-        // Total timeout for downloading a piece, combining the download time and the time to write to storage.
         let wait_timeout = tokio::time::sleep(
             self.config.download.piece_timeout + self.config.storage.write_piece_timeout,
         );
         tokio::pin!(wait_timeout);
 
-        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
         loop {
-            tokio::select! {
-                _ = interval.tick() => {
+            match self.piece_notifier.get(piece_id) {
+                Some(notifier) => {
+                    let notified = notifier.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+
                     let piece = self
                         .get_persistent_cache_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
-                    // If the piece is finished, return.
                     if piece.is_finished() {
                         debug!("wait piece finished success");
                         return Ok(piece);
                     }
+
+                    tokio::select! {
+                        _ = notified => {}
+                        _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        _ = &mut wait_timeout => {
+                            self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                            self.piece_notifier.remove_and_notify(piece_id);
+                            return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                        }
+                    }
                 }
-                _ = &mut wait_timeout => {
-                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
-                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                None => {
+                    let piece = self
+                        .get_persistent_cache_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    let piece = self
+                        .get_persistent_cache_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    self.metadata
+                        .wait_for_piece_finished_failed(piece_id)
+                        .unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::PieceNotFound(piece_id.to_string()));
                 }
             }
         }
@@ -1628,5 +1745,223 @@ impl Storage {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_wait_for_piece_finished_wakes_on_notification() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "d3add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14a";
+        const CONTENT: &[u8] = b"piece content";
+        storage
+            .download_task_started(TASK_ID, CONTENT.len() as u64, CONTENT.len() as u64, None)
+            .await
+            .unwrap();
+
+        let piece_id = storage.piece_id(TASK_ID, 0);
+        let piece = storage
+            .download_piece_started(piece_id.as_str(), 0)
+            .await
+            .unwrap();
+        assert!(!piece.is_finished());
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_some());
+
+        let storage_clone = storage.clone();
+        let piece_id_clone = piece_id.clone();
+        let waiter = tokio::spawn(async move {
+            let started_at = std::time::Instant::now();
+            storage_clone
+                .upload_piece(piece_id_clone.as_str(), TASK_ID, None)
+                .await
+                .unwrap();
+            started_at.elapsed()
+        });
+
+        sleep(Duration::from_millis(100)).await;
+        let mut reader = CONTENT;
+        storage
+            .download_piece_from_source_finished(
+                piece_id.as_str(),
+                TASK_ID,
+                0,
+                CONTENT.len() as u64,
+                &mut reader,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let elapsed = waiter.await.unwrap();
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "waiter took {elapsed:?}, expected a notification-driven wake"
+        );
+
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_download_piece_failed_wakes_waiters_with_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "e4add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14b";
+        storage
+            .download_task_started(TASK_ID, 1024, 1024, None)
+            .await
+            .unwrap();
+
+        let piece_id = storage.piece_id(TASK_ID, 0);
+        storage
+            .download_piece_started(piece_id.as_str(), 0)
+            .await
+            .unwrap();
+
+        let storage_clone = storage.clone();
+        let piece_id_clone = piece_id.clone();
+        let waiter = tokio::spawn(async move {
+            let started_at = std::time::Instant::now();
+            let result = storage_clone
+                .upload_piece(piece_id_clone.as_str(), TASK_ID, None)
+                .await;
+            (started_at.elapsed(), result)
+        });
+
+        sleep(Duration::from_millis(100)).await;
+        storage.download_piece_failed(piece_id.as_str()).unwrap();
+
+        let (elapsed, result) = waiter.await.unwrap();
+        assert!(result.is_err());
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "waiter took {elapsed:?}, expected a notification-driven wake"
+        );
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_persistent_piece_finished_wakes_on_notification() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "f5add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14c";
+        const CONTENT: &[u8] = b"piece content";
+        storage
+            .create_persistent_task(TASK_ID, CONTENT.len() as u64)
+            .await
+            .unwrap();
+
+        let piece_id = storage.persistent_piece_id(TASK_ID, 0);
+        let piece = storage
+            .download_persistent_piece_started(piece_id.as_str(), 0)
+            .await
+            .unwrap();
+        assert!(!piece.is_finished());
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_some());
+
+        let storage_clone = storage.clone();
+        let piece_id_clone = piece_id.clone();
+        let waiter = tokio::spawn(async move {
+            let started_at = std::time::Instant::now();
+            let piece = storage_clone
+                .download_persistent_piece_started(piece_id_clone.as_str(), 0)
+                .await
+                .unwrap();
+            (started_at.elapsed(), piece)
+        });
+
+        sleep(Duration::from_millis(100)).await;
+        let mut reader = CONTENT;
+        storage
+            .download_persistent_piece_from_source_finished(
+                piece_id.as_str(),
+                TASK_ID,
+                0,
+                CONTENT.len() as u64,
+                &mut reader,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+        let (elapsed, piece) = waiter.await.unwrap();
+        assert!(piece.is_finished());
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "waiter took {elapsed:?}, expected a notification-driven wake"
+        );
+
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_piece_finished_fails_fast_on_stale_piece() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let storage = Arc::new(
+            Storage::new(config, dir.path(), dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        const TASK_ID: &str = "a6add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14d";
+        storage
+            .download_task_started(TASK_ID, 1024, 1024, None)
+            .await
+            .unwrap();
+
+        // Simulate unfinished piece metadata left over from a previous run:
+        // the metadata exists but no notifier is registered in this process.
+        let piece_id = storage.piece_id(TASK_ID, 0);
+        storage
+            .metadata
+            .download_piece_started(piece_id.as_str(), 0)
+            .unwrap();
+        assert!(storage
+            .in_flight_piece_notifier(piece_id.as_str())
+            .is_none());
+
+        // The waiter fails fast with PieceNotFound instead of polling until
+        // the wait timeout, and the stale metadata is cleaned up.
+        let started_at = std::time::Instant::now();
+        let result = storage.upload_piece(piece_id.as_str(), TASK_ID, None).await;
+        assert!(matches!(result, Err(Error::PieceNotFound(_))));
+        assert!(
+            started_at.elapsed() < Duration::from_millis(100),
+            "waiter took {:?}, expected an immediate fail-fast",
+            started_at.elapsed()
+        );
+        assert!(storage.get_piece(piece_id.as_str()).unwrap().is_none());
     }
 }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -238,7 +238,7 @@ impl Storage {
     }
 
     /// Copies the persistent task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_persistent_task(&self, id: &str, to: &Path) -> Result<()> {
         self.content.copy_persistent_task(id, to).await
     }
@@ -403,7 +403,7 @@ impl Storage {
     }
 
     /// Copies the persistent cache task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_persistent_cache_task(&self, id: &str, to: &Path) -> Result<()> {
         self.content.copy_persistent_cache_task(id, to).await
     }
@@ -726,7 +726,7 @@ impl Storage {
 
     /// Updates the metadata of the piece and writes
     /// the data of piece to file when the piece downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_piece_started(
         &self,
         piece_id: &str,
@@ -747,7 +747,7 @@ impl Storage {
 
     /// Used for downloading piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -771,7 +771,7 @@ impl Storage {
     }
 
     // handle_downloaded_from_source_finished handles the downloaded piece from source.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_downloaded_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -797,7 +797,7 @@ impl Storage {
 
     /// Used for downloading piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -824,7 +824,7 @@ impl Storage {
 
     // handle_downloaded_piece_from_parent_finished handles the downloaded piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_downloaded_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -882,7 +882,7 @@ impl Storage {
 
     /// Updates the metadata of the piece and
     /// returns the data of the piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload_piece(
         &self,
         piece_id: &str,
@@ -939,7 +939,7 @@ impl Storage {
 
     /// Updates the metadata of the persistent piece and writes
     /// the data of piece to file when the persistent piece downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_piece_started(
         &self,
         piece_id: &str,
@@ -960,7 +960,7 @@ impl Storage {
 
     /// Used for downloading persistent piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1006,7 +1006,7 @@ impl Storage {
 
     /// Used for downloading piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1030,7 +1030,7 @@ impl Storage {
     }
 
     // handle_persistent_downloaded_from_source_finished handles the downloaded persistent piece from source.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_persistent_downloaded_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1064,7 +1064,7 @@ impl Storage {
 
     /// Updates the metadata of the piece and_then
     /// returns the data of the piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload_persistent_piece(
         &self,
         piece_id: &str,
@@ -1121,7 +1121,7 @@ impl Storage {
 
     /// Updates the metadata of the persistent cache piece and writes
     /// the data of piece to file when the persistent cache piece downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_cache_piece_started(
         &self,
         piece_id: &str,
@@ -1145,7 +1145,7 @@ impl Storage {
 
     /// Used for downloading persistent cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_persistent_cache_piece_from_parent_finished<
         R: AsyncRead + Unpin + ?Sized,
     >(
@@ -1201,7 +1201,7 @@ impl Storage {
 
     /// Updates the metadata of the piece and_then
     /// returns the data of the piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -1259,7 +1259,7 @@ impl Storage {
     }
 
     /// Waits for the piece to be finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn wait_for_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
         let piece = self
             .get_piece(piece_id)?
@@ -1337,7 +1337,7 @@ impl Storage {
     }
 
     /// Waits for the persistent piece to be finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn wait_for_persistent_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
         let piece = self
             .get_persistent_piece(piece_id)?
@@ -1415,7 +1415,7 @@ impl Storage {
     }
 
     /// Waits for the persistent cache piece to be finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn wait_for_persistent_cache_piece_finished(
         &self,
         piece_id: &str,
@@ -1497,7 +1497,7 @@ impl Storage {
 
     /// Updates the metadata of the cache piece and writes
     /// the data of cache piece to file when the cache piece downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_cache_piece_started(
         &self,
         piece_id: &str,
@@ -1507,13 +1507,18 @@ impl Storage {
         match self.wait_for_cache_piece_finished(piece_id).await {
             Ok(piece) => Ok(piece),
             // If piece is not found or wait timeout, create piece metadata.
-            Err(_) => self.metadata.download_piece_started(piece_id, number),
+            Err(_) => {
+                self.piece_notifier.register(piece_id);
+                self.metadata
+                    .download_piece_started(piece_id, number)
+                    .inspect_err(|_| self.piece_notifier.remove_and_notify(piece_id))
+            }
         }
     }
 
     /// Used for downloading cache piece from source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1523,18 +1528,21 @@ impl Storage {
         reader: &mut R,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
-        tokio::select! {
+        let piece = tokio::select! {
             piece = self.handle_downloaded_cache_piece_from_source_finished(piece_id, task_id, offset, length, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
                 Err(Error::DownloadPieceFinishedTimeout(piece_id.to_string()))
             }
-        }
+        }?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     // handle_downloaded_cache_piece_from_source_finished handles the downloaded cache piece from source.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_downloaded_cache_piece_from_source_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1569,7 +1577,7 @@ impl Storage {
 
     /// Used for downloading cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1581,19 +1589,22 @@ impl Storage {
         reader: &mut R,
         timeout: Duration,
     ) -> Result<metadata::Piece> {
-        tokio::select! {
+        let piece = tokio::select! {
             piece = self.handle_downloaded_cache_piece_from_parent_finished(piece_id, task_id, offset, length, expected_digest, parent_id, reader) => {
                 piece
             }
             _ = sleep(timeout) => {
                 Err(Error::DownloadPieceFinishedTimeout(piece_id.to_string()))
             }
-        }
+        }?;
+
+        self.piece_notifier.remove_and_notify(piece_id);
+        Ok(piece)
     }
 
     // handle_downloaded_cache_piece_from_parent_finished handles the downloaded cache piece from parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_downloaded_cache_piece_from_parent_finished<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -1644,12 +1655,14 @@ impl Storage {
     /// Updates the metadata of the cache piece when the cache piece downloads failed.
     #[instrument(level = "debug", skip_all)]
     pub fn download_cache_piece_failed(&self, piece_id: &str) -> Result<()> {
-        self.metadata.download_piece_failed(piece_id)
+        let result = self.metadata.download_piece_failed(piece_id);
+        self.piece_notifier.remove_and_notify(piece_id);
+        result
     }
 
     /// Updates the metadata of the piece and
     /// returns the data of the piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload_cache_piece(
         &self,
         piece_id: &str,
@@ -1708,10 +1721,8 @@ impl Storage {
     }
 
     /// Waits for the cache piece to be finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn wait_for_cache_piece_finished(&self, piece_id: &str) -> Result<metadata::Piece> {
-        // Fast path: the piece is usually already finished when the upload
-        // starts, so check once before setting up the timers.
         let piece = self
             .get_cache_piece(piece_id)?
             .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
@@ -1725,23 +1736,63 @@ impl Storage {
         );
         tokio::pin!(wait_timeout);
 
-        let mut interval = tokio::time::interval(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL);
         loop {
-            tokio::select! {
-                _ = interval.tick() => {
+            match self.piece_notifier.get(piece_id) {
+                Some(notifier) => {
+                    let notified = notifier.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+
                     let piece = self
                         .get_cache_piece(piece_id)?
                         .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
 
-                    // If the piece is finished, return.
                     if piece.is_finished() {
                         debug!("wait piece finished success");
                         return Ok(piece);
                     }
+
+                    tokio::select! {
+                        _ = notified => {}
+                        _ = sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL) => {}
+                        _ = &mut wait_timeout => {
+                            self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                            self.piece_notifier.remove_and_notify(piece_id);
+                            return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                        }
+                    }
                 }
-                _ = &mut wait_timeout => {
-                    self.metadata.wait_for_piece_finished_failed(piece_id).unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
-                    return Err(Error::WaitForPieceFinishedTimeout(piece_id.to_string()));
+                None => {
+                    let piece = self
+                        .get_cache_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    let piece = self
+                        .get_cache_piece(piece_id)?
+                        .ok_or_else(|| Error::PieceNotFound(piece_id.to_string()))?;
+
+                    if piece.is_finished() {
+                        debug!("wait piece finished success");
+                        return Ok(piece);
+                    }
+
+                    if self.piece_notifier.get(piece_id).is_some() {
+                        continue;
+                    }
+
+                    self.metadata
+                        .wait_for_piece_finished_failed(piece_id)
+                        .unwrap_or_else(|err| error!("delete piece metadata failed: {}", err));
+                    return Err(Error::PieceNotFound(piece_id.to_string()));
                 }
             }
         }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -16,6 +16,7 @@
 
 use bytes::BytesMut;
 use chrono::NaiveDateTime;
+use dashmap::DashMap;
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
@@ -27,6 +28,7 @@ use std::time::Duration;
 use tokio::{
     fs,
     io::{AsyncBufRead, AsyncRead, AsyncReadExt},
+    sync::Notify,
     time::sleep,
 };
 use tokio_util::io::InspectReader;
@@ -48,6 +50,11 @@ pub mod storage_engine;
 /// The default interval for waiting for the piece to be finished.
 pub const DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL: Duration = Duration::from_millis(100);
 
+/// The fallback interval for re-checking the piece metadata while waiting for an
+/// in-flight piece completion notification, guarding against missed notifications
+/// (e.g. the piece metadata is deleted outside the download flow).
+const DEFAULT_WAIT_FOR_PIECE_FINISHED_FALLBACK_INTERVAL: Duration = Duration::from_secs(1);
+
 /// Default temporary directory name for output operations.
 ///
 /// When users need to hardlink files from the client DaemonSet Pod's cache to the output
@@ -57,6 +64,45 @@ pub const DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL: Duration = Duration::from_mi
 /// hostPath mount point, which prevents hardlinks from being created across different
 /// quota contexts.
 pub const DEFAULT_TMP_DIR: &str = "tmp";
+
+/// PieceNotifier notifies the waiters when an in-flight piece download completes
+/// (finished, failed or its metadata deleted), so the waiters do not need to poll
+/// the piece metadata on an interval.
+///
+/// The notifier is registered just before the piece metadata is created when the
+/// piece download starts, and removed (waking all its waiters) when the download
+/// reaches a terminal state. The piece metadata remains the source of truth:
+/// waiters must re-check it after being notified.
+#[derive(Default)]
+struct PieceNotifier {
+    /// The notifiers of the in-flight pieces, keyed by the piece id.
+    notifiers: DashMap<String, Arc<Notify>>,
+}
+
+impl PieceNotifier {
+    /// Registers the notifier of the piece when its download starts. If the piece
+    /// is already registered by a concurrent download, the existing notifier is
+    /// kept.
+    fn register(&self, piece_id: &str) {
+        self.notifiers.entry(piece_id.to_string()).or_default();
+    }
+
+    /// Returns the notifier of the in-flight piece, or `None` if the piece is not
+    /// being downloaded by this process.
+    fn get(&self, piece_id: &str) -> Option<Arc<Notify>> {
+        self.notifiers
+            .get(piece_id)
+            .map(|notifier| notifier.value().clone())
+    }
+
+    /// Removes the notifier of the piece and wakes all its waiters when the piece
+    /// download completes.
+    fn remove_and_notify(&self, piece_id: &str) {
+        if let Some((_, notifier)) = self.notifiers.remove(piece_id) {
+            notifier.notify_waiters();
+        }
+    }
+}
 
 /// The storage of the task.
 pub struct Storage {
@@ -71,6 +117,10 @@ pub struct Storage {
 
     /// Implements the cache storage.
     cache: cache::Cache,
+
+    /// Notifies the waiters of the in-flight pieces when their downloads
+    /// complete.
+    piece_notifier: PieceNotifier,
 }
 
 /// Implements the storage.
@@ -88,6 +138,7 @@ impl Storage {
             metadata,
             content,
             cache,
+            piece_notifier: PieceNotifier::default(),
         })
     }
 
@@ -113,7 +164,7 @@ impl Storage {
     }
 
     /// Copies the task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_task(&self, id: &str, to: &Path) -> Result<()> {
         self.content.copy_task(id, to).await
     }

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -1989,8 +1989,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Simulate unfinished piece metadata left over from a previous run:
-        // the metadata exists but no notifier is registered in this process.
         let piece_id = storage.piece_id(TASK_ID, 0);
         storage
             .metadata
@@ -2000,8 +1998,6 @@ mod tests {
             .in_flight_piece_notifier(piece_id.as_str())
             .is_none());
 
-        // The waiter fails fast with PieceNotFound instead of polling until
-        // the wait timeout, and the stale metadata is cleaned up.
         let started_at = std::time::Instant::now();
         let result = storage.upload_piece(piece_id.as_str(), TASK_ID, None).await;
         assert!(matches!(result, Err(Error::PieceNotFound(_))));

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -1479,12 +1479,28 @@ impl<E: StorageEngineOwned> Metadata<E> {
     /// Updates the metadata of the piece when the piece downloads failed.
     #[instrument(level = "debug", skip_all)]
     pub fn download_piece_failed(&self, piece_id: &str) -> Result<()> {
+        // A failed download must never erase a piece another download completed,
+        // e.g. a duplicate downloader failing after the winner finished the piece.
+        if let Some(piece) = self.get_piece(piece_id)? {
+            if piece.is_finished() {
+                return Ok(());
+            }
+        }
+
         self.delete_piece(piece_id)
     }
 
     /// Waits for the piece to be finished or failed.
     #[instrument(level = "debug", skip_all)]
     pub fn wait_for_piece_finished_failed(&self, piece_id: &str) -> Result<()> {
+        // A timed-out or stale-detecting waiter must never erase a piece that
+        // has just been finished by its downloader.
+        if let Some(piece) = self.get_piece(piece_id)? {
+            if piece.is_finished() {
+                return Ok(());
+            }
+        }
+
         self.delete_piece(piece_id)
     }
 
@@ -1774,5 +1790,31 @@ mod tests {
         metadata.delete_pieces(task_id).unwrap();
         let pieces = metadata.get_pieces(task_id).unwrap();
         assert!(pieces.is_empty());
+    }
+
+    #[test]
+    fn test_download_piece_failed_keeps_finished_piece() {
+        let dir = tempdir().unwrap();
+        let log_dir = dir.path().join("log");
+        let metadata = Metadata::new(Arc::new(Config::default()), dir.path(), &log_dir).unwrap();
+        let task_id = "e4c4e940ad06c47fc36ac67801e6f8e36cb400e2391708620bc7e865b102062d";
+        let piece_id = metadata.piece_id(task_id, 1);
+
+        metadata
+            .download_piece_started(piece_id.as_str(), 1)
+            .unwrap();
+        metadata
+            .download_piece_finished(piece_id.as_str(), 0, 1024, "digest1", None)
+            .unwrap();
+
+        metadata.download_piece_failed(piece_id.as_str()).unwrap();
+        let piece = metadata.get_piece(piece_id.as_str()).unwrap().unwrap();
+        assert!(piece.is_finished());
+
+        metadata
+            .wait_for_piece_finished_failed(piece_id.as_str())
+            .unwrap();
+        let piece = metadata.get_piece(piece_id.as_str()).unwrap().unwrap();
+        assert!(piece.is_finished());
     }
 }

--- a/dragonfly-client-storage/src/piece_notifier.rs
+++ b/dragonfly-client-storage/src/piece_notifier.rs
@@ -66,22 +66,17 @@ mod tests {
     async fn test_piece_notifier_wakes_enabled_waiters() {
         let piece_notifier = PieceNotifier::default();
         let piece_id = "d3add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14a-0";
-
-        // Not registered yet, so there is no notifier.
         assert!(piece_notifier.get(piece_id).is_none());
 
         piece_notifier.register(piece_id);
         let notifier = piece_notifier.get(piece_id).unwrap();
 
-        // Registering again keeps the existing notifier.
         piece_notifier.register(piece_id);
         assert!(Arc::ptr_eq(
             &notifier,
             &piece_notifier.get(piece_id).unwrap()
         ));
 
-        // A notification signaled after the notified future is enabled wakes it,
-        // even if it is awaited later.
         let notified = notifier.notified();
         tokio::pin!(notified);
         notified.as_mut().enable();
@@ -91,10 +86,7 @@ mod tests {
             .await
             .unwrap();
 
-        // The notifier is removed after the completion.
         assert!(piece_notifier.get(piece_id).is_none());
-
-        // Removing a non-registered piece is a no-op.
         piece_notifier.remove_and_notify(piece_id);
     }
 }

--- a/dragonfly-client-storage/src/piece_notifier.rs
+++ b/dragonfly-client-storage/src/piece_notifier.rs
@@ -1,0 +1,100 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+/// PieceNotifier notifies the waiters when an in-flight piece download completes
+/// (finished, failed or its metadata deleted), so the waiters do not need to poll
+/// the piece metadata on an interval.
+///
+/// The notifier is registered just before the piece metadata is created when the
+/// piece download starts, and removed (waking all its waiters) when the download
+/// reaches a terminal state. The piece metadata remains the source of truth:
+/// waiters must re-check it after being notified.
+#[derive(Default)]
+pub(crate) struct PieceNotifier {
+    /// The notifiers of the in-flight pieces, keyed by the piece id.
+    notifiers: DashMap<String, Arc<Notify>>,
+}
+
+impl PieceNotifier {
+    /// Registers the notifier of the piece when its download starts. If the piece
+    /// is already registered by a concurrent download, the existing notifier is
+    /// kept.
+    pub(crate) fn register(&self, piece_id: &str) {
+        self.notifiers.entry(piece_id.to_string()).or_default();
+    }
+
+    /// Returns the notifier of the in-flight piece, or `None` if the piece is not
+    /// being downloaded by this process.
+    pub(crate) fn get(&self, piece_id: &str) -> Option<Arc<Notify>> {
+        self.notifiers
+            .get(piece_id)
+            .map(|notifier| notifier.value().clone())
+    }
+
+    /// Removes the notifier of the piece and wakes all its waiters when the piece
+    /// download completes.
+    pub(crate) fn remove_and_notify(&self, piece_id: &str) {
+        if let Some((_, notifier)) = self.notifiers.remove(piece_id) {
+            notifier.notify_waiters();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_piece_notifier_wakes_enabled_waiters() {
+        let piece_notifier = PieceNotifier::default();
+        let piece_id = "d3add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14a-0";
+
+        // Not registered yet, so there is no notifier.
+        assert!(piece_notifier.get(piece_id).is_none());
+
+        piece_notifier.register(piece_id);
+        let notifier = piece_notifier.get(piece_id).unwrap();
+
+        // Registering again keeps the existing notifier.
+        piece_notifier.register(piece_id);
+        assert!(Arc::ptr_eq(
+            &notifier,
+            &piece_notifier.get(piece_id).unwrap()
+        ));
+
+        // A notification signaled after the notified future is enabled wakes it,
+        // even if it is awaited later.
+        let notified = notifier.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        piece_notifier.remove_and_notify(piece_id);
+        tokio::time::timeout(Duration::from_secs(1), notified)
+            .await
+            .unwrap();
+
+        // The notifier is removed after the completion.
+        assert!(piece_notifier.get(piece_id).is_none());
+
+        // Removing a non-registered piece is a no-op.
+        piece_notifier.remove_and_notify(piece_id);
+    }
+}

--- a/dragonfly-client-storage/src/piece_notifier.rs
+++ b/dragonfly-client-storage/src/piece_notifier.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -22,7 +23,7 @@ use tokio::sync::Notify;
 /// (finished, failed or its metadata deleted), so the waiters do not need to poll
 /// the piece metadata on an interval.
 ///
-/// The notifier is registered just before the piece metadata is created when the
+/// The notifier is claimed just before the piece metadata is created when the
 /// piece download starts, and removed (waking all its waiters) when the download
 /// reaches a terminal state. The piece metadata remains the source of truth:
 /// waiters must re-check it after being notified.
@@ -32,12 +33,32 @@ pub(crate) struct PieceNotifier {
     notifiers: DashMap<String, Arc<Notify>>,
 }
 
+/// Claim is the result of claiming the download of a piece.
+pub(crate) enum Claim {
+    /// The caller inserted the notifier and is the sole downloader of the piece.
+    Owner,
+
+    /// Another download of the piece is already in flight. The caller should
+    /// wait on its notifier and re-check the piece metadata.
+    InFlight(Arc<Notify>),
+}
+
+/// PieceNotifier notifies the waiters when an in-flight piece download completes
+/// (finished, failed or its metadata deleted), so the waiters do not need to poll
+/// the piece metadata on an interval.
 impl PieceNotifier {
-    /// Registers the notifier of the piece when its download starts. If the piece
-    /// is already registered by a concurrent download, the existing notifier is
-    /// kept.
-    pub(crate) fn register(&self, piece_id: &str) {
-        self.notifiers.entry(piece_id.to_string()).or_default();
+    /// Atomically claims the download of the piece when its download starts.
+    /// Exactly one of the concurrent claimers becomes the owner; the others get
+    /// the owner's notifier to wait on, so the same piece is never downloaded
+    /// twice concurrently.
+    pub(crate) fn claim(&self, piece_id: &str) -> Claim {
+        match self.notifiers.entry(piece_id.to_string()) {
+            Entry::Occupied(entry) => Claim::InFlight(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Notify::new()));
+                Claim::Owner
+            }
+        }
     }
 
     /// Returns the notifier of the in-flight piece, or `None` if the piece is not
@@ -68,14 +89,13 @@ mod tests {
         let piece_id = "d3add1f66b0d0b8083f14479d6e181ec9e2b34cf07d4a1a2ee2fcf51d3a3f14a-0";
         assert!(piece_notifier.get(piece_id).is_none());
 
-        piece_notifier.register(piece_id);
+        assert!(matches!(piece_notifier.claim(piece_id), Claim::Owner));
         let notifier = piece_notifier.get(piece_id).unwrap();
 
-        piece_notifier.register(piece_id);
-        assert!(Arc::ptr_eq(
-            &notifier,
-            &piece_notifier.get(piece_id).unwrap()
-        ));
+        match piece_notifier.claim(piece_id) {
+            Claim::InFlight(in_flight) => assert!(Arc::ptr_eq(&notifier, &in_flight)),
+            Claim::Owner => panic!("expected the second claim to lose"),
+        }
 
         let notified = notifier.notified();
         tokio::pin!(notified);
@@ -88,5 +108,6 @@ mod tests {
 
         assert!(piece_notifier.get(piece_id).is_none());
         piece_notifier.remove_and_notify(piece_id);
+        assert!(matches!(piece_notifier.claim(piece_id), Claim::Owner));
     }
 }

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -150,7 +150,7 @@ pub struct QUICServerHandler {
 /// Implements the request handler.
 impl QUICServerHandler {
     /// Handles a single QUIC connection.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle(
         &self,
         connection: quinn::Connection,
@@ -495,7 +495,7 @@ impl QUICServerHandler {
     /// upload rate limiting, and prepares both the piece metadata and
     /// content stream for transmission. It's the core handler for regular
     /// piece download requests in the P2P network.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_piece(
         &self,
         piece_id: &str,
@@ -559,7 +559,7 @@ impl QUICServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent layer.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_persistent_piece(
         &self,
         piece_id: &str,
@@ -623,7 +623,7 @@ impl QUICServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent cache layer.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -728,7 +728,7 @@ impl QUICServerHandler {
     /// This function sends the provided bytes as a response and ensures
     /// all data is flushed to the underlying transport. This is typically
     /// used for sending headers and small payloads in a single operation.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn write_response(
         &self,
         request: Bytes,
@@ -750,7 +750,7 @@ impl QUICServerHandler {
     /// reader's internal buffer directly without an intermediate copy buffer.
     /// It's designed for streaming large piece content without loading
     /// everything into memory. The operation is flushed to ensure data delivery.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn write_stream<R: AsyncBufRead + Unpin + ?Sized>(
         &self,
         stream: &mut R,

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -188,11 +188,7 @@ impl TCPServerHandler {
     /// It reads the protocol header to determine the request type and dispatches
     /// to the appropriate handler. Supports both regular piece downloads and
     /// persistent cache piece downloads with proper request/response framing.
-    #[instrument(
-        level = "debug",
-        skip_all,
-        fields(host_id, remote_address, task_id, piece_id)
-    )]
+    #[instrument(skip_all, fields(host_id, remote_address, task_id, piece_id))]
     async fn handle(&self, stream: TcpStream, remote_address: String) -> ClientResult<()> {
         let (mut reader, mut writer) = stream.into_split();
         let header = self.read_header(&mut reader).await?;
@@ -455,7 +451,7 @@ impl TCPServerHandler {
     /// upload rate limiting, and prepares both the piece metadata and
     /// content stream for transmission. It's the core handler for regular
     /// piece download requests in the P2P network.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_piece(
         &self,
         piece_id: &str,
@@ -519,7 +515,7 @@ impl TCPServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent layer.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_persistent_piece(
         &self,
         piece_id: &str,
@@ -583,7 +579,7 @@ impl TCPServerHandler {
     /// which have different storage semantics and metadata structure. This
     /// enables efficient serving of frequently accessed content from the
     /// persistent cache layer.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn handle_persistent_cache_piece(
         &self,
         piece_id: &str,
@@ -690,7 +686,7 @@ impl TCPServerHandler {
     /// This function sends the provided bytes as a response and ensures
     /// all data is flushed to the underlying transport. This is typically
     /// used for sending headers and small payloads in a single operation.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn write_response(
         &self,
         request: Bytes,
@@ -711,7 +707,7 @@ impl TCPServerHandler {
     /// socket with sendfile, so the piece bytes move from the page cache to
     /// the socket inside the kernel without passing through user space.
     #[cfg(target_os = "linux")]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn write_stream(
         &self,
         reader: RangeReader,
@@ -741,7 +737,7 @@ impl TCPServerHandler {
     /// It's designed for streaming large piece content without loading
     /// everything into memory. The operation is flushed to ensure data delivery.
     #[cfg(not(target_os = "linux"))]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn write_stream(
         &self,
         mut reader: RangeReader,

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -38,7 +38,7 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
         // Set length (potential truncation).
         f.set_len(length).await?;
         let f = f.try_clone().await?;
-        return tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let fd = f.as_fd();
             let offset = 0;
             let flags = FallocateFlags::KEEP_SIZE;
@@ -61,9 +61,8 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
             }
         })
         .await
-        .map_err(io::Error::other)?;
+        .map_err(io::Error::other)??;
     }
 
-    #[cfg(not(target_os = "linux"))]
     Ok(())
 }

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -37,25 +37,31 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
 
         // Set length (potential truncation).
         f.set_len(length).await?;
-        let fd = f.as_fd();
-        let offset = 0;
-        let flags = FallocateFlags::KEEP_SIZE;
+        let f = f.try_clone().await?;
+        return tokio::task::spawn_blocking(move || {
+            let fd = f.as_fd();
+            let offset = 0;
+            let flags = FallocateFlags::KEEP_SIZE;
 
-        loop {
-            match fallocate(fd, flags, offset, length) {
-                Ok(_) => return Ok(()),
-                Err(rustix::io::Errno::INTR) => continue,
-                Err(err)
-                    if err == rustix::io::Errno::NOTSUP || err == rustix::io::Errno::OPNOTSUPP =>
-                {
-                    warn!("fallocate not supported, skipping preallocation");
-                    return Ok(());
-                }
-                Err(err) => {
-                    return Err(Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
+            loop {
+                match fallocate(fd, flags, offset, length) {
+                    Ok(_) => return Ok(()),
+                    Err(rustix::io::Errno::INTR) => continue,
+                    Err(err)
+                        if err == rustix::io::Errno::NOTSUP
+                            || err == rustix::io::Errno::OPNOTSUPP =>
+                    {
+                        warn!("fallocate not supported, skipping preallocation");
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        return Err(Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
+                    }
                 }
             }
-        }
+        })
+        .await
+        .map_err(io::Error::other)?;
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -717,7 +717,6 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
         if download.prefetch {
             match self.task.prefetch_task_started(task_id.as_str()).await {
                 Ok(_) => {
-                    info!("prefetch task started");
                     let socket_path = self.socket_path.clone();
                     let task_manager_clone = self.task.clone();
                     tokio::spawn(

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -749,7 +749,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                     );
                 }
                 // If the task is already prefetched, ignore the error.
-                Err(ClientError::InvalidState(_)) => info!("task is already prefetched"),
+                Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
                 Err(err) => {
                     error!("prefetch task started: {}", err);
                 }

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -646,7 +646,6 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         if download.prefetch {
             match self.task.prefetch_task_started(task_id.as_str()).await {
                 Ok(_) => {
-                    info!("prefetch task started");
                     let socket_path = self.socket_path.clone();
                     let task_manager_clone = self.task.clone();
                     tokio::spawn(

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -88,6 +88,9 @@ use url::Url;
 use super::interceptor::{ExtractTracingInterceptor, InjectTracingInterceptor};
 use super::middleware::BBRLayer;
 
+/// The default interval for waiting for the piece to be finished.
+pub const DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL: Duration = Duration::from_millis(100);
+
 /// gRPC server for upload operations.
 pub struct DfdaemonUploadServer {
     /// Configuration of the dfdaemon.
@@ -1094,10 +1097,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     }
 
                     // Wait for the piece to be finished.
-                    tokio::time::sleep(
-                        dragonfly_client_storage::DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
-                    )
-                    .await;
+                    tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL).await;
                 }
             }
             .in_current_span(),
@@ -1851,10 +1851,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     }
 
                     // Wait for the piece to be finished.
-                    tokio::time::sleep(
-                        dragonfly_client_storage::DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
-                    )
-                    .await;
+                    tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL).await;
                 }
             }
             .in_current_span(),
@@ -2414,10 +2411,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     }
 
                     // Wait for the piece to be finished.
-                    tokio::time::sleep(
-                        dragonfly_client_storage::DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
-                    )
-                    .await;
+                    tokio::time::sleep(DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL).await;
                 }
             }
             .in_current_span(),

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -477,7 +477,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
         tokio::spawn(
             async move {
                 match task_manager_clone
-                    .download_and_ensure_announcement(
+                    .download_with_scheduler(
                         &task_clone,
                         host_id.as_str(),
                         peer_id.as_str(),

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -678,7 +678,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     );
                 }
                 // If the task is already prefetched, ignore the error.
-                Err(ClientError::InvalidState(_)) => info!("task is already prefetched"),
+                Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
                 Err(err) => {
                     error!("prefetch task started: {}", err);
                 }

--- a/dragonfly-client/src/grpc/mod.rs
+++ b/dragonfly-client/src/grpc/mod.rs
@@ -111,6 +111,7 @@ pub async fn prefetch_task(
     let priority = download.priority;
 
     // Download task by dfdaemon download client.
+    info!("prefetch task started");
     let response = dfdaemon_download_client
         .download_task(request)
         .await

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -369,7 +369,7 @@ pub async fn registry_mirror_https_handler(
 }
 
 /// Handles the http request by client.
-#[instrument(level = "debug", skip_all)]
+#[instrument(skip_all)]
 pub async fn http_handler(
     config: Arc<Config>,
     task: Arc<Task>,
@@ -599,7 +599,7 @@ async fn upgraded_tunnel(
 
 /// Handles the upgraded https request from the client.
 #[allow(clippy::too_many_arguments)]
-#[instrument(level = "debug", skip_all, fields(url, method))]
+#[instrument(skip_all, fields(url, method))]
 pub async fn upgraded_handler(
     config: Arc<Config>,
     task: Arc<Task>,
@@ -735,7 +735,7 @@ pub async fn upgraded_handler(
 }
 
 /// Proxies the request via the dfdaemon.
-#[instrument(level = "debug", skip_all, fields(host_id, task_id, peer_id))]
+#[instrument(skip_all, fields(host_id, task_id, peer_id))]
 async fn proxy_via_dfdaemon(
     config: Arc<Config>,
     task: Arc<Task>,
@@ -837,7 +837,6 @@ async fn proxy_via_dfdaemon(
         let task_id = message.task_id.clone();
         match task.prefetch_task_started(task_id.as_str()).await {
             Ok(_) => {
-                info!("prefetch task started");
                 let config = config.clone();
                 let task_manager = task.clone();
                 let dynconfig = dynconfig.clone();

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -350,7 +350,7 @@ pub async fn download(
 ///  Prefetch the full task by the task manager directly. It is similar to the
 /// prefetch_task of the dfdaemon gRPC module, but downloads the task by the task manager
 /// instead of the dfdaemon download gRPC client.
-#[instrument(level = "debug", skip_all)]
+#[instrument(skip_all)]
 pub async fn prefetch(
     config: Arc<Config>,
     task_manager: Arc<Task>,
@@ -384,6 +384,7 @@ pub async fn prefetch(
     let priority = download.priority;
 
     // Download the task by the task manager.
+    info!("prefetch task started");
     let mut out_stream_rx = self::download(config, task_manager, dynconfig, request)
         .await
         .inspect_err(|err| {

--- a/dragonfly-client/src/resource/parent_selector.rs
+++ b/dragonfly-client/src/resource/parent_selector.rs
@@ -132,7 +132,7 @@ pub struct ParentSelector {
 /// Implements parent peer selection and connection management logic.
 impl ParentSelector {
     /// Creates a new parent selector instance.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,
@@ -154,7 +154,7 @@ impl ParentSelector {
     /// This function performs weighted random selection where parents with higher weights
     /// (better idle bandwidth) have a higher probability of being selected. If weight
     /// calculation fails, falls back to uniform random selection.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
         let weights: Vec<u64> = parents
             .iter()
@@ -201,7 +201,7 @@ impl ParentSelector {
     /// - Creates a new gRPC connection if one doesn't exist.
     /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
     /// - Updates the connection's request counter.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn register(&self, parents: &[Peer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
         let mut join_set = JoinSet::new();
@@ -295,7 +295,7 @@ impl ParentSelector {
     /// - Triggers connection shutdown.
     /// - Removes the weight entry.
     /// - Removes the connection from the pool.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn unregister(&self, parents: &[Peer]) {
         for parent in parents {
             debug!("unregister parent {}", parent.id);
@@ -330,7 +330,7 @@ impl ParentSelector {
     /// - Updates the parent's weight based on idle TX bandwidth.
     /// - Runs until shutdown signal or connection failure.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn sync_host(
         host_id: String,
         peer_id: String,
@@ -453,7 +453,7 @@ pub struct PersistentParentSelector {
 /// Implements persistent parent peer selection and connection management logic.
 impl PersistentParentSelector {
     /// Creates a new persistent parent selector instance.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,
@@ -475,7 +475,7 @@ impl PersistentParentSelector {
     /// This function performs weighted random selection where parents with higher weights
     /// (better idle bandwidth) have a higher probability of being selected. If weight
     /// calculation fails, falls back to uniform random selection.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
         let weights: Vec<u64> = parents
             .iter()
@@ -523,7 +523,7 @@ impl PersistentParentSelector {
     /// - Creates a new gRPC connection if one doesn't exist.
     /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
     /// - Updates the connection's request counter.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn register(&self, parents: &[PersistentPeer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
         let mut join_set = JoinSet::new();
@@ -617,7 +617,7 @@ impl PersistentParentSelector {
     /// - Triggers connection shutdown.
     /// - Removes the weight entry.
     /// - Removes the connection from the pool.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn unregister(&self, parents: &[PersistentPeer]) {
         for parent in parents {
             debug!("unregister persistent parent {}", parent.id);
@@ -652,7 +652,7 @@ impl PersistentParentSelector {
     /// - Updates the parent's weight based on idle TX bandwidth.
     /// - Runs until shutdown signal or connection failure.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn sync_host(
         host_id: String,
         peer_id: String,
@@ -775,7 +775,7 @@ pub struct PersistentCacheParentSelector {
 /// Implements persistent cache parent peer selection and connection management logic.
 impl PersistentCacheParentSelector {
     /// Creates a new persistent cache parent selector instance.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,
@@ -797,7 +797,7 @@ impl PersistentCacheParentSelector {
     /// This function performs weighted random selection where parents with higher weights
     /// (better idle bandwidth) have a higher probability of being selected. If weight
     /// calculation fails, falls back to uniform random selection.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn select(&self, parents: Vec<CollectedParent>) -> CollectedParent {
         let weights: Vec<u64> = parents
             .iter()
@@ -845,7 +845,7 @@ impl PersistentCacheParentSelector {
     /// - Creates a new gRPC connection if one doesn't exist.
     /// - Spawns a background task to continuously sync host metrics (bandwidth, load).
     /// - Updates the connection's request counter.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn register(&self, parents: &[PersistentCachePeer]) -> Result<()> {
         let dfdaemon_shutdown = self.shutdown.clone();
         let mut join_set = JoinSet::new();
@@ -942,7 +942,7 @@ impl PersistentCacheParentSelector {
     /// - Triggers connection shutdown.
     /// - Removes the weight entry.
     /// - Removes the connection from the pool.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn unregister(&self, parents: &[PersistentCachePeer]) {
         for parent in parents {
             debug!("unregister persistent cache parent {}", parent.id);
@@ -980,7 +980,7 @@ impl PersistentCacheParentSelector {
     /// - Updates the parent's weight based on idle TX bandwidth.
     /// - Runs until shutdown signal or connection failure.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn sync_host(
         host_id: String,
         peer_id: String,

--- a/dragonfly-client/src/resource/parent_selector.rs
+++ b/dragonfly-client/src/resource/parent_selector.rs
@@ -132,7 +132,6 @@ pub struct ParentSelector {
 /// Implements parent peer selection and connection management logic.
 impl ParentSelector {
     /// Creates a new parent selector instance.
-    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,
@@ -453,7 +452,6 @@ pub struct PersistentParentSelector {
 /// Implements persistent parent peer selection and connection management logic.
 impl PersistentParentSelector {
     /// Creates a new persistent parent selector instance.
-    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,
@@ -775,7 +773,6 @@ pub struct PersistentCacheParentSelector {
 /// Implements persistent cache parent peer selection and connection management logic.
 impl PersistentCacheParentSelector {
     /// Creates a new persistent cache parent selector instance.
-    #[instrument(skip_all)]
     pub fn new(
         config: Arc<Config>,
         id_generator: Arc<IDGenerator>,

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -126,7 +126,7 @@ impl PersistentCacheTask {
     }
 
     /// Gets a persistent cache task from local.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentCacheTask>> {
         self.storage.get_persistent_cache_task(task_id)
     }
@@ -616,13 +616,13 @@ impl PersistentCacheTask {
     }
 
     /// Updates the metadata of the persistent cache task when the task downloads finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentCacheTask> {
         self.storage.download_persistent_cache_task_finished(id)
     }
 
     /// Updates the metadata of the persistent cache task when the task downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self
             .storage

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -126,13 +126,13 @@ impl PersistentCacheTask {
     }
 
     /// Gets a persistent cache task from local.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentCacheTask>> {
         self.storage.get_persistent_cache_task(task_id)
     }
 
     /// Creates a persistent cache task from local.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload(
         &self,
         task_id: &str,
@@ -528,7 +528,7 @@ impl PersistentCacheTask {
     }
 
     /// Updates the metadata of the persistent cache task when the persistent cache task downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_started(
         &self,
         task_id: &str,
@@ -616,13 +616,13 @@ impl PersistentCacheTask {
     }
 
     /// Updates the metadata of the persistent cache task when the task downloads finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentCacheTask> {
         self.storage.download_persistent_cache_task_finished(id)
     }
 
     /// Updates the metadata of the persistent cache task when the task downloads failed.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self
             .storage
@@ -639,14 +639,14 @@ impl PersistentCacheTask {
     }
 
     //// copy_task copies the persistent cache task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_task(&self, id: &str, to: &Path) -> ClientResult<()> {
         self.storage.copy_persistent_cache_task(id, to).await
     }
 
     /// Downloads a persistent cache task.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download(
         &self,
         task: &metadata::PersistentCacheTask,
@@ -805,7 +805,7 @@ impl PersistentCacheTask {
 
     /// Downloads a partial persistent cache task with scheduler.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler(
         &self,
         task: &metadata::PersistentCacheTask,
@@ -1110,7 +1110,7 @@ impl PersistentCacheTask {
 
     /// Downloads a partial persistent cache task with scheduler from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_parent(
         &self,
         task: &metadata::PersistentCacheTask,
@@ -1455,7 +1455,7 @@ impl PersistentCacheTask {
 
     /// Downloads a partial persistent cache task from a local.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_from_local(
         &self,
         task: &metadata::PersistentCacheTask,
@@ -1605,7 +1605,7 @@ impl PersistentCacheTask {
     }
 
     /// Stats the persistent cache task from the scheduler.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat(
         &self,
         task_id: &str,
@@ -1620,7 +1620,7 @@ impl PersistentCacheTask {
     }
 
     /// Stats the local persistent cache task from the scheduler.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat_local(
         &self,
         task_id: &str,
@@ -1651,7 +1651,7 @@ impl PersistentCacheTask {
     }
 
     /// Returns the persistent cache tasks from local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn list_local(&self) -> ClientResult<ListLocalPersistentCacheTasksResponse> {
         let tasks = self
             .storage
@@ -1689,7 +1689,7 @@ impl PersistentCacheTask {
     }
 
     /// Deletes a persistent cache task.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn delete(&self, task_id: &str) {
         self.storage.delete_persistent_cache_task(task_id).await
     }

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -141,13 +141,13 @@ impl PersistentTask {
     }
 
     /// Gets a persistent task from local.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentTask>> {
         self.storage.get_persistent_task(task_id)
     }
 
     /// Creates a persistent task from local.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn upload(
         &self,
         task_id: &str,
@@ -325,7 +325,7 @@ impl PersistentTask {
     /// Orchestrates uploading content for a task by first persisting the local file
     /// into the local piece-based storage, then uploading the same file to the
     /// configured source storage backend.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn upload_content(
         &self,
         task_id: &str,
@@ -348,7 +348,7 @@ impl PersistentTask {
     /// when possible or, if linking fails, concurrently reading the file by piece
     /// and writing each piece into persistent storage, ensuring all targeted pieces
     /// are successfully imported.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn upload_content_to_local(
         &self,
         task_id: &str,
@@ -556,7 +556,7 @@ impl PersistentTask {
     /// using a PUT request created from the backend factory, while recording metrics
     /// for request start, failure, and completion, and converting non‑successful
     /// backend responses into structured backend errors.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn upload_content_to_source(
         &self,
         task_id: &str,
@@ -627,7 +627,7 @@ impl PersistentTask {
     }
 
     /// Updates the metadata of the persistent task when the persistent task downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_started(
         &self,
         task_id: &str,
@@ -743,7 +743,7 @@ impl PersistentTask {
 
     /// Updates the metadata of the persistent task when the
     /// persistent task downloads started for replication.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_started_for_replication(
         &self,
         task_id: &str,
@@ -806,13 +806,13 @@ impl PersistentTask {
     }
 
     /// Updates the metadata of the persistent task when the task downloads finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentTask> {
         self.storage.download_persistent_task_finished(id)
     }
 
     /// Updates the metadata of the persistent task when the task downloads failed.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self.storage.download_persistent_task_failed(id).await?;
         Ok(())
@@ -826,14 +826,14 @@ impl PersistentTask {
     }
 
     //// copy_task copies the persistent task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_task(&self, id: &str, to: &Path) -> ClientResult<()> {
         self.storage.copy_persistent_task(id, to).await
     }
 
     /// Downloads a persistent task for replication.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_for_replication(
         &self,
         task: &metadata::PersistentTask,
@@ -990,7 +990,7 @@ impl PersistentTask {
     /// Downloads a partial task for replication
     /// with scheduler.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_for_replication_with_scheduler(
         &self,
         task: &metadata::PersistentTask,
@@ -1326,7 +1326,7 @@ impl PersistentTask {
 
     /// Downloads a persistent task.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download(
         &self,
         task: &metadata::PersistentTask,
@@ -1514,7 +1514,7 @@ impl PersistentTask {
 
     /// Downloads a partial task with scheduler.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler(
         &self,
         task: &metadata::PersistentTask,
@@ -1952,7 +1952,7 @@ impl PersistentTask {
 
     /// Downloads a partial task with scheduler from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_parent(
         &self,
         task: &metadata::PersistentTask,
@@ -2307,7 +2307,7 @@ impl PersistentTask {
 
     /// Downloads a partial task with scheduler from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_source(
         &self,
         task: &metadata::PersistentTask,
@@ -2621,7 +2621,7 @@ impl PersistentTask {
 
     /// Downloads a partial task from a local.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_from_local(
         &self,
         task: &metadata::PersistentTask,
@@ -2754,7 +2754,7 @@ impl PersistentTask {
 
     /// Downloads a partial task from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_from_source(
         &self,
         task: &metadata::PersistentTask,
@@ -2979,7 +2979,7 @@ impl PersistentTask {
     }
 
     /// Checks if the persistent task exists in the source.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn exists(
         &self,
         task_id: &str,
@@ -3006,7 +3006,7 @@ impl PersistentTask {
     }
 
     /// Stats the persistent task in the source.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat_source(
         &self,
         task_id: &str,
@@ -3033,7 +3033,7 @@ impl PersistentTask {
     }
 
     /// Stats the persistent task from the scheduler.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat(&self, task_id: &str, host_id: &str) -> ClientResult<CommonPersistentTask> {
         self.scheduler_client
             .stat_persistent_task(StatPersistentTaskRequest {
@@ -3044,7 +3044,7 @@ impl PersistentTask {
     }
 
     /// Stats the local persistent task from the scheduler.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat_local(&self, task_id: &str) -> ClientResult<StatLocalPersistentTaskResponse> {
         let Some(task) = self.get(task_id).inspect_err(|err| {
             error!(
@@ -3072,7 +3072,7 @@ impl PersistentTask {
     }
 
     /// Returns the persistent tasks from local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn list_local(&self) -> ClientResult<ListLocalPersistentTasksResponse> {
         let tasks = self.storage.get_persistent_tasks().inspect_err(|err| {
             error!("list persistent tasks from local storage error: {:?}", err);
@@ -3104,7 +3104,7 @@ impl PersistentTask {
     }
 
     /// Deletes a persistent task.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn delete(&self, task_id: &str) {
         self.storage.delete_persistent_task(task_id).await
     }

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -141,7 +141,7 @@ impl PersistentTask {
     }
 
     /// Gets a persistent task from local.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get(&self, task_id: &str) -> ClientResult<Option<metadata::PersistentTask>> {
         self.storage.get_persistent_task(task_id)
     }
@@ -806,13 +806,13 @@ impl PersistentTask {
     }
 
     /// Updates the metadata of the persistent task when the task downloads finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::PersistentTask> {
         self.storage.download_persistent_task_finished(id)
     }
 
     /// Updates the metadata of the persistent task when the task downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         let _ = self.storage.download_persistent_task_failed(id).await?;
         Ok(())

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -348,13 +348,6 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
-        // Clean up residual piece metadata if error occurred.
-        let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self.storage.download_piece_failed(piece_id).err() {
-                error!("set piece metadata failed: {}", err)
-            };
-        });
-
         // Record the start of downloading piece.
         let piece = self
             .storage
@@ -365,9 +358,14 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
-            scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
+
+        let guard = scopeguard::guard((), |_| {
+            if let Some(err) = self.storage.download_piece_failed(piece_id).err() {
+                error!("set piece metadata failed: {}", err)
+            };
+        });
 
         if is_prefetch {
             // Acquire the prefetch rate limiter.
@@ -478,13 +476,6 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
-        // Clean up residual piece metadata if error occurred.
-        let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self.storage.download_piece_failed(piece_id).err() {
-                error!("set piece metadata failed: {}", err)
-            };
-        });
-
         // Record the start of downloading piece.
         let piece = self
             .storage
@@ -495,9 +486,14 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
-            scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
+
+        let guard = scopeguard::guard((), |_| {
+            if let Some(err) = self.storage.download_piece_failed(piece_id).err() {
+                error!("set piece metadata failed: {}", err)
+            };
+        });
 
         if is_prefetch {
             // Acquire the prefetch rate limiter.
@@ -700,17 +696,6 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
-        // Clean up residual persistent metadata if error occurred.
-        let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self
-                .storage
-                .download_persistent_piece_failed(piece_id)
-                .err()
-            {
-                error!("set persistent piece metadata failed: {}", err)
-            };
-        });
-
         // Acquire the download rate limiter.
         self.download_bandwidth_limiter
             .acquire(length as usize)
@@ -726,9 +711,18 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished persistent piece {} from local", piece_id);
-            scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
+
+        let guard = scopeguard::guard((), |_| {
+            if let Some(err) = self
+                .storage
+                .download_persistent_piece_failed(piece_id)
+                .err()
+            {
+                error!("set persistent piece metadata failed: {}", err)
+            };
+        });
 
         let (mut reader, offset, digest) = match (
             self.config.download.protocol.as_str(),
@@ -827,17 +821,6 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
-        // Clean up residual piece metadata if error occurred.
-        let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self
-                .storage
-                .download_persistent_piece_failed(piece_id)
-                .err()
-            {
-                error!("set piece metadata failed: {}", err)
-            };
-        });
-
         // Record the start of downloading piece.
         let piece = self
             .storage
@@ -848,9 +831,18 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
-            scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
+
+        let guard = scopeguard::guard((), |_| {
+            if let Some(err) = self
+                .storage
+                .download_persistent_piece_failed(piece_id)
+                .err()
+            {
+                error!("set piece metadata failed: {}", err)
+            };
+        });
 
         // Acquire the back to source rate limiter.
         self.back_to_source_bandwidth_limiter
@@ -1045,17 +1037,6 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
-        // Clean up residual persistent cache metadata if error occurred.
-        let guard = scopeguard::guard((), |_| {
-            if let Some(err) = self
-                .storage
-                .download_persistent_cache_piece_failed(piece_id)
-                .err()
-            {
-                error!("set persistent cache piece metadata failed: {}", err)
-            };
-        });
-
         // Acquire the download rate limiter.
         self.download_bandwidth_limiter
             .acquire(length as usize)
@@ -1071,9 +1052,18 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished persistent cache piece {} from local", piece_id);
-            scopeguard::ScopeGuard::into_inner(guard);
             return Ok(piece);
         }
+
+        let guard = scopeguard::guard((), |_| {
+            if let Some(err) = self
+                .storage
+                .download_persistent_cache_piece_failed(piece_id)
+                .err()
+            {
+                error!("set persistent cache piece metadata failed: {}", err)
+            };
+        });
 
         let (mut reader, offset, digest) = match (
             self.config.download.protocol.as_str(),

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -244,7 +244,7 @@ impl Piece {
     }
 
     /// Removes the finished pieces from interested pieces.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn remove_finished_from_interested(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -262,7 +262,7 @@ impl Piece {
     }
 
     /// Merges the finished pieces and has finished pieces.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn merge_finished_pieces(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -308,7 +308,7 @@ impl Piece {
     }
 
     /// Downloads a single piece from local cache.
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_from_local_into_range_reader(
         &self,
         piece_id: &str,
@@ -326,14 +326,14 @@ impl Piece {
 
     /// Downloads a single piece from local cache. Fake the download piece
     /// from the local cache, just collect the metrics.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a single piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_from_parent(
         &self,
         piece_id: &str,
@@ -458,7 +458,7 @@ impl Piece {
 
     /// Downloads a single piece from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_from_source(
         &self,
         piece_id: &str,
@@ -624,13 +624,13 @@ impl Piece {
     }
 
     /// Gets a persistent piece from the local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn get_persistent(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_piece(piece_id)
     }
 
     /// Creates a new persistent piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn create_persistent<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -646,7 +646,7 @@ impl Piece {
     }
 
     /// Registers a new persistent piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn register_persistent(
         &self,
         piece_id: &str,
@@ -659,7 +659,7 @@ impl Piece {
     }
 
     /// Downloads a persistent piece from local cache.
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_persistent_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -679,14 +679,14 @@ impl Piece {
 
     /// Downloads a persistent piece from local cache. Fake the download
     /// persistent piece from the local cache, just collect the metrics.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_persistent_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a persistent piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_persistent_from_parent(
         &self,
         piece_id: &str,
@@ -808,7 +808,7 @@ impl Piece {
 
     /// Downloads a single persistent piece from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_persistent_from_source(
         &self,
         piece_id: &str,
@@ -969,13 +969,13 @@ impl Piece {
     }
 
     /// Gets a persistent cache piece from the local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn get_persistent_cache(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_cache_piece(piece_id)
     }
 
     /// Creates a new persistent cache piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn create_persistent_cache<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -991,7 +991,7 @@ impl Piece {
     }
 
     /// Registers a new persistent cache piece.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn register_persistent_cache(
         &self,
         piece_id: &str,
@@ -1004,7 +1004,7 @@ impl Piece {
     }
 
     /// Downloads a persistent cache piece from local cache.
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_persistent_cache_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -1024,14 +1024,14 @@ impl Piece {
 
     /// Downloads a persistent cache piece from local cache. Fake the download
     /// persistent cache piece from the local cache, just collect the metrics.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_persistent_cache_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
 
     /// Downloads a persistent cache piece from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all, fields(piece_id))]
+    #[instrument(skip_all, fields(piece_id))]
     pub async fn download_persistent_cache_from_parent(
         &self,
         piece_id: &str,

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -244,7 +244,7 @@ impl Piece {
     }
 
     /// Removes the finished pieces from interested pieces.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn remove_finished_from_interested(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -262,7 +262,7 @@ impl Piece {
     }
 
     /// Merges the finished pieces and has finished pieces.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn merge_finished_pieces(
         &self,
         finished_pieces: Vec<metadata::Piece>,
@@ -308,7 +308,7 @@ impl Piece {
     }
 
     /// Downloads a single piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_from_local_into_range_reader(
         &self,
         piece_id: &str,
@@ -326,7 +326,7 @@ impl Piece {
 
     /// Downloads a single piece from local cache. Fake the download piece
     /// from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
@@ -624,7 +624,7 @@ impl Piece {
     }
 
     /// Gets a persistent piece from the local storage.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_piece(piece_id)
     }
@@ -659,7 +659,7 @@ impl Piece {
     }
 
     /// Downloads a persistent piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -679,7 +679,7 @@ impl Piece {
 
     /// Downloads a persistent piece from local cache. Fake the download
     /// persistent piece from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }
@@ -969,13 +969,13 @@ impl Piece {
     }
 
     /// Gets a persistent cache piece from the local storage.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get_persistent_cache(&self, piece_id: &str) -> Result<Option<metadata::Piece>> {
         self.storage.get_persistent_cache_piece(piece_id)
     }
 
     /// Creates a new persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn create_persistent_cache<R: AsyncRead + Unpin + ?Sized>(
         &self,
         piece_id: &str,
@@ -991,7 +991,7 @@ impl Piece {
     }
 
     /// Registers a new persistent cache piece.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn register_persistent_cache(
         &self,
         piece_id: &str,
@@ -1004,7 +1004,7 @@ impl Piece {
     }
 
     /// Downloads a persistent cache piece from local cache.
-    #[instrument(skip_all, fields(piece_id))]
+    #[instrument(level = "debug", skip_all, fields(piece_id))]
     pub async fn download_persistent_cache_from_local_into_async_read(
         &self,
         piece_id: &str,
@@ -1024,7 +1024,7 @@ impl Piece {
 
     /// Downloads a persistent cache piece from local cache. Fake the download
     /// persistent cache piece from the local cache, just collect the metrics.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_persistent_cache_from_local(&self, length: u64) {
         collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
     }

--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -121,7 +121,7 @@ impl PieceCollector {
     }
 
     /// Runs the piece collector.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn run(&self) -> Receiver<CollectedPiece> {
         let config = self.config.clone();
         let host_id = self.host_id.clone();
@@ -177,7 +177,7 @@ impl PieceCollector {
     /// `collected_piece_tx`, it carries a complete list of available parents, enabling
     /// load-balanced concurrent downloads across different peers.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn collect_from_parents(
         config: Arc<Config>,
         host_id: &str,
@@ -415,7 +415,7 @@ impl PersistentPieceCollector {
     }
 
     /// Runs the piece collector.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn run(&self) -> Receiver<CollectedPiece> {
         let config = self.config.clone();
         let host_id = self.host_id.clone();
@@ -471,7 +471,7 @@ impl PersistentPieceCollector {
     /// `collected_piece_tx`, it carries a complete list of available parents, enabling
     /// load-balanced concurrent downloads across different peers.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn collect_from_parents(
         config: Arc<Config>,
         host_id: &str,
@@ -717,7 +717,7 @@ impl PersistentCachePieceCollector {
     }
 
     /// Runs the piece collector.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn run(&self) -> Receiver<CollectedPiece> {
         let config = self.config.clone();
         let host_id = self.host_id.clone();
@@ -773,7 +773,7 @@ impl PersistentCachePieceCollector {
     /// `collected_piece_tx`, it carries a complete list of available parents, enabling
     /// load-balanced concurrent downloads across different peers.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn collect_from_parents(
         config: Arc<Config>,
         host_id: &str,

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -167,7 +167,7 @@ impl QUICDownloader {
 #[async_trait]
 impl Downloader for QUICDownloader {
     /// Downloads a piece from the other peer by the QUIC protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_piece(
         &self,
         addr: &str,
@@ -193,7 +193,7 @@ impl Downloader for QUICDownloader {
 
     /// Downloads a persistent piece from the other peer by
     /// the QUIC protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_persistent_piece(
         &self,
         addr: &str,
@@ -223,7 +223,7 @@ impl Downloader for QUICDownloader {
 
     /// Downloads a persistent cache piece from the other peer by
     /// the QUIC protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_persistent_cache_piece(
         &self,
         addr: &str,
@@ -319,7 +319,7 @@ impl TCPDownloader {
 #[async_trait]
 impl Downloader for TCPDownloader {
     /// Downloads a piece from the other peer by the TCP protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_piece(
         &self,
         addr: &str,
@@ -345,7 +345,7 @@ impl Downloader for TCPDownloader {
 
     /// Downloads a persistent piece from the other peer by
     /// the TCP protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_persistent_piece(
         &self,
         addr: &str,
@@ -375,7 +375,7 @@ impl Downloader for TCPDownloader {
 
     /// Downloads a persistent cache piece from the other peer by
     /// the TCP protocol.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_persistent_cache_piece(
         &self,
         addr: &str,

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -46,7 +46,7 @@ use dragonfly_client_metric::{
     collect_backend_request_failure_metrics, collect_backend_request_finished_metrics,
     collect_backend_request_started_metrics,
 };
-use dragonfly_client_storage::{metadata, Storage};
+use dragonfly_client_storage::{metadata, Storage, DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL};
 use dragonfly_client_util::{
     http::{hashmap_to_headermap, headermap_to_hashmap},
     id_generator::IDGenerator,
@@ -59,7 +59,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
 use tokio::sync::{
     mpsc::{self, Sender},
@@ -71,6 +71,12 @@ use tonic::{Request, Status};
 use tracing::{debug, error, info, instrument, warn, Instrument};
 
 use super::*;
+
+/// DEFAULT_WAIT_FOR_IN_FLIGHT_PIECE_TIMEOUT is the maximum duration to wait for the
+/// interested pieces being downloaded by other concurrent downloads of the same task
+/// (e.g. the prefetch) to be written to the local storage, before falling back to
+/// downloading with the scheduler.
+const DEFAULT_WAIT_FOR_IN_FLIGHT_PIECE_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Represents a task manager.
 pub struct Task {
@@ -454,6 +460,52 @@ impl Task {
         if interested_pieces.is_empty() {
             info!("all pieces are downloaded from local");
             return Ok(());
+        };
+
+        // If the task is prefetched, the interested pieces are probably being downloaded
+        // by other concurrent downloads of the same task. Wait for the in-flight pieces
+        // to be written to the local storage before downloading with the scheduler, to
+        // avoid the scheduling stall when no candidate parent is available.
+        let interested_pieces = if !request.is_prefetch
+            && self
+                .storage
+                .get_task(task_id)
+                .ok()
+                .flatten()
+                .is_some_and(|task| task.is_prefetched())
+        {
+            let finished_pieces = self
+                .wait_for_in_flight_pieces(
+                    task,
+                    host_id,
+                    peer_id,
+                    request.need_piece_content,
+                    interested_pieces.clone(),
+                    download_progress_tx.clone(),
+                )
+                .await?;
+
+            // Remove the finished pieces from the pieces.
+            let interested_pieces = self
+                .piece
+                .remove_finished_from_interested(finished_pieces, interested_pieces);
+            info!(
+                "interested pieces after waiting for in-flight pieces: {:?}",
+                interested_pieces
+                    .iter()
+                    .map(|p| p.number)
+                    .collect::<Vec<u32>>()
+            );
+
+            // Check if all pieces are downloaded.
+            if interested_pieces.is_empty() {
+                info!("all pieces are downloaded from local");
+                return Ok(());
+            };
+
+            interested_pieces
+        } else {
+            interested_pieces
         };
         debug!("download the pieces with scheduler");
 
@@ -1952,6 +2004,95 @@ impl Task {
         }
 
         Ok(finished_pieces)
+    }
+
+    /// Waits for the interested pieces being downloaded by other concurrent downloads
+    /// of the same task (e.g. the prefetch) to be written to the local storage, and
+    /// downloads the finished ones from the local storage. Stops when all interested
+    /// pieces are finished, none of the remaining pieces is in-flight, or the wait
+    /// timeout is exceeded.
+    #[instrument(level = "debug", skip_all)]
+    async fn wait_for_in_flight_pieces(
+        &self,
+        task: &metadata::Task,
+        host_id: &str,
+        peer_id: &str,
+        need_piece_content: bool,
+        interested_pieces: Vec<metadata::Piece>,
+        download_progress_tx: Sender<Result<DownloadTaskResponse, Status>>,
+    ) -> ClientResult<Vec<metadata::Piece>> {
+        // Get the id of the task.
+        let task_id = task.id.as_str();
+
+        // Initialize the finished pieces.
+        let mut finished_pieces: Vec<metadata::Piece> = Vec::new();
+        let mut interested_pieces = interested_pieces;
+
+        // Total timeout for waiting for the in-flight pieces to be written to the
+        // local storage.
+        let wait_timeout = tokio::time::sleep(DEFAULT_WAIT_FOR_IN_FLIGHT_PIECE_TIMEOUT);
+        tokio::pin!(wait_timeout);
+
+        // Delay the first tick by one interval, giving the concurrent downloads a
+        // chance to start downloading the interested pieces.
+        let mut interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
+            DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
+        );
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    // Download the pieces from the local.
+                    let partial_finished_pieces = self
+                        .download_partial_from_local(
+                            task,
+                            host_id,
+                            peer_id,
+                            need_piece_content,
+                            interested_pieces.clone(),
+                            download_progress_tx.clone(),
+                        )
+                        .await?;
+
+                    // Remove the finished pieces from the pieces.
+                    interested_pieces = self.piece.remove_finished_from_interested(
+                        partial_finished_pieces.clone(),
+                        interested_pieces,
+                    );
+
+                    // Merge the finished pieces.
+                    finished_pieces = self
+                        .piece
+                        .merge_finished_pieces(finished_pieces, partial_finished_pieces);
+
+                    // If all pieces are finished, return.
+                    if interested_pieces.is_empty() {
+                        debug!("wait in-flight pieces finished success");
+                        return Ok(finished_pieces);
+                    }
+
+                    // Stop waiting if none of the remaining interested pieces is in-flight.
+                    // The piece metadata is created when its download starts and removed
+                    // when its download fails, so the remaining pieces without metadata
+                    // will not be written to the local storage soon.
+                    let has_in_flight_piece = interested_pieces.iter().any(|interested_piece| {
+                        matches!(
+                            self.piece
+                                .get(self.piece.id(task_id, interested_piece.number).as_str()),
+                            Ok(Some(_))
+                        )
+                    });
+
+                    if !has_in_flight_piece {
+                        return Ok(finished_pieces);
+                    }
+                }
+                _ = &mut wait_timeout => {
+                    return Ok(finished_pieces);
+                }
+            }
+        }
     }
 
     /// Downloads a partial task from the source.

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -2468,46 +2468,34 @@ mod tests {
     use std::sync::Arc;
     use tempfile::tempdir;
 
-    // test_delete_task_not_found tests the Task.delete method when the task does not exist.
     #[tokio::test]
     async fn test_delete_task_not_found() {
-        // Create a temporary directory for testing.
         let temp_dir = tempdir().unwrap();
         let log_dir = temp_dir.path().join("log");
         std::fs::create_dir_all(&log_dir).unwrap();
 
-        // Create configuration.
         let config = Config::default();
         let config = Arc::new(config);
 
-        // Create storage.
         let storage = Storage::new(config.clone(), temp_dir.path(), log_dir)
             .await
             .unwrap();
         let storage = Arc::new(storage);
 
-        // Test Storage.get_task and Error::TaskNotFound.
         let task_id = "non-existent-task-id";
-
-        // Verify that non-existent tasks return None.
         let task = storage.get_task(task_id).unwrap();
         assert!(task.is_none(), "non-existent tasks should return None");
 
-        // Create a task and save it to storage.
         let task_id = "test-task-id";
         storage
             .download_task_started(task_id, 1024, 4096, None)
             .await
             .unwrap();
 
-        // Verify that the task exists.
         let task = storage.get_task(task_id).unwrap();
         assert!(task.is_some(), "task should exist");
 
-        // Delete the task from storage.
         storage.delete_task(task_id).await;
-
-        // Verify that the task has been deleted.
         let task = storage.get_task(task_id).unwrap();
         assert!(task.is_none(), "task should be deleted");
     }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -142,7 +142,7 @@ impl Task {
     }
 
     /// Gets the metadata of the task.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn get(&self, id: &str) -> ClientResult<Option<metadata::Task>> {
         self.storage.get_task(id)
     }
@@ -300,25 +300,25 @@ impl Task {
     }
 
     /// Updates the metadata of the task when the task downloads finished.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.download_task_finished(id)
     }
 
     /// Updates the metadata of the task when the task downloads failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         self.storage.download_task_failed(id).await.map(|_| ())
     }
 
     /// Updates the metadata of the task when the task prefetch started.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn prefetch_task_started(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_started(id).await
     }
 
     /// Updates the metadata of the task when the task prefetch failed.
-    #[instrument(skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn prefetch_task_failed(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_failed(id).await
     }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -142,13 +142,13 @@ impl Task {
     }
 
     /// Gets the metadata of the task.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn get(&self, id: &str) -> ClientResult<Option<metadata::Task>> {
         self.storage.get_task(id)
     }
 
     /// Updates the metadata of the task when the task downloads started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_started(
         &self,
         id: &str,
@@ -300,25 +300,25 @@ impl Task {
     }
 
     /// Updates the metadata of the task when the task downloads finished.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub fn download_finished(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.download_task_finished(id)
     }
 
     /// Updates the metadata of the task when the task downloads failed.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_failed(&self, id: &str) -> ClientResult<()> {
         self.storage.download_task_failed(id).await.map(|_| ())
     }
 
     /// Updates the metadata of the task when the task prefetch started.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn prefetch_task_started(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_started(id).await
     }
 
     /// Updates the metadata of the task when the task prefetch failed.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn prefetch_task_failed(&self, id: &str) -> ClientResult<metadata::Task> {
         self.storage.prefetch_task_failed(id).await
     }
@@ -329,14 +329,14 @@ impl Task {
     }
 
     //// copy_task copies the task content to the destination.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn copy_task(&self, id: &str, to: &Path) -> ClientResult<()> {
         self.storage.copy_task(id, to).await
     }
 
     /// Downloads a task.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download(
         &self,
         task: &metadata::Task,
@@ -601,7 +601,7 @@ impl Task {
 
     /// Downloads a task and announces the peer to the scheduler, even if all pieces are
     /// hit in the local cache.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn download_and_ensure_announcement(
         &self,
         task: &metadata::Task,
@@ -631,7 +631,7 @@ impl Task {
 
     /// Downloads a partial task with scheduler.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler(
         &self,
         task: &metadata::Task,
@@ -1064,7 +1064,7 @@ impl Task {
     /// reports the metadata of the peer to the scheduler by the register request with the
     /// metadata_only flag and the download peer started/finished requests, no pieces need
     /// to be downloaded.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_local(
         &self,
         task: &metadata::Task,
@@ -1189,7 +1189,7 @@ impl Task {
 
     /// Downloads a partial task with scheduler from a parent.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_parent(
         &self,
         task: &metadata::Task,
@@ -1546,7 +1546,7 @@ impl Task {
 
     /// Downloads a partial task with scheduler from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_with_scheduler_from_source(
         &self,
         task: &metadata::Task,
@@ -1870,7 +1870,7 @@ impl Task {
 
     /// Downloads a partial task from a local.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_from_local(
         &self,
         task: &metadata::Task,
@@ -2011,7 +2011,7 @@ impl Task {
     /// downloads the finished ones from the local storage. Stops when all interested
     /// pieces are finished, none of the remaining pieces is in-flight, or the wait
     /// timeout is exceeded.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn wait_for_in_flight_pieces(
         &self,
         task: &metadata::Task,
@@ -2097,7 +2097,7 @@ impl Task {
 
     /// Downloads a partial task from the source.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     async fn download_partial_from_source(
         &self,
         task: &metadata::Task,
@@ -2327,7 +2327,7 @@ impl Task {
     }
 
     /// Returns the task metadata from scheduler.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat(&self, task_id: &str, host_id: &str) -> ClientResult<CommonTask> {
         self.scheduler_client
             .stat_task(StatTaskRequest {
@@ -2341,7 +2341,7 @@ impl Task {
     }
 
     /// Returns the task metadata from local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn stat_local(&self, task_id: &str) -> ClientResult<StatLocalTaskResponse> {
         let Some(task) = self.get(task_id).inspect_err(|err| {
             error!("get task {} from local storage error: {:?}", task_id, err);
@@ -2366,7 +2366,7 @@ impl Task {
     }
 
     /// Returns the tasks from local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn list_local(&self) -> ClientResult<ListLocalTasksResponse> {
         let tasks = self.storage.get_tasks().inspect_err(|err| {
             error!("list tasks from local storage error: {:?}", err);
@@ -2393,7 +2393,7 @@ impl Task {
     }
 
     /// Delete a task and reclaim local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn delete(&self, task_id: &str, host_id: &str) -> ClientResult<()> {
         let task = self.get(task_id).inspect_err(|err| {
             error!("get task {} from local storage error: {:?}", task_id, err);
@@ -2424,7 +2424,7 @@ impl Task {
     }
 
     /// Delete a local task and reclaim local storage.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(skip_all)]
     pub async fn delete_local(&self, task_id: &str) -> ClientResult<()> {
         let task = self.get(task_id).inspect_err(|err| {
             error!("get task {} from local storage error: {:?}", task_id, err);

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -46,12 +46,13 @@ use dragonfly_client_metric::{
     collect_backend_request_failure_metrics, collect_backend_request_finished_metrics,
     collect_backend_request_started_metrics,
 };
-use dragonfly_client_storage::{metadata, Storage, DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL};
+use dragonfly_client_storage::{metadata, Storage};
 use dragonfly_client_util::{
     http::{hashmap_to_headermap, headermap_to_hashmap},
     id_generator::IDGenerator,
     shutdown,
 };
+use futures::future::select_all;
 use leaky_bucket::RateLimiter;
 use reqwest::header::HeaderMap;
 use std::path::Path;
@@ -63,7 +64,7 @@ use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
 use tokio::sync::{
     mpsc::{self, Sender},
-    Mutex, Semaphore,
+    Mutex, Notify, Semaphore,
 };
 use tokio::task::JoinSet;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
@@ -2033,61 +2034,80 @@ impl Task {
         let wait_timeout = tokio::time::sleep(DEFAULT_WAIT_FOR_IN_FLIGHT_PIECE_TIMEOUT);
         tokio::pin!(wait_timeout);
 
-        // Delay the first tick by one interval, giving the concurrent downloads a
-        // chance to start downloading the interested pieces.
-        let mut interval = tokio::time::interval_at(
-            tokio::time::Instant::now() + DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
-            DEFAULT_WAIT_FOR_PIECE_FINISHED_INTERVAL,
-        );
-
         loop {
+            // Subscribe to the completion of the interested pieces before checking
+            // the local storage, so completions signaled during the check are not
+            // missed. The completion notifier is registered when the piece download
+            // starts and removed when it completes, so the pieces without a
+            // notifier are not in-flight and will not be written to the local
+            // storage soon.
+            let notifiers: Vec<(u32, Arc<Notify>)> = interested_pieces
+                .iter()
+                .filter_map(|interested_piece| {
+                    self.storage
+                        .in_flight_piece_notifier(
+                            self.piece.id(task_id, interested_piece.number).as_str(),
+                        )
+                        .map(|notifier| (interested_piece.number, notifier))
+                })
+                .collect();
+
+            let mut notifieds: Vec<(u32, _)> = notifiers
+                .iter()
+                .map(|(number, notifier)| {
+                    let mut notified = Box::pin(notifier.notified());
+                    // Enable the notified future, so a completion signaled before
+                    // the select below still wakes it.
+                    notified.as_mut().enable();
+                    (*number, notified)
+                })
+                .collect();
+
+            // Download the pieces from the local.
+            let partial_finished_pieces = self
+                .download_partial_from_local(
+                    task,
+                    host_id,
+                    peer_id,
+                    need_piece_content,
+                    interested_pieces.clone(),
+                    download_progress_tx.clone(),
+                )
+                .await?;
+
+            // Remove the finished pieces from the pieces.
+            interested_pieces = self.piece.remove_finished_from_interested(
+                partial_finished_pieces.clone(),
+                interested_pieces,
+            );
+
+            // Merge the finished pieces.
+            finished_pieces = self
+                .piece
+                .merge_finished_pieces(finished_pieces, partial_finished_pieces);
+
+            // If all pieces are finished, return.
+            if interested_pieces.is_empty() {
+                debug!("wait in-flight pieces finished success");
+                return Ok(finished_pieces);
+            }
+
+            // Keep only the subscriptions of the remaining interested pieces.
+            notifieds.retain(|(number, _)| {
+                interested_pieces
+                    .iter()
+                    .any(|interested_piece| interested_piece.number == *number)
+            });
+
+            // Stop waiting if none of the remaining interested pieces is in-flight.
+            if notifieds.is_empty() {
+                return Ok(finished_pieces);
+            }
+
+            // Wait for any of the in-flight pieces to complete, then collect it
+            // from the local storage in the next iteration.
             tokio::select! {
-                _ = interval.tick() => {
-                    // Download the pieces from the local.
-                    let partial_finished_pieces = self
-                        .download_partial_from_local(
-                            task,
-                            host_id,
-                            peer_id,
-                            need_piece_content,
-                            interested_pieces.clone(),
-                            download_progress_tx.clone(),
-                        )
-                        .await?;
-
-                    // Remove the finished pieces from the pieces.
-                    interested_pieces = self.piece.remove_finished_from_interested(
-                        partial_finished_pieces.clone(),
-                        interested_pieces,
-                    );
-
-                    // Merge the finished pieces.
-                    finished_pieces = self
-                        .piece
-                        .merge_finished_pieces(finished_pieces, partial_finished_pieces);
-
-                    // If all pieces are finished, return.
-                    if interested_pieces.is_empty() {
-                        debug!("wait in-flight pieces finished success");
-                        return Ok(finished_pieces);
-                    }
-
-                    // Stop waiting if none of the remaining interested pieces is in-flight.
-                    // The piece metadata is created when its download starts and removed
-                    // when its download fails, so the remaining pieces without metadata
-                    // will not be written to the local storage soon.
-                    let has_in_flight_piece = interested_pieces.iter().any(|interested_piece| {
-                        matches!(
-                            self.piece
-                                .get(self.piece.id(task_id, interested_piece.number).as_str()),
-                            Ok(Some(_))
-                        )
-                    });
-
-                    if !has_in_flight_piece {
-                        return Ok(finished_pieces);
-                    }
-                }
+                _ = select_all(notifieds.iter_mut().map(|(_, notified)| notified)) => {}
                 _ = &mut wait_timeout => {
                     return Ok(finished_pieces);
                 }

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -2056,8 +2056,6 @@ impl Task {
                 .iter()
                 .map(|(number, notifier)| {
                     let mut notified = Box::pin(notifier.notified());
-                    // Enable the notified future, so a completion signaled before
-                    // the select below still wakes it.
                     notified.as_mut().enable();
                     (*number, notified)
                 })

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -508,9 +508,40 @@ impl Task {
         } else {
             interested_pieces
         };
-        debug!("download the pieces with scheduler");
+
+        // If the seed peer is enabled and the range length is less than or equal to the max piece
+        // length, download the pieces from the source directly.
+        if self.config.seed_peer.enable
+            && !request.disable_back_to_source
+            && request
+                .range
+                .is_some_and(|range| range.length <= super::piece::MAX_PIECE_LENGTH)
+        {
+            debug!(
+                "seed peer downloads the range task from source directly, skipping the scheduler"
+            );
+
+            if let Err(err) = self
+                .download_partial_from_source(
+                    task,
+                    host_id,
+                    peer_id,
+                    interested_pieces.clone(),
+                    request.clone(),
+                    download_progress_tx.clone(),
+                )
+                .await
+            {
+                error!("download from source error: {:?}", err);
+                return Err(err);
+            }
+
+            info!("all pieces are downloaded from source");
+            return Ok(());
+        }
 
         // Download the pieces with scheduler.
+        debug!("download the pieces with scheduler");
         let finished_pieces = match self
             .download_partial_with_scheduler(
                 task,
@@ -603,7 +634,7 @@ impl Task {
     /// Downloads a task and announces the peer to the scheduler, even if all pieces are
     /// hit in the local cache.
     #[instrument(skip_all)]
-    pub async fn download_and_ensure_announcement(
+    pub async fn download_with_scheduler(
         &self,
         task: &metadata::Task,
         host_id: &str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request standardizes and simplifies tracing instrumentation across multiple backend and client modules. The main change is the removal of the explicit `level = "debug"` parameter from the `#[instrument]` macro in function annotations, defaulting to the macro's standard logging level. Additionally, the `info!` log in one location is downgraded to `debug!` for consistency. A few files also add missing `instrument` imports.

The most important changes are:

**Tracing instrumentation simplification:**

* Removed the explicit `level = "debug"` argument from all `#[instrument]` macro usages in backend and client methods, relying on the default log level instead. This affects methods such as `stat`, `get`, `put`, and `exists` in `hdfs.rs`, `object_storage.rs`, `http.rs`, and similar methods in `hugging_face.rs`, `model_scope.rs`, and client methods in `quic.rs` and `tcp.rs`. [[1]](diffhunk://#diff-cd1d5e18ab53a872f52409d8f57a522927798574e1bd8a3d6b9523ba20b9c661L117-R117) [[2]](diffhunk://#diff-cd1d5e18ab53a872f52409d8f57a522927798574e1bd8a3d6b9523ba20b9c661L200-R200) [[3]](diffhunk://#diff-cd1d5e18ab53a872f52409d8f57a522927798574e1bd8a3d6b9523ba20b9c661L272-R278) [[4]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL385-R385) [[5]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL658-R658) [[6]](diffhunk://#diff-f54c33c0ce074f6cd19d4a52f22bc25e5d0b9181fa00bddb3aaa9fb76b0276acL805-R805) [[7]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L611-R611) [[8]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L698-R698) [[9]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L776-R776) [[10]](diffhunk://#diff-aa82735c59a36c00c1b1bbc938f96d6e5f0d02f86eebdc05e9b8120356da6e37L878-R878) [[11]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L62-R62) [[12]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L86-R86) [[13]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L120-R120) [[14]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L140-R140) [[15]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L177-R177) [[16]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L197-R197) [[17]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L233-R233) [[18]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L295-R295) [[19]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L313-R313) [[20]](diffhunk://#diff-db71b7660172d45fc8969c9de9063b8a94f52782f017b6763d464604d6be49d8L350-R350) [[21]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL57-R57) [[22]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL81-R81) [[23]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL116-R116) [[24]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL136-R136) [[25]](diffhunk://#diff-310d4eac37200650a61284af74174f541446de46c9086dca1e90998dcab4916dL174-R174)

* Added missing `instrument` imports in `hugging_face.rs` and `model_scope.rs` to support new annotations. [[1]](diffhunk://#diff-538aec6acde94f21db33ba6de2ccdc27583d18b2ab70d82d0cfc0de61d5785f4L55-R55) [[2]](diffhunk://#diff-1c182b5a3db9f84889b643bc7e5d21f6152dde50f1d3a15f06d3d6ef0c777afbL55-R55)

**Logging level adjustment:**

* Changed a log statement in `http.rs` from `info!` to `debug!` when handling a 416 Range Not Satisfiable response, ensuring consistent log verbosity.

**Code consistency:**

* Ensured all backend and client methods that perform network operations now have consistent tracing instrumentation, improving debugging and observability. [[1]](diffhunk://#diff-538aec6acde94f21db33ba6de2ccdc27583d18b2ab70d82d0cfc0de61d5785f4R362) [[2]](diffhunk://#diff-538aec6acde94f21db33ba6de2ccdc27583d18b2ab70d82d0cfc0de61d5785f4R573) [[3]](diffhunk://#diff-538aec6acde94f21db33ba6de2ccdc27583d18b2ab70d82d0cfc0de61d5785f4R675) [[4]](diffhunk://#diff-1c182b5a3db9f84889b643bc7e5d21f6152dde50f1d3a15f06d3d6ef0c777afbR338) [[5]](diffhunk://#diff-1c182b5a3db9f84889b643bc7e5d21f6152dde50f1d3a15f06d3d6ef0c777afbR549-R551) [[6]](diffhunk://#diff-1c182b5a3db9f84889b643bc7e5d21f6152dde50f1d3a15f06d3d6ef0c777afbR643-R649)

**Minor cleanup:**

* Removed an unused `info` import from `http.rs`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
