### PR TITLE
feat(dfdaemon): support size-based log  and add dfdaemon logging configuration

### DIFF
--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -15,6 +15,7 @@
  */
 
 use anyhow::Context;
+use bytesize::ByteSize;
 use clap::Parser;
 use dragonfly_client::announcer::SchedulerAnnouncer;
 use dragonfly_client::dynconfig::Dynconfig;
@@ -110,6 +111,14 @@ struct Args {
 
     #[arg(
         long,
+        default_value_t = ByteSize::default(),
+        env = "DFDAEMON_LOG_MAX_FILE_SIZE",
+        help = "Specify the max size of each log file"
+    )]
+    log_max_file_size: ByteSize,
+
+    #[arg(
+        long,
         default_value_t = false,
         env = "DFDAEMON_CONSOLE",
         help = "Specify whether to print logs to the console. If enabled, logs will not be written to the local log files"
@@ -167,6 +176,7 @@ async fn main() -> Result<(), anyhow::Error> {
         args.log_dir.clone(),
         args.log_level,
         args.log_max_files,
+        args.log_max_file_size,
         config.tracing.protocol.clone(),
         config.tracing.endpoint.clone(),
         config.tracing.path.clone(),
@@ -565,11 +575,23 @@ async fn main() -> Result<(), anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use anyhow::Context;
     use dragonfly_client::health::Health;
     use dragonfly_client_util::shutdown;
     use std::net::{Ipv4Addr, TcpListener};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn logging_uses_cli_defaults_when_options_are_omitted() {
+        let args = Args::try_parse_from(["dfdaemon"]).unwrap();
+
+        assert_eq!(args.log_level, Level::INFO);
+        assert_eq!(args.log_dir, dfdaemon::default_dfdaemon_log_dir());
+        assert_eq!(args.log_max_files, 6);
+        assert_eq!(args.log_max_file_size, ByteSize::default());
+        assert!(!args.console);
+    }
 
     #[tokio::test]
     async fn background_server_panic_propagates_with_context() {

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -111,7 +111,7 @@ struct Args {
 
     #[arg(
         long,
-        default_value_t = ByteSize::default(),
+        default_value = "1GiB",
         env = "DFDAEMON_LOG_MAX_FILE_SIZE",
         help = "Specify the max size of each log file"
     )]
@@ -585,11 +585,10 @@ mod tests {
     #[test]
     fn logging_uses_cli_defaults_when_options_are_omitted() {
         let args = Args::try_parse_from(["dfdaemon"]).unwrap();
-
         assert_eq!(args.log_level, Level::INFO);
         assert_eq!(args.log_dir, dfdaemon::default_dfdaemon_log_dir());
         assert_eq!(args.log_max_files, 6);
-        assert_eq!(args.log_max_file_size, ByteSize::default());
+        assert_eq!(args.log_max_file_size, ByteSize::gib(1));
         assert!(!args.console);
     }
 

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -38,13 +38,6 @@ use tracing_subscriber::{
 /// The timeout for the span exporter.
 const SPAN_EXPORTER_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn rolling_condition(max_file_size: ByteSize) -> RollingConditionBasic {
-    match max_file_size.as_u64() {
-        0 => RollingConditionBasic::new().hourly(),
-        size => RollingConditionBasic::new().hourly().max_size(size),
-    }
-}
-
 /// Initializes the tracing system.
 #[allow(clippy::too_many_arguments)]
 pub fn init_tracing(
@@ -82,7 +75,7 @@ pub fn init_tracing(
     } else {
         let appender = BasicRollingFileAppender::new(
             log_dir.join(name).with_extension("log"),
-            rolling_condition(log_max_file_size),
+            RollingConditionBasic::new().max_size(log_max_file_size.as_u64()),
             log_max_files,
         )
         .expect("failed to create rolling file appender");
@@ -271,14 +264,16 @@ mod tests {
     fn zero_max_file_size_disables_size_based_rotation() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let log_path = temp_dir.path().join("dfdaemon.log");
-        let mut appender =
-            BasicRollingFileAppender::new(&log_path, rolling_condition(ByteSize::default()), 6)
-                .expect("failed to create rolling file appender");
+        let mut appender = BasicRollingFileAppender::new(
+            &log_path,
+            RollingConditionBasic::new().max_size(ByteSize::gib(1).as_u64()),
+            6,
+        )
+        .expect("failed to create rolling file appender");
 
         appender.write_all(b"first").unwrap();
         appender.write_all(b"second").unwrap();
         appender.flush().unwrap();
-
         assert!(!log_path.with_extension("log.1").exists());
     }
 
@@ -286,14 +281,16 @@ mod tests {
     fn positive_max_file_size_enables_size_based_rotation() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let log_path = temp_dir.path().join("dfdaemon.log");
-        let mut appender =
-            BasicRollingFileAppender::new(&log_path, rolling_condition(ByteSize::b(4)), 6)
-                .expect("failed to create rolling file appender");
+        let mut appender = BasicRollingFileAppender::new(
+            &log_path,
+            RollingConditionBasic::new().max_size(ByteSize::b(4).as_u64()),
+            6,
+        )
+        .expect("failed to create rolling file appender");
 
         appender.write_all(b"1234").unwrap();
         appender.write_all(b"5").unwrap();
         appender.flush().unwrap();
-
         assert!(log_path.with_extension("log.1").exists());
     }
 

--- a/dragonfly-client/src/tracing/mod.rs
+++ b/dragonfly-client/src/tracing/mod.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use bytesize::ByteSize;
 use dragonfly_client_config::dfdaemon::Host;
 use opentelemetry::{global, trace::TracerProvider, KeyValue};
 use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
@@ -37,6 +38,13 @@ use tracing_subscriber::{
 /// The timeout for the span exporter.
 const SPAN_EXPORTER_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn rolling_condition(max_file_size: ByteSize) -> RollingConditionBasic {
+    match max_file_size.as_u64() {
+        0 => RollingConditionBasic::new().hourly(),
+        size => RollingConditionBasic::new().hourly().max_size(size),
+    }
+}
+
 /// Initializes the tracing system.
 #[allow(clippy::too_many_arguments)]
 pub fn init_tracing(
@@ -44,6 +52,7 @@ pub fn init_tracing(
     log_dir: PathBuf,
     log_level: Level,
     log_max_files: usize,
+    log_max_file_size: ByteSize,
     otel_protocol: Option<String>,
     otel_endpoint: Option<String>,
     otel_path: Option<PathBuf>,
@@ -73,7 +82,7 @@ pub fn init_tracing(
     } else {
         let appender = BasicRollingFileAppender::new(
             log_dir.join(name).with_extension("log"),
-            RollingConditionBasic::new().hourly(),
+            rolling_condition(log_max_file_size),
             log_max_files,
         )
         .expect("failed to create rolling file appender");
@@ -255,7 +264,38 @@ pub fn init_command_tracing(log_level: Level, console: bool) -> Vec<WorkerGuard>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tempfile::TempDir;
+
+    #[test]
+    fn zero_max_file_size_disables_size_based_rotation() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let log_path = temp_dir.path().join("dfdaemon.log");
+        let mut appender =
+            BasicRollingFileAppender::new(&log_path, rolling_condition(ByteSize::default()), 6)
+                .expect("failed to create rolling file appender");
+
+        appender.write_all(b"first").unwrap();
+        appender.write_all(b"second").unwrap();
+        appender.flush().unwrap();
+
+        assert!(!log_path.with_extension("log.1").exists());
+    }
+
+    #[test]
+    fn positive_max_file_size_enables_size_based_rotation() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let log_path = temp_dir.path().join("dfdaemon.log");
+        let mut appender =
+            BasicRollingFileAppender::new(&log_path, rolling_condition(ByteSize::b(4)), 6)
+                .expect("failed to create rolling file appender");
+
+        appender.write_all(b"1234").unwrap();
+        appender.write_all(b"5").unwrap();
+        appender.flush().unwrap();
+
+        assert!(log_path.with_extension("log.1").exists());
+    }
 
     #[test]
     fn test_init_tracing_comprehensive() {
@@ -268,6 +308,7 @@ mod tests {
             log_dir.clone(),
             Level::INFO,
             10,
+            ByteSize::default(),
             None,
             None,
             None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request introduces a comprehensive logging configuration system for `dfdaemon`, allowing logging parameters to be specified via both configuration files and command-line arguments, with command-line options taking precedence. It adds a new `Logging` struct to the configuration, supports more granular control over log file rotation (including maximum file size), and ensures robust testing for these features. The changes also refactor the code to consistently apply logging settings throughout the application.

**Logging configuration enhancements:**

* Introduced a new `Logging` struct to the `Config` for `dfdaemon`, supporting fields for log level, directory, maximum number of files, maximum file size, and console output. This struct is fully deserializable and has sensible defaults. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1540-R1579) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1743-R1746)
* Added helper functions for default values and deserialization logic for logging fields, including parsing the log level from strings.

**Command-line integration and override logic:**

* Updated the CLI argument parsing in `main.rs` to allow optional overrides for all logging settings, and implemented logic to merge CLI arguments with configuration file values, giving precedence to CLI options. [[1]](diffhunk://#diff-604c5c398a2f3dd79f31b1303d9afebc0bc90d4d11a11f4764893bd5ffa54070L89-R120) [[2]](diffhunk://#diff-604c5c398a2f3dd79f31b1303d9afebc0bc90d4d11a11f4764893bd5ffa54070R133-R163) [[3]](diffhunk://#diff-604c5c398a2f3dd79f31b1303d9afebc0bc90d4d11a11f4764893bd5ffa54070R189-R213)

**Log rotation improvements:**

* Enhanced the tracing initialization to support hourly log rotation with an optional maximum file size; if the size is set to zero, only time-based rotation is used. [[1]](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R48) [[2]](diffhunk://#diff-0bb89dc9b5d2ef0bccfaf41d4a4255fc6cad63be28c3890f60110dad2e62cc79R76-R82)

**Testing:**

* Added comprehensive unit tests to verify default logging configuration, deserialization from YAML, correct application of CLI overrides, and fallback to config defaults when CLI options are omitted. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1845-R1882) [[2]](diffhunk://#diff-604c5c398a2f3dd79f31b1303d9afebc0bc90d4d11a11f4764893bd5ffa54070R601-R674)

**Codebase consistency:**

* Refactored code to consistently use the new logging configuration in all relevant places, including storage initialization and tracing setup.

These changes make logging configuration more flexible, robust, and user-friendly for `dfdaemon`.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
Set the maximum rotation size to 8KiB
<img width="3818" height="416" alt="image" src="https://github.com/user-attachments/assets/fe75a983-1891-496e-85e1-f9ffc3c97b1b" />
Exceeds 8KiB, normal rotation is performed.
<img width="1520" height="368" alt="image" src="https://github.com/user-attachments/assets/4d4b58c1-39e4-47cd-b3b5-dbf63badf19e" />

