### PR TITLE
Update debug message for accuracy in logging

### DIFF
--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -517,9 +517,7 @@ impl Task {
                 .is_some_and(|range| range.length <= super::piece::MIN_PIECE_LENGTH)
                 || content_length <= super::piece::MIN_PIECE_LENGTH)
         {
-            debug!(
-                "seed peer downloads the range task from source directly, skipping the scheduler"
-            );
+            debug!("peer downloads the range task from source directly, skipping the scheduler");
 
             if let Err(err) = self
                 .download_partial_from_source(


### PR DESCRIPTION
Fixes debug log to use "peer" instead of "seed peer" for accuracy.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to a debug log message in the `Task` implementation. The message is now more generic, changing "seed peer" to "peer" to better reflect the code's behavior.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
