### PR TITLE
refactor(dynconfig): make manager addr optional, unify refresh interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,6 @@ dependencies = [
  "http 1.4.2",
  "http-body-util",
  "humantime",
- "humantime-serde",
  "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -2116,7 +2116,7 @@ key: /etc/ssl/private/client.pem
     #[test]
     fn default_dynconfig() {
         let default_dynconfig = Dynconfig::default();
-        assert_eq!(default_dynconfig.refresh_interval, Duration::from_secs(300));
+        assert_eq!(default_dynconfig.refresh_interval, Duration::from_secs(60));
     }
 
     #[test]

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -52,7 +52,7 @@ pub fn default_dfdaemon_config_path() -> PathBuf {
 }
 
 /// Returns the default dynconfig path for dfdaemon, which is used when the
-/// manager is not configured.
+/// manager address is not configured.
 #[inline]
 pub fn default_dfdaemon_dynconfig_path() -> PathBuf {
     crate::default_config_dir().join("dynconfig.yaml")
@@ -244,12 +244,6 @@ fn default_scheduler_schedule_timeout() -> Duration {
 /// Returns the default interval to refresh dynamic configuration from manager.
 #[inline]
 fn default_dynconfig_refresh_interval() -> Duration {
-    Duration::from_secs(300)
-}
-
-/// Returns the default interval to refresh the local dynamic configuration.
-#[inline]
-pub fn default_local_dynconfig_refresh_interval() -> Duration {
     Duration::from_secs(60)
 }
 
@@ -709,8 +703,10 @@ impl Default for Upload {
 #[derive(Debug, Clone, Default, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Manager {
-    /// The manager address.
-    pub addr: String,
+    /// The manager address. If not configured, the dynamic configuration is
+    /// loaded from the local dynconfig file instead of being fetched from the
+    /// manager.
+    pub addr: Option<String>,
 
     /// The root CA cert path with PEM format for the manager, and it is used
     /// for mutual TLS.
@@ -1640,11 +1636,9 @@ pub struct Config {
     #[validate]
     pub upload: Upload,
 
-    /// The manager configuration for dfdaemon. If not configured, the dynamic
-    /// configuration is loaded from the local dynconfig file instead of being
-    /// fetched from the manager.
+    /// The manager configuration for dfdaemon.
     #[validate]
-    pub manager: Option<Manager>,
+    pub manager: Manager,
 
     /// The scheduler configuration for dfdaemon.
     #[validate]
@@ -2005,7 +1999,7 @@ mod tests {
         fs::write(&key_path, "Client key content").await.unwrap();
 
         let manager = Manager {
-            addr: "http://example.com".to_string(),
+            addr: Some("http://example.com".to_string()),
             ca_cert: Some(ca_path),
             cert: Some(cert_path),
             key: Some(key_path),
@@ -2024,7 +2018,10 @@ addr: http://another-service:8080
 "#;
 
         let manager: Manager = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(manager.addr, "http://another-service:8080");
+        assert_eq!(
+            manager.addr,
+            Some("http://another-service:8080".to_string())
+        );
         assert!(manager.ca_cert.is_none());
         assert!(manager.cert.is_none());
         assert!(manager.key.is_none());
@@ -2040,7 +2037,10 @@ key: /etc/ssl/private/client.pem
 "#;
 
         let manager: Manager = serde_yaml::from_str(yaml).expect("Failed to deserialize");
-        assert_eq!(manager.addr, "http://manager-service:65003");
+        assert_eq!(
+            manager.addr,
+            Some("http://manager-service:65003".to_string())
+        );
         assert_eq!(
             manager.ca_cert,
             Some(PathBuf::from("/etc/ssl/certs/ca.crt"))

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -66,7 +66,6 @@ anyhow.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
 humantime.workspace = true
-humantime-serde.workspace = true
 uuid.workspace = true
 percent-encoding.workspace = true
 tokio-rustls.workspace = true

--- a/dragonfly-client/src/dynconfig/local.rs
+++ b/dragonfly-client/src/dynconfig/local.rs
@@ -27,17 +27,14 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::fs;
 use tokio::net::lookup_host;
-use tokio::sync::RwLock;
 use tonic_health::pb::health_check_response::ServingStatus;
 use tracing::{error, info, instrument};
 use url::Url;
 
 use dragonfly_client_config::dfdaemon::{
-    default_local_dynconfig_refresh_interval, default_local_dynconfig_scheduler_addr,
-    Config as DfdaemonConfig,
+    default_local_dynconfig_scheduler_addr, Config as DfdaemonConfig,
 };
 
 /// The scheduler configuration for the local dynamic configuration.
@@ -71,13 +68,6 @@ impl Default for Scheduler {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Config {
-    /// The interval to refresh the local dynamic configuration.
-    #[serde(
-        default = "default_local_dynconfig_refresh_interval",
-        with = "humantime_serde"
-    )]
-    pub refresh_interval: Duration,
-
     /// The scheduler configuration for scheduler discovery.
     pub scheduler: Scheduler,
 
@@ -94,7 +84,6 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            refresh_interval: default_local_dynconfig_refresh_interval(),
             scheduler: Scheduler::default(),
             client_config: None,
             seed_client_config: None,
@@ -110,26 +99,13 @@ pub struct Local {
 
     /// Path of the local dynconfig file.
     path: PathBuf,
-
-    /// The interval to refresh the local dynamic configuration, updated from
-    /// the file on each refresh.
-    refresh_interval: RwLock<Duration>,
 }
 
 /// The implementation of Local.
 impl Local {
     /// Creates a new local backend.
     pub fn new(config: Arc<DfdaemonConfig>, path: PathBuf) -> Self {
-        Self {
-            config,
-            path,
-            refresh_interval: RwLock::new(default_local_dynconfig_refresh_interval()),
-        }
-    }
-
-    /// Returns the interval to refresh the local dynamic configuration.
-    pub async fn refresh_interval(&self) -> Duration {
-        *self.refresh_interval.read().await
+        Self { config, path }
     }
 
     /// Generates the default dynconfig file if it does not exist.
@@ -162,9 +138,6 @@ impl Local {
             error!("read dynconfig {} failed: {}", self.path.display(), err);
         })?;
         let config: Config = serde_yaml::from_str(&content).or_err(ErrorType::ConfigError)?;
-
-        // Update the refresh interval from the file.
-        *self.refresh_interval.write().await = config.refresh_interval;
 
         // Discover the schedulers from the static address list or by DNS.
         let schedulers = match config.scheduler.addrs.as_deref() {
@@ -339,7 +312,6 @@ mod tests {
     #[test]
     fn deserialize_local_config_correctly() {
         let yaml = r#"
-refreshInterval: 10s
 scheduler:
   addr: 'scheduler-headless.default.svc:8002'
 clientConfig:
@@ -381,7 +353,6 @@ seedClientConfig:
 "#;
 
         let config: Config = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(config.refresh_interval, Duration::from_secs(10));
         assert_eq!(config.scheduler.addr, "scheduler-headless.default.svc:8002");
 
         let block_list = config.client_config.unwrap().block_list.unwrap();
@@ -408,10 +379,6 @@ scheduler:
 "#;
 
         let config: Config = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(
-            config.refresh_interval,
-            default_local_dynconfig_refresh_interval()
-        );
         assert!(config.client_config.is_none());
         assert!(config.seed_client_config.is_none());
     }
@@ -423,10 +390,7 @@ scheduler:
         let path = dir.path().join("dynconfig.yaml");
         tokio::fs::write(
             &path,
-            format!(
-                "refreshInterval: 10s\nscheduler:\n  addr: 'localhost:{}'\n",
-                health_addr.port()
-            ),
+            format!("scheduler:\n  addr: 'localhost:{}'\n", health_addr.port()),
         )
         .await
         .unwrap();
@@ -439,7 +403,6 @@ scheduler:
             .iter()
             .all(|scheduler| scheduler.port == health_addr.port() as i32));
         assert!(data.available_scheduler_cluster_id.is_none());
-        assert_eq!(local.refresh_interval().await, Duration::from_secs(10));
     }
 
     #[tokio::test]
@@ -455,10 +418,6 @@ scheduler:
         assert_eq!(
             config.scheduler.addr,
             default_local_dynconfig_scheduler_addr()
-        );
-        assert_eq!(
-            config.refresh_interval,
-            default_local_dynconfig_refresh_interval()
         );
     }
 

--- a/dragonfly-client/src/dynconfig/mod.rs
+++ b/dragonfly-client/src/dynconfig/mod.rs
@@ -26,7 +26,6 @@ use remote::Remote;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{debug, error, info, instrument};
 
@@ -150,9 +149,9 @@ pub struct Data {
     pub seed_client_config: Option<SchedulerClusterSeedClientConfig>,
 }
 
-/// Backend of the dynamic configuration. When the manager is configured, the
-/// dynamic configuration is fetched from the manager, otherwise it is loaded
-/// from the local dynconfig file.
+/// Backend of the dynamic configuration. When the manager address is
+/// configured, the dynamic configuration is fetched from the manager,
+/// otherwise it is loaded from the local dynconfig file.
 enum Backend {
     /// Fetches the dynamic configuration from the manager.
     Remote(Remote),
@@ -218,18 +217,15 @@ impl Dynconfig {
 
     /// Creates a new backend for the dynamic configuration based on the provided configuration.
     async fn backend(config: Arc<Config>, dynconfig_path: PathBuf) -> Result<Backend> {
-        match config.manager {
-            Some(ref manager) => {
-                let manager_client = ManagerClient::new(manager, manager.addr.clone())
+        match config.manager.addr {
+            Some(ref addr) => {
+                let manager_client = ManagerClient::new(&config.manager, addr.clone())
                     .await
                     .inspect_err(|err| {
                         error!("initialize manager client failed: {}", err);
                     })?;
 
-                info!(
-                    "refresh dynamic configuration from manager {}",
-                    manager.addr
-                );
+                info!("refresh dynamic configuration from manager {}", addr);
                 Ok(Backend::Remote(Remote::new(
                     config.clone(),
                     Arc::new(manager_client),
@@ -237,7 +233,7 @@ impl Dynconfig {
             }
             None => {
                 info!(
-                    "manager is not configured, load dynamic configuration from {}",
+                    "manager address is not configured, load dynamic configuration from {}",
                     dynconfig_path.display()
                 );
 
@@ -254,10 +250,7 @@ impl Dynconfig {
         let mut shutdown = self.shutdown.clone();
 
         // Start the refresh loop.
-        let mut interval = tokio::time::interval(self.refresh_interval().await);
-
-        // Start the refresh loop. The refresh interval is re-evaluated on each
-        // iteration, since the local backend can change it on refresh.
+        let mut interval = tokio::time::interval(self.config.dynconfig.refresh_interval);
         loop {
             tokio::select! {
                 _ = interval.tick() => {
@@ -291,13 +284,5 @@ impl Dynconfig {
 
         *self.data.write().await = data;
         Ok(())
-    }
-
-    /// Returns the interval to refresh the dynamic configuration.
-    async fn refresh_interval(&self) -> Duration {
-        match &self.backend {
-            Backend::Remote(_) => self.config.dynconfig.refresh_interval,
-            Backend::Local(local) => local.refresh_interval().await,
-        }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Make `Manager.addr` an `Option<String>` instead of a required `String`
- Flatten `manager` from `Option<Manager>` to a plain `Manager` struct
- Remove separate local dynconfig refresh interval; both backends now use the unified `dynconfig.refresh_interval` (changed default to 60s)
- Remove `refresh_interval` field from local `Config` and related logic
- Drop `humantime-serde` dependency from `dragonfly-client

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
