### PR TITLE
Prefer IPv4 for schedulers on dual-stack hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "cgroups-rs",
  "headers 0.4.1",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "dragonfly-client-request",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.2"
+version = "1.4.3"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -36,15 +36,15 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.2.32"
-dragonfly-client = { path = "dragonfly-client", version = "1.4.2" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.2" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.2" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.2" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.2" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.2" }
-dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.2" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.2" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.2" }
+dragonfly-client = { path = "dragonfly-client", version = "1.4.3" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.3" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.3" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.3" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.3" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.3" }
+dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.3" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.3" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.3" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -228,7 +228,7 @@ impl QUICServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload piece content");
+                debug!("start upload piece content");
 
                 match self.handle_piece(piece_id.as_str(), task_id).await {
                     Ok((piece_content, mut content_reader)) => {
@@ -314,7 +314,7 @@ impl QUICServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload persistent piece content");
+                debug!("start upload persistent piece content");
 
                 match self
                     .handle_persistent_piece(piece_id.as_str(), task_id)
@@ -406,7 +406,7 @@ impl QUICServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload persistent cache piece content");
+                debug!("start upload persistent cache piece content");
 
                 match self
                     .handle_persistent_cache_piece(piece_id.as_str(), task_id)

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -217,7 +217,7 @@ impl TCPServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload piece content");
+                debug!("start upload piece content");
 
                 match self.handle_piece(piece_id.as_str(), task_id).await {
                     Ok((piece_content, content_reader)) => {
@@ -292,7 +292,7 @@ impl TCPServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload persistent piece content");
+                debug!("start upload persistent piece content");
 
                 match self
                     .handle_persistent_piece(piece_id.as_str(), task_id)
@@ -373,7 +373,7 @@ impl TCPServerHandler {
 
                 // Collect upload piece started metrics.
                 collect_upload_piece_started_metrics();
-                info!("start upload persistent cache piece content");
+                debug!("start upload persistent cache piece content");
 
                 match self
                     .handle_persistent_cache_piece(piece_id.as_str(), task_id)

--- a/dragonfly-client/src/dynconfig/local.rs
+++ b/dragonfly-client/src/dynconfig/local.rs
@@ -227,7 +227,7 @@ impl Local {
 
     /// Resolves the scheduler address to the list of schedulers via DNS. The
     /// resolved addresses are sorted to keep the scheduler selection stable
-    /// across refreshes.
+    /// across refreshes, and IPv4 addresses are preferred on dual-stack hosts.
     #[instrument(skip_all)]
     async fn resolve_schedulers(&self, addr: &str) -> Result<Vec<ManagerScheduler>> {
         let mut socket_addrs: Vec<SocketAddr> = lookup_host(addr)
@@ -238,6 +238,11 @@ impl Local {
             .collect();
         if socket_addrs.is_empty() {
             return Err(Error::AvailableSchedulersNotFound);
+        }
+
+        // Prefer IPv4 when the address resolves to both families.
+        if socket_addrs.iter().any(|socket_addr| socket_addr.is_ipv4()) {
+            socket_addrs.retain(|socket_addr| socket_addr.is_ipv4());
         }
 
         socket_addrs.sort();
@@ -403,6 +408,18 @@ scheduler:
             .iter()
             .all(|scheduler| scheduler.port == health_addr.port() as i32));
         assert!(data.available_scheduler_cluster_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_schedulers_should_prefer_ipv4() {
+        let dir = tempfile::tempdir().unwrap();
+        let local = new_local(dir.path().join("dynconfig.yaml"));
+
+        let schedulers = local.resolve_schedulers("localhost:8002").await.unwrap();
+        assert!(!schedulers.is_empty());
+        assert!(schedulers
+            .iter()
+            .all(|scheduler| IpAddr::from_str(&scheduler.ip).unwrap().is_ipv4()));
     }
 
     #[tokio::test]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Filter out IPv6 addresses when any IPv4 address is present
- Adds test verifying all resolved schedulers are IPv4 on dual-stack
- Updates doc comment to reflect the new preference behavior

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
