### PR TITLE
chore: add graphify-out to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ scripts/certs
 # Cloud files
 .claude
 .claude-analysis
+
+# Graphify
+graphify-out


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Excludes the `graphify-out` directory from version control.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
