### PR TITLE
refactor(task): replace send_timeout with send for download progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "cgroups-rs",
  "headers 0.4.1",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "dragonfly-api",
  "dragonfly-client-config",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bincode",
  "bytes",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4956,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "dragonfly-client-request",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.3"
+version = "1.4.4"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -36,15 +36,15 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.2.32"
-dragonfly-client = { path = "dragonfly-client", version = "1.4.3" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.3" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.3" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.3" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.3" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.3" }
-dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.3" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.3" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.3" }
+dragonfly-client = { path = "dragonfly-client", version = "1.4.4" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.4" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.4" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.4" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.4" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.4" }
+dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.4" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.4" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.4" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1296,7 +1296,7 @@ impl PersistentCacheTask {
                     })?;
                 } else {
                     download_progress_tx
-                    .send_timeout(
+                    .send(
                         Ok(DownloadPersistentCacheTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.clone(),
@@ -1309,7 +1309,6 @@ impl PersistentCacheTask {
                                 ),
                             ),
                         }),
-                        REQUEST_TIMEOUT,
                     )
                     .await
                     .unwrap_or_else(|err| {
@@ -1568,7 +1567,7 @@ impl PersistentCacheTask {
                 })?;
             } else {
                 download_progress_tx
-                .send_timeout(
+                .send(
                     Ok(DownloadPersistentCacheTaskResponse {
                         host_id: host_id.to_string(),
                         task_id: task_id.to_string(),
@@ -1581,7 +1580,6 @@ impl PersistentCacheTask {
                             ),
                         ),
                     }),
-                    REQUEST_TIMEOUT,
                 )
                 .await
                 .unwrap_or_else(|err| {

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -2138,7 +2138,7 @@ impl PersistentTask {
                     })?;
                 } else {
                     download_progress_tx
-                    .send_timeout(
+                    .send(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.clone(),
@@ -2151,7 +2151,6 @@ impl PersistentTask {
                                 ),
                             ),
                         }),
-                        REQUEST_TIMEOUT,
                     )
                     .await
                     .unwrap_or_else(|err| {
@@ -2433,7 +2432,7 @@ impl PersistentTask {
                     })?;
                 } else {
                     download_progress_tx
-                    .send_timeout(
+                    .send(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.to_string(),
@@ -2446,7 +2445,6 @@ impl PersistentTask {
                                 ),
                             ),
                         }),
-                        REQUEST_TIMEOUT,
                     )
                     .await
                     .unwrap_or_else(|err| {
@@ -2726,7 +2724,7 @@ impl PersistentTask {
                 })?;
             } else {
                 download_progress_tx
-                .send_timeout(Ok(DownloadPersistentTaskResponse {
+                .send(Ok(DownloadPersistentTaskResponse {
                     host_id: host_id.to_string(),
                     task_id: task_id.to_string(),
                     peer_id: peer_id.to_string(),
@@ -2735,7 +2733,7 @@ impl PersistentTask {
                             dfdaemon::v2::DownloadPieceFinishedResponse { piece: Some(piece) },
                         ),
                     ),
-                }), REQUEST_TIMEOUT)
+                }))
                 .await
                 .unwrap_or_else(|err| {
                     error!(
@@ -2878,7 +2876,7 @@ impl PersistentTask {
                     })?;
                 } else {
                     download_progress_tx
-                    .send_timeout(
+                    .send(
                         Ok(DownloadPersistentTaskResponse {
                             host_id: host_id.to_string(),
                             task_id: task_id.to_string(),
@@ -2891,7 +2889,6 @@ impl PersistentTask {
                                 ),
                             ),
                         }),
-                        REQUEST_TIMEOUT,
                     )
                     .await
                     .unwrap_or_else(|err| {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1408,21 +1408,18 @@ impl Task {
                         })?;
                 } else {
                     download_progress_tx
-                        .send_timeout(
-                            Ok(DownloadTaskResponse {
-                                host_id: host_id.to_string(),
-                                task_id: task_id.to_string(),
-                                peer_id: peer_id.to_string(),
-                                response: Some(
-                                    download_task_response::Response::DownloadPieceFinishedResponse(
-                                        dfdaemon::v2::DownloadPieceFinishedResponse {
-                                            piece: Some(piece.clone()),
-                                        },
-                                    ),
+                        .send(Ok(DownloadTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece.clone()),
+                                    },
                                 ),
-                            }),
-                            REQUEST_TIMEOUT,
-                        )
+                            ),
+                        }))
                         .await
                         .unwrap_or_else(|err| {
                             error!(
@@ -1707,21 +1704,18 @@ impl Task {
                         })?;
                 } else {
                     download_progress_tx
-                        .send_timeout(
-                            Ok(DownloadTaskResponse {
-                                host_id: host_id.to_string(),
-                                task_id: task_id.to_string(),
-                                peer_id: peer_id.to_string(),
-                                response: Some(
-                                    download_task_response::Response::DownloadPieceFinishedResponse(
-                                        dfdaemon::v2::DownloadPieceFinishedResponse {
-                                            piece: Some(piece.clone()),
-                                        },
-                                    ),
+                        .send(Ok(DownloadTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece.clone()),
+                                    },
                                 ),
-                            }),
-                            REQUEST_TIMEOUT,
-                        )
+                            ),
+                        }))
                         .await
                         .unwrap_or_else(|err| {
                             error!(
@@ -2015,21 +2009,16 @@ impl Task {
                     })?;
             } else {
                 download_progress_tx
-                    .send_timeout(
-                        Ok(DownloadTaskResponse {
-                            host_id: host_id.to_string(),
-                            task_id: task_id.to_string(),
-                            peer_id: peer_id.to_string(),
-                            response: Some(
-                                download_task_response::Response::DownloadPieceFinishedResponse(
-                                    dfdaemon::v2::DownloadPieceFinishedResponse {
-                                        piece: Some(piece),
-                                    },
-                                ),
+                    .send(Ok(DownloadTaskResponse {
+                        host_id: host_id.to_string(),
+                        task_id: task_id.to_string(),
+                        peer_id: peer_id.to_string(),
+                        response: Some(
+                            download_task_response::Response::DownloadPieceFinishedResponse(
+                                dfdaemon::v2::DownloadPieceFinishedResponse { piece: Some(piece) },
                             ),
-                        }),
-                        REQUEST_TIMEOUT,
-                    )
+                        ),
+                    }))
                     .await
                     .unwrap_or_else(|err| {
                         error!(
@@ -2283,21 +2272,18 @@ impl Task {
                         })?;
                 } else {
                     download_progress_tx
-                        .send_timeout(
-                            Ok(DownloadTaskResponse {
-                                host_id: host_id.to_string(),
-                                task_id: task_id.to_string(),
-                                peer_id: peer_id.to_string(),
-                                response: Some(
-                                    download_task_response::Response::DownloadPieceFinishedResponse(
-                                        dfdaemon::v2::DownloadPieceFinishedResponse {
-                                            piece: Some(piece),
-                                        },
-                                    ),
+                        .send(Ok(DownloadTaskResponse {
+                            host_id: host_id.to_string(),
+                            task_id: task_id.to_string(),
+                            peer_id: peer_id.to_string(),
+                            response: Some(
+                                download_task_response::Response::DownloadPieceFinishedResponse(
+                                    dfdaemon::v2::DownloadPieceFinishedResponse {
+                                        piece: Some(piece),
+                                    },
                                 ),
-                            }),
-                            REQUEST_TIMEOUT,
-                        )
+                            ),
+                        }))
                         .await
                         .unwrap_or_else(|err| {
                             error!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request removes the use of the `.send_timeout` method with a fixed timeout for progress updates in the `Task`, `PersistentTask`, and `PersistentCacheTask` implementations, replacing it with the simpler `.send` method. This change streamlines the code and eliminates the explicit timeout parameter when sending progress updates over channels.

**Refactoring of progress update sending:**

* Replaced `.send_timeout` with `.send` for all progress update transmissions in `dragonfly-client/src/resource/task.rs`, `persistent_task.rs`, and `persistent_cache_task.rs`, removing the need for the `REQUEST_TIMEOUT` parameter. [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1411-R1411) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1710-R1707) [[3]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L2018-R2021) [[4]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L2286-R2275) [[5]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2141-R2141) [[6]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2436-R2435) [[7]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2729-R2727) [[8]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2881-R2879) [[9]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1299-R1299) [[10]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1571-R1570)
* Removed all instances of passing the `REQUEST_TIMEOUT` argument to `.send_timeout`, simplifying method calls. [[1]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1423-R1422) [[2]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L1722-R1718) [[3]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L2018-R2021) [[4]](diffhunk://#diff-c7b7b9968d56a9246c8cbfb03440b01e70293fcae9082d1b2c18d3942551f7c5L2298-R2286) [[5]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2154) [[6]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2449) [[7]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2738-R2736) [[8]](diffhunk://#diff-a32cdf3cab68dde93779f32403bf1667fa2ec2ed677504c13a3b3c38e7af9d32L2894) [[9]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1312) [[10]](diffhunk://#diff-f95fb90718c7b67c4be3b2561b7ef633f021db56a99b04eb237aa1dac285ebf8L1584)

These changes make progress reporting more straightforward and reduce potential issues related to timeouts when sending updates.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
