### PR TITLE
fix: abort incomplete downloads and propagate stream errors to clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "cgroups-rs",
  "http",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bytes",
  "dragonfly-api",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "dragonfly-client-request",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.5"
+version = "1.4.6"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -36,15 +36,15 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.2.32"
-dragonfly-client = { path = "dragonfly-client", version = "1.4.5" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.5" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.5" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.5" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.5" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.5" }
-dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.5" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.5" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.5" }
+dragonfly-client = { path = "dragonfly-client", version = "1.4.6" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.6" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.6" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.6" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.6" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.6" }
+dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.6" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.6" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.6" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -538,6 +538,7 @@ impl ExportCommand {
 
         //  Download file.
         let mut downloaded = 0;
+        let mut content_length = None;
         let mut out_stream = response.into_inner();
         loop {
             match out_stream.message().await {
@@ -557,6 +558,7 @@ impl ExportCommand {
                                 };
                             }
 
+                            content_length = Some(response.content_length);
                             progress_bar.set_length(response.content_length);
                         }
                         Some(download_persistent_cache_task_response::Response::DownloadPieceFinishedResponse(
@@ -634,6 +636,20 @@ impl ExportCommand {
                     return Err(Error::TonicStatus(err));
                 }
             }
+        }
+
+        // Abort if the stream ended before all pieces were received.
+        if content_length != Some(downloaded) {
+            error!(
+                "download incomplete: received {} bytes, expected {} bytes",
+                downloaded,
+                content_length.unwrap_or_default()
+            );
+            fs::remove_file(&self.output).await.inspect_err(|err| {
+                error!("remove file {:?} failed: {}", self.output, err);
+            })?;
+
+            return Err(Error::Unknown("download incomplete".to_string()));
         }
 
         if let Some(f) = &mut f {

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1162,6 +1162,8 @@ async fn download(
 
     // Download file.
     let mut downloaded = 0;
+    let mut initialized = false;
+    let mut remaining_pieces = HashSet::new();
     let mut out_stream = response.into_inner();
     loop {
         match out_stream.message().await {
@@ -1182,6 +1184,9 @@ async fn download(
                             }
                         }
 
+                        initialized = true;
+                        remaining_pieces =
+                            response.pieces.iter().map(|piece| piece.number).collect();
                         progress_bar.set_length(response.content_length);
                     }
                     Some(download_task_response::Response::DownloadPieceFinishedResponse(
@@ -1238,6 +1243,7 @@ async fn download(
                             debug!("copy piece {} to {:?} success", piece.number, args.output);
                         }
 
+                        remaining_pieces.remove(&piece.number);
                         downloaded += piece.length;
                         let position = min(
                             downloaded + piece.length,
@@ -1265,6 +1271,19 @@ async fn download(
                 return Err(Error::TonicStatus(err));
             }
         }
+    }
+
+    // Abort if the stream ended before all pieces were received.
+    if !initialized || !remaining_pieces.is_empty() {
+        error!(
+            "download incomplete: {} pieces not received",
+            remaining_pieces.len()
+        );
+        fs::remove_file(&args.output).await.inspect_err(|err| {
+            error!("remove file {:?} failed: {}", args.output, err);
+        })?;
+
+        return Err(Error::Unknown("download incomplete".to_string()));
     }
 
     if let Some(f) = &mut f {

--- a/dragonfly-client/src/bin/dfstore/export.rs
+++ b/dragonfly-client/src/bin/dfstore/export.rs
@@ -599,6 +599,7 @@ impl ExportCommand {
 
         //  Download file.
         let mut downloaded = 0;
+        let mut content_length = None;
         let mut out_stream = response.into_inner();
         loop {
             match out_stream.message().await {
@@ -618,6 +619,7 @@ impl ExportCommand {
                                 };
                             }
 
+                            content_length = Some(response.content_length);
                             progress_bar.set_length(response.content_length);
                         }
                         Some(download_persistent_task_response::Response::DownloadPieceFinishedResponse(
@@ -695,6 +697,20 @@ impl ExportCommand {
                     return Err(Error::TonicStatus(err));
                 }
             }
+        }
+
+        // Abort if the stream ended before all pieces were received.
+        if content_length != Some(downloaded) {
+            error!(
+                "download incomplete: received {} bytes, expected {} bytes",
+                downloaded,
+                content_length.unwrap_or_default()
+            );
+            fs::remove_file(&self.output).await.inspect_err(|err| {
+                error!("remove file {:?} failed: {}", self.output, err);
+            })?;
+
+            return Err(Error::Unknown("download incomplete".to_string()));
         }
 
         if let Some(f) = &mut f {

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -500,10 +500,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -514,7 +511,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             err: Status,
         ) {
             out_stream_tx
-                .send_timeout(Err(err), super::REQUEST_TIMEOUT)
+                .send(Err(err))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -1294,10 +1291,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -1850,10 +1844,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -455,10 +455,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -469,7 +466,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             err: Status,
         ) {
             out_stream_tx
-                .send_timeout(Err(err), super::REQUEST_TIMEOUT)
+                .send(Err(err))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -1370,10 +1367,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }
@@ -1968,10 +1962,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
             err: impl std::error::Error,
         ) {
             out_stream_tx
-                .send_timeout(
-                    Err(Status::internal(err.to_string())),
-                    super::REQUEST_TIMEOUT,
-                )
+                .send(Err(Status::internal(err.to_string())))
                 .await
                 .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
         }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -909,8 +909,11 @@ async fn proxy_via_dfdaemon(
             // descriptors while waiting.
             let mut finished_pieces = HashMap::new();
 
-            // Get the first piece number from the started response.
-            let Some(first_piece) = download_task_started_response.pieces.first() else {
+            // Get the first and last piece numbers from the started response.
+            let (Some(first_piece), Some(last_piece)) = (
+                download_task_started_response.pieces.first(),
+                download_task_started_response.pieces.last(),
+            ) else {
                 error!("response pieces is empty");
 
                 // Send the none response to the client in case if it is empty file.
@@ -947,6 +950,11 @@ async fn proxy_via_dfdaemon(
 
                             let Some(piece) = download_task_response.piece else {
                                 error!("response piece is empty");
+                                body_tx
+                                    .send(Err(ClientError::UnexpectedResponse))
+                                    .await
+                                    .unwrap_or_default();
+
                                 return;
                             };
 
@@ -970,6 +978,7 @@ async fn proxy_via_dfdaemon(
                                     Ok(piece_range_reader) => piece_range_reader,
                                     Err(err) => {
                                         error!("download piece reader error: {}", err);
+                                        body_tx.send(Err(err)).await.unwrap_or_default();
                                         return;
                                     }
                                 };
@@ -986,6 +995,7 @@ async fn proxy_via_dfdaemon(
                                         }
                                         Err(err) => {
                                             error!("download piece reader error: {}", err);
+                                            body_tx.send(Err(err)).await.unwrap_or_default();
                                             return;
                                         }
                                     }
@@ -995,16 +1005,36 @@ async fn proxy_via_dfdaemon(
                             }
                         } else {
                             error!("response unknown message");
+                            body_tx
+                                .send(Err(ClientError::UnexpectedResponse))
+                                .await
+                                .unwrap_or_default();
+
                             return;
                         }
                     }
                     None => {
-                        debug!("message is none");
+                        // The stream is closed. If the response body is incomplete,
+                        // abort the connection with an error.
+                        if need_piece_number <= last_piece.number {
+                            error!(
+                                "stream ended at piece {}, last piece is {}",
+                                need_piece_number, last_piece.number
+                            );
+                            body_tx
+                                .send(Err(ClientError::Unknown(format!(
+                                    "response body is truncated at piece {need_piece_number}"
+                                ))))
+                                .await
+                                .unwrap_or_default();
+                        }
+
                         return;
                     }
                     Some(Err(err)) => {
                         if initialized {
                             error!("stream error: {}", err);
+                            body_tx.send(Err(err.into())).await.unwrap_or_default();
                             return;
                         }
 

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -16,7 +16,7 @@
 
 use crate::dynconfig::block_list::DownloadBlockListCheckParams;
 use crate::dynconfig::Dynconfig;
-use crate::grpc::{DOWNLOAD_STREAM_BUFFER_SIZE, REQUEST_TIMEOUT};
+use crate::grpc::DOWNLOAD_STREAM_BUFFER_SIZE;
 use crate::resource::task::Task;
 use dragonfly_api::common::v2::TaskType;
 use dragonfly_api::dfdaemon::v2::{DownloadTaskRequest, DownloadTaskResponse};
@@ -214,7 +214,7 @@ pub async fn download(
         err: impl std::error::Error,
     ) {
         out_stream_tx
-            .send_timeout(Err(Status::internal(err.to_string())), REQUEST_TIMEOUT)
+            .send(Err(Status::internal(err.to_string())))
             .await
             .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
     }
@@ -225,7 +225,7 @@ pub async fn download(
         err: Status,
     ) {
         out_stream_tx
-            .send_timeout(Err(err), REQUEST_TIMEOUT)
+            .send(Err(err))
             .await
             .unwrap_or_else(|err| error!("send download progress error: {:?}", err));
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Replace `send_timeout` with `send` for error propagation to avoid dropped errors when timeout expires
- Detect incomplete downloads in dfget/dfcache/dfstore by tracking expected vs received pieces/bytes; delete partial files on mismatch
- Propagate stream errors and truncation to proxy clients via `body_tx` instead of silently returning
- Track remaining pieces in dfget using a `HashSet` populated from the started response
- Bump version from 1.4.5 to 1.4.6
<!--- Describe your changes in detail -->

## Related Issue

Fixed https://github.com/dragonflyoss/client/issues/1959
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
