### PR TITLE
refactor(proxy): reuse shared HTTP/HTTPS clients instead of per-request

### DIFF
--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -38,25 +38,22 @@ use dragonfly_client_util::{
 use futures::TryStreamExt;
 use http_body_util::{combinators::BoxBody, BodyExt, Empty, StreamBody};
 use hyper::body::Frame;
-use hyper::client::conn::http1::Builder as ClientBuilder;
 use hyper::server::conn::http1::Builder as ServerBuilder;
 use hyper::service::service_fn;
 use hyper::upgrade::Upgraded;
 use hyper::{Method, Request};
 use hyper_util::{
-    client::legacy::Client,
+    client::legacy::{connect::HttpConnector, Client},
     rt::{tokio::TokioIo, TokioExecutor},
 };
 use leaky_bucket::RateLimiter;
 use rcgen::Certificate;
 use rustls::{RootCertStore, ServerConfig};
-use rustls_pki_types::CertificateDer;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tokio::net::TcpListener;
-use tokio::net::TcpStream;
 use tokio::sync::{mpsc, Barrier};
 use tokio_rustls::TlsAcceptor;
 use tokio_stream::wrappers::ReceiverStream;
@@ -84,8 +81,11 @@ pub struct Proxy {
     /// Address of the proxy server.
     addr: SocketAddr,
 
-    /// Certificate of the client for the registry.
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    /// HTTP client for proxying requests directly to remote servers.
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+
+    /// HTTPS client for proxying requests directly to remote servers.
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
 
     /// CA certificate of the proxy server to sign the self-signed certificate.
     server_ca_cert: Arc<Option<Certificate>>,
@@ -113,11 +113,50 @@ impl Proxy {
         shutdown: shutdown::Shutdown,
         shutdown_complete_tx: mpsc::UnboundedSender<()>,
     ) -> Self {
+        // Load and generate the registry certificates from the PEM format file.
+        let registry_cert = match config.proxy.registry_mirror.load_cert_der() {
+            Ok(registry_cert) => {
+                info!("load registry cert success");
+                registry_cert
+            }
+            Err(err) => {
+                error!("load registry cert failed: {}", err);
+                None
+            }
+        };
+
+        let client_config_builder = match registry_cert {
+            Some(registry_cert) => {
+                let mut root_cert_store = RootCertStore::empty();
+                root_cert_store.add_parsable_certificates(registry_cert);
+
+                // TLS client config using the custom CA store for lookups.
+                rustls::ClientConfig::builder()
+                    .with_root_certificates(root_cert_store)
+                    .with_no_client_auth()
+            }
+            // Default TLS client config with native roots.
+            None => rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(NoVerifier::new())
+                .with_no_client_auth(),
+        };
+
         let mut proxy = Self {
             config: config.clone(),
             task: task.clone(),
             addr: SocketAddr::new(config.proxy.server.ip.unwrap(), config.proxy.server.port),
-            registry_cert: Arc::new(None),
+            http_client: Client::builder(TokioExecutor::new())
+                .http1_preserve_header_case(true)
+                .http1_title_case_headers(true)
+                .build_http(),
+            https_client: Client::builder(TokioExecutor::new()).build(
+                hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_tls_config(client_config_builder)
+                    .https_or_http()
+                    .enable_http1()
+                    .build(),
+            ),
             server_ca_cert: Arc::new(None),
             request_rate_limiter: Arc::new(
                 RateLimiter::builder()
@@ -131,18 +170,6 @@ impl Proxy {
             dynconfig,
             shutdown,
             _shutdown_complete: shutdown_complete_tx,
-        };
-
-        // Load and generate the registry certificates from the PEM format file.
-        proxy.registry_cert = match config.proxy.registry_mirror.load_cert_der() {
-            Ok(registry_cert) => {
-                info!("load registry cert success");
-                Arc::new(registry_cert)
-            }
-            Err(err) => {
-                error!("load registry cert failed: {}", err);
-                Arc::new(None)
-            }
         };
 
         // Generate the CA certificate and key from the PEM format files.
@@ -183,7 +210,9 @@ impl Proxy {
         struct Context {
             config: Arc<Config>,
             task: Arc<Task>,
-            registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+            http_client: Client<HttpConnector, hyper::body::Incoming>,
+            https_client:
+                Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
             server_ca_cert: Arc<Option<Certificate>>,
             request_rate_limiter: Arc<RateLimiter>,
             dynconfig: Arc<Dynconfig>,
@@ -192,7 +221,8 @@ impl Proxy {
         let context = Context {
             config: self.config.clone(),
             task: self.task.clone(),
-            registry_cert: self.registry_cert.clone(),
+            http_client: self.http_client.clone(),
+            https_client: self.https_client.clone(),
             server_ca_cert: self.server_ca_cert.clone(),
             request_rate_limiter: self.request_rate_limiter.clone(),
             dynconfig: self.dynconfig.clone(),
@@ -224,7 +254,7 @@ impl Proxy {
                                 service_fn(move |request|{
                                     let context = context.clone();
                                     async move {
-                                        handler(context.config, context.task, request, context.registry_cert, context.server_ca_cert, context.request_rate_limiter, context.dynconfig, remote_address.ip()).await
+                                        handler(context.config, context.task, request, context.http_client, context.https_client, context.server_ca_cert, context.request_rate_limiter, context.dynconfig, remote_address.ip()).await
                                     }
                                 } ),
                                 )
@@ -253,7 +283,8 @@ pub async fn handler(
     config: Arc<Config>,
     task: Arc<Task>,
     request: Request<hyper::body::Incoming>,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     server_ca_cert: Arc<Option<Certificate>>,
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
@@ -288,7 +319,8 @@ pub async fn handler(
                 task,
                 request,
                 remote_ip,
-                registry_cert,
+                http_client,
+                https_client,
                 server_ca_cert,
                 request_rate_limiter,
                 dynconfig,
@@ -301,7 +333,8 @@ pub async fn handler(
             task,
             request,
             remote_ip,
-            registry_cert,
+            http_client,
+            https_client,
             dynconfig,
         )
         .await;
@@ -314,7 +347,8 @@ pub async fn handler(
             task,
             request,
             remote_ip,
-            registry_cert,
+            http_client,
+            https_client,
             server_ca_cert,
             request_rate_limiter,
             dynconfig,
@@ -322,7 +356,16 @@ pub async fn handler(
         .await;
     }
 
-    http_handler(config, task, request, remote_ip, registry_cert, dynconfig).await
+    http_handler(
+        config,
+        task,
+        request,
+        remote_ip,
+        http_client,
+        https_client,
+        dynconfig,
+    )
+    .await
 }
 
 /// Handles the http request for the registry mirror by client.
@@ -332,11 +375,21 @@ pub async fn registry_mirror_http_handler(
     task: Arc<Task>,
     request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     dynconfig: Arc<Dynconfig>,
 ) -> ClientResult<Response> {
     let request = make_registry_mirror_request(config.clone(), request)?;
-    return http_handler(config, task, request, remote_ip, registry_cert, dynconfig).await;
+    return http_handler(
+        config,
+        task,
+        request,
+        remote_ip,
+        http_client,
+        https_client,
+        dynconfig,
+    )
+    .await;
 }
 
 /// Handles the https request for the registry mirror by client.
@@ -347,7 +400,8 @@ pub async fn registry_mirror_https_handler(
     task: Arc<Task>,
     request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     server_ca_cert: Arc<Option<Certificate>>,
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
@@ -358,7 +412,8 @@ pub async fn registry_mirror_https_handler(
         task,
         request,
         remote_ip,
-        registry_cert,
+        http_client,
+        https_client,
         server_ca_cert,
         request_rate_limiter,
         dynconfig,
@@ -373,7 +428,8 @@ pub async fn http_handler(
     task: Arc<Task>,
     request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     dynconfig: Arc<Dynconfig>,
 ) -> ClientResult<Response> {
     // Authenticate the request with the basic auth.
@@ -455,7 +511,7 @@ pub async fn http_handler(
             request
         );
 
-        return proxy_via_https(request, registry_cert).await;
+        return proxy_via_https(request, https_client).await;
     }
 
     info!(
@@ -463,7 +519,7 @@ pub async fn http_handler(
         request
     );
 
-    return proxy_via_http(request).await;
+    return proxy_via_http(request, http_client).await;
 }
 
 /// Handles the https request by client.
@@ -474,7 +530,8 @@ pub async fn https_handler(
     task: Arc<Task>,
     request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     server_ca_cert: Arc<Option<Certificate>>,
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
@@ -495,7 +552,8 @@ pub async fn https_handler(
                         host,
                         port,
                         remote_ip,
-                        registry_cert,
+                        http_client,
+                        https_client,
                         server_ca_cert,
                         request_rate_limiter,
                         dynconfig,
@@ -531,7 +589,8 @@ async fn upgraded_tunnel(
     host: String,
     port: u16,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     server_ca_cert: Arc<Option<Certificate>>,
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
@@ -581,7 +640,8 @@ async fn upgraded_tunnel(
                     port,
                     request,
                     remote_ip,
-                    registry_cert.clone(),
+                    http_client.clone(),
+                    https_client.clone(),
                     request_rate_limiter.clone(),
                     dynconfig.clone(),
                 )
@@ -606,7 +666,8 @@ pub async fn upgraded_handler(
     port: u16,
     mut request: Request<hyper::body::Incoming>,
     remote_ip: std::net::IpAddr,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
     request_rate_limiter: Arc<RateLimiter>,
     dynconfig: Arc<Dynconfig>,
 ) -> ClientResult<Response> {
@@ -724,7 +785,7 @@ pub async fn upgraded_handler(
             request,
         );
 
-        return proxy_via_https(request, registry_cert).await;
+        return proxy_via_https(request, https_client).await;
     }
 
     info!(
@@ -732,7 +793,7 @@ pub async fn upgraded_handler(
         request,
     );
 
-    return proxy_via_http(request).await;
+    return proxy_via_http(request, http_client).await;
 }
 
 /// Proxies the request via the dfdaemon.
@@ -1096,30 +1157,18 @@ async fn proxy_via_dfdaemon(
 
 /// Proxies the HTTP request directly to the remote server.
 #[instrument(level = "debug", skip_all)]
-async fn proxy_via_http(mut request: Request<hyper::body::Incoming>) -> ClientResult<Response> {
-    let Some(host) = request.uri().host() else {
+async fn proxy_via_http(
+    mut request: Request<hyper::body::Incoming>,
+    http_client: Client<HttpConnector, hyper::body::Incoming>,
+) -> ClientResult<Response> {
+    if request.uri().host().is_none() {
         error!("CONNECT host is not socket addr: {:?}", request.uri());
         return Ok(make_error_response(
             header::ErrorType::Proxy,
             http::StatusCode::BAD_REQUEST,
             None,
         ));
-    };
-    let port = request.uri().port_u16().unwrap_or(80);
-
-    let stream = TcpStream::connect((host, port)).await?;
-    let io = TokioIo::new(stream);
-    let (mut client, conn) = ClientBuilder::new()
-        .preserve_header_case(true)
-        .title_case_headers(true)
-        .handshake(io)
-        .await?;
-
-    tokio::task::spawn(async move {
-        if let Err(err) = conn.await {
-            error!("connection failed: {:?}", err);
-        }
-    });
+    }
 
     // Override Host header with the URI authority to handle containerd's
     // behavior with non-default ports, which otherwise causes request
@@ -1137,7 +1186,10 @@ async fn proxy_via_http(mut request: Request<hyper::body::Incoming>) -> ClientRe
     .or_err(ErrorType::ParseError)?;
     request.headers_mut().insert(hyper::header::HOST, host);
 
-    let response = client.send_request(request).await?;
+    let response = http_client.request(request).await.inspect_err(|err| {
+        error!("request failed: {:?}", err);
+    })?;
+
     Ok(response.map(|b| b.map_err(ClientError::from).boxed()))
 }
 
@@ -1145,32 +1197,8 @@ async fn proxy_via_http(mut request: Request<hyper::body::Incoming>) -> ClientRe
 #[instrument(level = "debug", skip_all)]
 async fn proxy_via_https(
     mut request: Request<hyper::body::Incoming>,
-    registry_cert: Arc<Option<Vec<CertificateDer<'static>>>>,
+    https_client: Client<hyper_rustls::HttpsConnector<HttpConnector>, hyper::body::Incoming>,
 ) -> ClientResult<Response> {
-    let client_config_builder = match registry_cert.as_ref() {
-        Some(registry_cert) => {
-            let mut root_cert_store = RootCertStore::empty();
-            root_cert_store.add_parsable_certificates(registry_cert.to_owned());
-
-            // TLS client config using the custom CA store for lookups.
-            rustls::ClientConfig::builder()
-                .with_root_certificates(root_cert_store)
-                .with_no_client_auth()
-        }
-        // Default TLS client config with native roots.
-        None => rustls::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(NoVerifier::new())
-            .with_no_client_auth(),
-    };
-
-    let https = hyper_rustls::HttpsConnectorBuilder::new()
-        .with_tls_config(client_config_builder)
-        .https_or_http()
-        .enable_http1()
-        .build();
-    let client = Client::builder(TokioExecutor::new()).build(https);
-
     // Override Host header with the URI authority to handle containerd's
     // behavior with non-443 HTTPS ports, which otherwise causes request
     // failures. The default port (443) is stripped, since clients sign
@@ -1187,7 +1215,7 @@ async fn proxy_via_https(
     .or_err(ErrorType::ParseError)?;
     request.headers_mut().insert(hyper::header::HOST, host);
 
-    let response = client.request(request).await.inspect_err(|err| {
+    let response = https_client.request(request).await.inspect_err(|err| {
         error!("request failed: {:?}", err);
     })?;
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Replace per-request HTTP/HTTPS client creation with shared clients built once at startup
- Move TLS config and client construction into `Proxy::new`, storing them as struct fields
- Pass `http_client` and `https_client` through handler chain instead of `registry_cert`
- `proxy_via_http` now uses the shared `Client` instead of raw `TcpStream` + `ClientBuilder`
- `proxy_via_https` no longer rebuilds TLS config and connector on every request
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
