### PR TITLE
fix(piece-collector): add timeout to unblock pieces when slow parents delay reporting

### DIFF
--- a/dragonfly-client/src/resource/piece_collector.rs
+++ b/dragonfly-client/src/resource/piece_collector.rs
@@ -33,6 +33,36 @@ use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, Instrument};
 
+/// The maximum duration to wait for all parents to report a piece before sending it
+/// with the parents collected so far.
+const DEFAULT_WAIT_FOR_ALL_PARENTS_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Sends the piece with the parents collected so far after the timeout, if it has
+/// not been sent yet.
+fn send_piece_after_timeout(
+    number: u32,
+    collected_pieces: Arc<DashMap<u32, CollectedPiece>>,
+    collected_piece_tx: Sender<CollectedPiece>,
+) {
+    tokio::spawn(
+        async move {
+            tokio::time::sleep(DEFAULT_WAIT_FOR_ALL_PARENTS_TIMEOUT).await;
+            if let Some((_, piece)) = collected_pieces.remove(&number) {
+                debug!(
+                    "timeout waiting for all parents, send piece {} with {} parents",
+                    number,
+                    piece.parents.len()
+                );
+
+                collected_piece_tx.send(piece).await.unwrap_or_else(|err| {
+                    error!("send CollectedPiece failed: {}", err);
+                });
+            }
+        }
+        .in_current_span(),
+    );
+}
+
 /// The parent peer collected from the parent.
 #[derive(Clone, Debug, Default)]
 pub struct CollectedParent {
@@ -175,11 +205,10 @@ impl PieceCollector {
     /// # Piece Collection Strategy
     ///
     /// For each piece reported by a parent, the function accumulates parents in
-    /// `collected_pieces`. A piece is not dispatched to the downloader immediately upon the
-    /// first response. It waits until all candidate parents have had a chance to
-    /// report availability. This ensures that when a piece is finally sent through
-    /// `collected_piece_tx`, it carries a complete list of available parents, enabling
-    /// load-balanced concurrent downloads across different peers.
+    /// `collected_pieces`. A piece is sent to the piece downloader once all candidate
+    /// parents have reported it, or once the wait for all parents times out after the
+    /// first report, whichever comes first. This balances load across parents without
+    /// letting a slow parent block the piece.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     async fn collect_from_parents(
@@ -258,11 +287,18 @@ impl PieceCollector {
                         parent.download_quic_port = message.quic_port;
                         piece.parents.push(parent.clone());
 
-                        // When a piece has already been collected, wait until we've
-                        // gathered responses from all candidate parents before proceeding.
-                        // This ensures load is balanced across different parents during
-                        // concurrent piece downloads.
+                        // Wait for all parents to report the piece for load balancing.
+                        // The first report starts a timeout to bound the wait when some
+                        // parents are slow.
                         if piece.parents.len() < parents.len() {
+                            if piece.parents.len() == 1 {
+                                send_piece_after_timeout(
+                                    message.number,
+                                    collected_pieces.clone(),
+                                    collected_piece_tx.clone(),
+                                );
+                            }
+
                             continue;
                         }
                     } else {
@@ -470,11 +506,10 @@ impl PersistentPieceCollector {
     /// # Piece Collection Strategy
     ///
     /// For each piece reported by a parent, the function accumulates parents in
-    /// `collected_pieces`. A piece is not dispatched to the downloader immediately upon the
-    /// first response. It waits until all candidate parents have had a chance to
-    /// report availability. This ensures that when a piece is finally sent through
-    /// `collected_piece_tx`, it carries a complete list of available parents, enabling
-    /// load-balanced concurrent downloads across different peers.
+    /// `collected_pieces`. A piece is sent to the piece downloader once all candidate
+    /// parents have reported it, or once the wait for all parents times out after the
+    /// first report, whichever comes first. This balances load across parents without
+    /// letting a slow parent block the piece.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     async fn collect_from_parents(
@@ -558,11 +593,18 @@ impl PersistentPieceCollector {
                         parent.download_quic_port = message.quic_port;
                         piece.parents.push(parent.clone());
 
-                        // When a piece has already been collected, wait until we've
-                        // gathered responses from all candidate parents before proceeding.
-                        // This ensures load is balanced across different parents during
-                        // concurrent piece downloads.
+                        // Wait for all parents to report the piece for load balancing.
+                        // The first report starts a timeout to bound the wait when some
+                        // parents are slow.
                         if piece.parents.len() < parents.len() {
+                            if piece.parents.len() == 1 {
+                                send_piece_after_timeout(
+                                    message.number,
+                                    collected_pieces.clone(),
+                                    collected_piece_tx.clone(),
+                                );
+                            }
+
                             continue;
                         }
                     } else {
@@ -773,11 +815,10 @@ impl PersistentCachePieceCollector {
     /// # Piece Collection Strategy
     ///
     /// For each piece reported by a parent, the function accumulates parents in
-    /// `collected_pieces`. A piece is not dispatched to the downloader immediately upon the
-    /// first response. It waits until all candidate parents have had a chance to
-    /// report availability. This ensures that when a piece is finally sent through
-    /// `collected_piece_tx`, it carries a complete list of available parents, enabling
-    /// load-balanced concurrent downloads across different peers.
+    /// `collected_pieces`. A piece is sent to the piece downloader once all candidate
+    /// parents have reported it, or once the wait for all parents times out after the
+    /// first report, whichever comes first. This balances load across parents without
+    /// letting a slow parent block the piece.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     async fn collect_from_parents(
@@ -861,11 +902,18 @@ impl PersistentCachePieceCollector {
                         parent.download_quic_port = message.quic_port;
                         piece.parents.push(parent.clone());
 
-                        // When a piece has already been collected, wait until we've
-                        // gathered responses from all candidate parents before proceeding.
-                        // This ensures load is balanced across different parents during
-                        // concurrent piece downloads.
+                        // Wait for all parents to report the piece for load balancing.
+                        // The first report starts a timeout to bound the wait when some
+                        // parents are slow.
                         if piece.parents.len() < parents.len() {
+                            if piece.parents.len() == 1 {
+                                send_piece_after_timeout(
+                                    message.number,
+                                    collected_pieces.clone(),
+                                    collected_piece_tx.clone(),
+                                );
+                            }
+
                             continue;
                         }
                     } else {


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, piece collection waited indefinitely for all candidate parents to report a piece before dispatching it. If any parent was slow or unresponsive, the piece would be blocked until all parents responded. Now, a 100ms timeout is started on the first parent report; if not all parents have responded by then, the piece is dispatched with the parents collected so far.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
