### PR TITLE
Enhance storage management with page cache optimizations and readahead

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -321,6 +321,13 @@ fn default_gc_policy_persistent_cache_task_ttl() -> Duration {
     Duration::from_secs(86_400)
 }
 
+/// Returns the default idle timeout of the task's page cache, default is 40
+/// minutes.
+#[inline]
+fn default_gc_policy_page_cache_idle_timeout() -> Duration {
+    Duration::from_secs(2_400)
+}
+
 /// Returns the default threshold of the disk usage to do gc.
 #[inline]
 fn default_gc_policy_disk_threshold() -> ByteSize {
@@ -1081,6 +1088,15 @@ pub struct Policy {
     )]
     pub persistent_cache_task_ttl: Duration,
 
+    /// The idle timeout of the task's page cache. If the finished task has no
+    /// download or upload activity within the timeout, dfdaemon will drop the
+    /// page cache of the task content.
+    #[serde(
+        default = "default_gc_policy_page_cache_idle_timeout",
+        with = "humantime_serde"
+    )]
+    pub page_cache_idle_timeout: Duration,
+
     /// Optionally defines a specific disk capacity to be used as the base for
     /// calculating GC trigger points with `disk_high_threshold_percent` and `disk_low_threshold_percent`.
     ///
@@ -1125,6 +1141,7 @@ impl Default for Policy {
             task_ttl: default_gc_policy_task_ttl(),
             persistent_task_ttl: default_gc_policy_persistent_task_ttl(),
             persistent_cache_task_ttl: default_gc_policy_persistent_cache_task_ttl(),
+            page_cache_idle_timeout: default_gc_policy_page_cache_idle_timeout(),
             disk_high_threshold_percent: default_gc_policy_disk_high_threshold_percent(),
             disk_low_threshold_percent: default_gc_policy_disk_low_threshold_percent(),
         }
@@ -2168,6 +2185,7 @@ key: /etc/ssl/private/client.pem
             task_ttl: Duration::from_secs(12 * 3600),
             persistent_task_ttl: Duration::from_secs(24 * 3600),
             persistent_cache_task_ttl: Duration::from_secs(48 * 3600),
+            page_cache_idle_timeout: default_gc_policy_page_cache_idle_timeout(),
             disk_threshold: ByteSize::mb(100),
             disk_high_threshold_percent: 90,
             disk_low_threshold_percent: 70,
@@ -2178,6 +2196,7 @@ key: /etc/ssl/private/client.pem
             task_ttl: Duration::from_secs(12 * 3600),
             persistent_task_ttl: Duration::from_secs(24 * 3600),
             persistent_cache_task_ttl: Duration::from_secs(48 * 3600),
+            page_cache_idle_timeout: default_gc_policy_page_cache_idle_timeout(),
             disk_threshold: ByteSize::mb(100),
             disk_high_threshold_percent: 100,
             disk_low_threshold_percent: 70,

--- a/dragonfly-client-config/src/lib.rs
+++ b/dragonfly-client-config/src/lib.rs
@@ -32,6 +32,9 @@ pub const SERVICE_NAME: &str = "dragonfly";
 /// The name of the package.
 pub const NAME: &str = "client";
 
+/// The minimum piece length.
+pub const MIN_PIECE_LENGTH: u64 = 4 * 1024 * 1024;
+
 /// The version of the cargo package.
 pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
@@ -273,10 +274,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -489,10 +493,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -774,10 +781,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -21,7 +21,7 @@ use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{fadvise_dontneed, fallocate};
+use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -215,7 +215,16 @@ impl Content {
     /// Copies the task content to the destination.
     #[instrument(level = "debug", skip_all)]
     pub async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -262,6 +271,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -440,7 +455,16 @@ impl Content {
     /// Copies the persistent task content to the destination.
     #[instrument(level = "debug", skip_all)]
     pub async fn copy_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_persistent_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_persistent_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -463,6 +487,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -710,7 +740,16 @@ impl Content {
     /// Copies the persistent cache task content to the destination.
     #[instrument(level = "debug", skip_all)]
     pub async fn copy_persistent_cache_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -733,6 +772,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -20,8 +20,8 @@ use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
-use dragonfly_client_util::fs::fallocate;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
+use dragonfly_client_util::fs::{fadvise_dontneed, fallocate};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -235,6 +235,13 @@ impl Content {
                 error!("remove {:?} failed: {}", task_path, err);
             })?;
         Ok(())
+    }
+
+    /// Drops the cached pages of the task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
     }
 
     /// Reads the piece from the content.
@@ -556,6 +563,13 @@ impl Content {
         Ok(())
     }
 
+    /// Drops the cached pages of the persistent task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_persistent_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
+    }
+
     /// Returns the persistent task path by task id.
     fn get_persistent_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent task needs split by the first 3 characters of task id(sha256) to
@@ -820,6 +834,13 @@ impl Content {
         Ok(())
     }
 
+    /// Drops the cached pages of the persistent cache task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_cache_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_persistent_cache_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
+    }
+
     /// Returns the persistent cache task path by task id.
     fn get_persistent_cache_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent cache task needs split by the first 3 characters of task id(sha256) to
@@ -900,6 +921,82 @@ mod tests {
 
         content.delete_task(task_id).await.unwrap();
         assert!(!task_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+        content.create_task(task_id, 13).await.unwrap();
+
+        let data = b"hello, world!";
+        let mut stream = futures::stream::iter([Ok(Bytes::from_static(data))]);
+        content
+            .write_piece_from_stream(task_id, 0, 13, &mut stream)
+            .await
+            .unwrap();
+
+        content.fadvise_dontneed_task(task_id).await.unwrap();
+
+        let mut reader = content.read_piece(task_id, 0, 13, None).await.unwrap();
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, data);
+
+        assert!(content
+            .fadvise_dontneed_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        content.create_persistent_task(task_id, 13).await.unwrap();
+        content
+            .fadvise_dontneed_persistent_task(task_id)
+            .await
+            .unwrap();
+
+        assert!(content
+            .fadvise_dontneed_persistent_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_persistent_cache_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        content
+            .create_persistent_cache_task(task_id, 13)
+            .await
+            .unwrap();
+        content
+            .fadvise_dontneed_persistent_cache_task(task_id)
+            .await
+            .unwrap();
+
+        assert!(content
+            .fadvise_dontneed_persistent_cache_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -21,7 +21,7 @@ use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{fadvise_dontneed, fallocate};
+use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -243,7 +243,16 @@ impl Content {
     /// Copies the task content to the destination.
     #[instrument(skip_all)]
     pub async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -290,6 +299,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -468,7 +483,16 @@ impl Content {
     /// Copies the persistent task content to the destination.
     #[instrument(level = "debug", skip_all)]
     pub async fn copy_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_persistent_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_persistent_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -491,6 +515,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -738,7 +768,16 @@ impl Content {
     /// Copies the persistent cache task content to the destination.
     #[instrument(level = "debug", skip_all)]
     pub async fn copy_persistent_cache_task(&self, task_id: &str, to: &Path) -> Result<()> {
-        fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
+        let length = fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
+
+        // Kick off writeback of the copied content, so dirty pages do not
+        // accumulate until the kernel writeback thresholds kick in.
+        if let Ok(f) = fs::File::open(to).await {
+            sync_file_range(&f.into_std().await, 0, length)
+                .await
+                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+        }
+
         info!("copy to {:?} success", to);
         Ok(())
     }
@@ -761,6 +800,12 @@ impl Content {
         let fd = self.fd_cache.open(&task_path).await.inspect_err(|err| {
             error!("open {:?} failed: {}", task_path, err);
         })?;
+
+        // Queue readahead of the range explicitly, since interleaved uploads
+        // on the shared descriptor break the sequential detection.
+        fadvise_willneed(&fd, target_offset, target_length)
+            .await
+            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
 
         Ok(super::io::RangeReader::new(
             fd,

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use bytesize::ByteSize;
 use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
@@ -301,10 +302,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -517,10 +521,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,
@@ -802,10 +809,13 @@ impl Content {
         })?;
 
         // Queue readahead of the range explicitly, since interleaved uploads
-        // on the shared descriptor break the sequential detection.
-        fadvise_willneed(&fd, target_offset, target_length)
-            .await
-            .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        // on the shared descriptor break the sequential detection. Skip the
+        // small ranges, which the kernel readahead covers quickly.
+        if target_length >= MIN_PIECE_LENGTH {
+            fadvise_willneed(&fd, target_offset, target_length)
+                .await
+                .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
+        }
 
         Ok(super::io::RangeReader::new(
             fd,

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -20,8 +20,8 @@ use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
-use dragonfly_client_util::fs::fallocate;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
+use dragonfly_client_util::fs::{fadvise_dontneed, fallocate};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -263,6 +263,13 @@ impl Content {
                 error!("remove {:?} failed: {}", task_path, err);
             })?;
         Ok(())
+    }
+
+    /// Drops the cached pages of the task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
     }
 
     /// Reads the piece from the content.
@@ -584,6 +591,13 @@ impl Content {
         Ok(())
     }
 
+    /// Drops the cached pages of the persistent task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_persistent_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
+    }
+
     /// Returns the persistent task path by task id.
     fn get_persistent_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent task needs split by the first 3 characters of task id(sha256) to
@@ -848,6 +862,13 @@ impl Content {
         Ok(())
     }
 
+    /// Drops the cached pages of the persistent cache task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_cache_task(&self, task_id: &str) -> Result<()> {
+        let f = fs::File::open(self.get_persistent_cache_task_path(task_id)).await?;
+        fadvise_dontneed(&f).await
+    }
+
     /// Returns the persistent cache task path by task id.
     fn get_persistent_cache_task_path(&self, task_id: &str) -> PathBuf {
         // The persistent cache task needs split by the first 3 characters of task id(sha256) to
@@ -928,6 +949,82 @@ mod tests {
 
         content.delete_task(task_id).await.unwrap();
         assert!(!task_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+        content.create_task(task_id, 13).await.unwrap();
+
+        let data = b"hello, world!";
+        let mut stream = futures::stream::iter([Ok(Bytes::from_static(data))]);
+        content
+            .write_piece_from_stream(task_id, 0, 13, &mut stream)
+            .await
+            .unwrap();
+
+        content.fadvise_dontneed_task(task_id).await.unwrap();
+
+        let mut reader = content.read_piece(task_id, 0, 13, None).await.unwrap();
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(buffer, data);
+
+        assert!(content
+            .fadvise_dontneed_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_persistent_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        content.create_persistent_task(task_id, 13).await.unwrap();
+        content
+            .fadvise_dontneed_persistent_task(task_id)
+            .await
+            .unwrap();
+
+        assert!(content
+            .fadvise_dontneed_persistent_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed_persistent_cache_task() {
+        let temp_dir = tempdir().unwrap();
+        let config = Arc::new(Config::default());
+        let content = Content::new(config, temp_dir.path()).await.unwrap();
+
+        let task_id = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        content
+            .create_persistent_cache_task(task_id, 13)
+            .await
+            .unwrap();
+        content
+            .fadvise_dontneed_persistent_cache_task(task_id)
+            .await
+            .unwrap();
+
+        assert!(content
+            .fadvise_dontneed_persistent_cache_task(
+                "aaa6963dccfd5b4f60b48845606946cea72084f14ed5cce61ec96e69f80a30f8"
+            )
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/dragonfly-client-storage/src/io.rs
+++ b/dragonfly-client-storage/src/io.rs
@@ -17,6 +17,7 @@
 use bytes::{Bytes, BytesMut};
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
+use dragonfly_client_util::fs::sync_file_range;
 use futures::{Stream, TryStreamExt};
 use std::cmp::{max, min};
 use std::fs::File;
@@ -28,6 +29,7 @@ use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt, ReadBuf};
 use tokio::task::JoinHandle;
+use tracing::warn;
 
 /// The response of writing a range.
 pub struct WriteRangeResponse {
@@ -318,6 +320,12 @@ pub async fn write_range<R: AsyncRead + Unpin + ?Sized>(
         )));
     }
 
+    // Kick off writeback of the written range, so dirty pages do not
+    // accumulate across pieces until the kernel writeback thresholds kick in.
+    sync_file_range(&fd, offset - length, length)
+        .await
+        .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+
     Ok(WriteRangeResponse {
         length,
         hash: hasher.finalize().to_string(),
@@ -473,6 +481,12 @@ where
             "expected length {expected_length} but got {length}"
         )));
     }
+
+    // Kick off writeback of the written range, so dirty pages do not
+    // accumulate across pieces until the kernel writeback thresholds kick in.
+    sync_file_range(&fd, offset - length, length)
+        .await
+        .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
 
     Ok(WriteRangeResponse {
         length,

--- a/dragonfly-client-storage/src/lib.rs
+++ b/dragonfly-client-storage/src/lib.rs
@@ -131,6 +131,12 @@ impl Storage {
         self.content.copy_task(id, to).await
     }
 
+    /// Drops the cached pages of the task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_task(&self, id: &str) -> Result<()> {
+        self.content.fadvise_dontneed_task(id).await
+    }
+
     /// Checks if the task content is on the same device inode as the
     /// destination.
     pub async fn is_same_dev_inode_as_task(&self, id: &str, to: &Path) -> Result<bool> {
@@ -360,6 +366,12 @@ impl Storage {
         self.metadata.get_persistent_tasks()
     }
 
+    /// Drops the cached pages of the persistent task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_task(&self, id: &str) -> Result<()> {
+        self.content.fadvise_dontneed_persistent_task(id).await
+    }
+
     /// Deletes the persistent task metadatas, persistent task content and piece metadatas.
     #[instrument(level = "debug", skip_all)]
     pub async fn delete_persistent_task(&self, id: &str) {
@@ -536,6 +548,14 @@ impl Storage {
     #[instrument(level = "debug", skip_all)]
     pub fn get_persistent_cache_tasks(&self) -> Result<Vec<metadata::PersistentCacheTask>> {
         self.metadata.get_persistent_cache_tasks()
+    }
+
+    /// Drops the cached pages of the persistent cache task content.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn fadvise_dontneed_persistent_cache_task(&self, id: &str) -> Result<()> {
+        self.content
+            .fadvise_dontneed_persistent_cache_task(id)
+            .await
     }
 
     /// Deletes the persistent cache task metadatas, persistent cache task content and piece metadatas.

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -34,11 +34,6 @@ use crate::storage_engine::{rocksdb::RocksdbStorageEngine, DatabaseObject, Stora
 /// timeout will be garbage collected by disk usage.
 pub const DEFAULT_DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// The default timeout for the finished task to be considered cold, which covers
-/// the propagation window of the task and the reads of the hard linked
-/// destination. The page cache of the cold task is dropped.
-pub const DEFAULT_PAGE_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(40 * 60);
-
 /// The metadata of the task.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Task {
@@ -103,10 +98,10 @@ impl Task {
     /// Returns whether the page cache of the task needs to be dropped:
     /// downloads finished, not uploading and no download or upload activity
     /// within the idle timeout.
-    pub fn need_drop_page_cache(&self) -> bool {
+    pub fn need_drop_page_cache(&self, idle_timeout: Duration) -> bool {
         self.is_finished()
             && !self.is_uploading()
-            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+            && self.updated_at + idle_timeout < Utc::now().naive_utc()
     }
 
     /// Returns whether the task needs to be evicted: the download is
@@ -224,10 +219,10 @@ impl PersistentTask {
     /// Returns whether the page cache of the persistent task needs to be
     /// dropped: downloads finished, not uploading and no download or upload
     /// activity within the idle timeout.
-    pub fn need_drop_page_cache(&self) -> bool {
+    pub fn need_drop_page_cache(&self, idle_timeout: Duration) -> bool {
         self.is_finished()
             && !self.is_uploading()
-            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+            && self.updated_at + idle_timeout < Utc::now().naive_utc()
     }
 
     /// Returns whether the persistent task needs to be evicted: not
@@ -342,10 +337,10 @@ impl PersistentCacheTask {
     /// Returns whether the page cache of the persistent cache task needs to
     /// be dropped: downloads finished, not uploading and no download or
     /// upload activity within the idle timeout.
-    pub fn need_drop_page_cache(&self) -> bool {
+    pub fn need_drop_page_cache(&self, idle_timeout: Duration) -> bool {
         self.is_finished()
             && !self.is_uploading()
-            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+            && self.updated_at + idle_timeout < Utc::now().naive_utc()
     }
 
     /// Returns whether the persistent cache task needs to be evicted: not
@@ -1701,18 +1696,18 @@ mod tests {
             finished_at: Some(Utc::now().naive_utc()),
             ..Default::default()
         };
-        assert!(task.need_drop_page_cache());
+        assert!(task.need_drop_page_cache(Duration::from_secs(2_400)));
 
         task.uploading_count = 1;
-        assert!(!task.need_drop_page_cache());
+        assert!(!task.need_drop_page_cache(Duration::from_secs(2_400)));
 
         task.uploading_count = 0;
         task.updated_at = Utc::now().naive_utc();
-        assert!(!task.need_drop_page_cache());
+        assert!(!task.need_drop_page_cache(Duration::from_secs(2_400)));
 
         task.updated_at = NaiveDateTime::default();
         task.finished_at = None;
-        assert!(!task.need_drop_page_cache());
+        assert!(!task.need_drop_page_cache(Duration::from_secs(2_400)));
     }
 
     #[test]

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -30,6 +30,15 @@ use tracing::{error, info, instrument};
 
 use crate::storage_engine::{rocksdb::RocksdbStorageEngine, DatabaseObject, StorageEngineOwned};
 
+/// The default timeout for downloading tasks. The started task that exceeds the
+/// timeout will be garbage collected by disk usage.
+pub const DEFAULT_DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// The default timeout for the finished task to be considered cold, which covers
+/// the propagation window of the task and the reads of the hard linked
+/// destination. The page cache of the cold task is dropped.
+pub const DEFAULT_PAGE_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
 /// The metadata of the task.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Task {
@@ -89,6 +98,23 @@ impl Task {
     /// Returns whether the task is expired.
     pub fn is_expired(&self, ttl: Duration) -> bool {
         self.updated_at + ttl < Utc::now().naive_utc()
+    }
+
+    /// Returns whether the page cache of the task needs to be dropped:
+    /// downloads finished, not uploading and no download or upload activity
+    /// within the idle timeout.
+    pub fn need_drop_page_cache(&self) -> bool {
+        self.is_finished()
+            && !self.is_uploading()
+            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+    }
+
+    /// Returns whether the task needs to be evicted: the download is
+    /// finished, failed, or has exceeded the download timeout.
+    pub fn need_evict(&self) -> bool {
+        self.is_finished()
+            || self.is_failed()
+            || self.created_at + DEFAULT_DOWNLOAD_TASK_TIMEOUT < Utc::now().naive_utc()
     }
 
     /// Returns whether the task is prefetched.
@@ -195,6 +221,25 @@ impl PersistentTask {
         self.created_at + self.ttl < Utc::now().naive_utc()
     }
 
+    /// Returns whether the page cache of the persistent task needs to be
+    /// dropped: downloads finished, not uploading and no download or upload
+    /// activity within the idle timeout.
+    pub fn need_drop_page_cache(&self) -> bool {
+        self.is_finished()
+            && !self.is_uploading()
+            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+    }
+
+    /// Returns whether the persistent task needs to be evicted: not
+    /// persistent and the download is finished, failed, or has exceeded the
+    /// download timeout.
+    pub fn need_evict(&self) -> bool {
+        !self.is_persistent()
+            && (self.is_finished()
+                || self.is_failed()
+                || self.created_at + DEFAULT_DOWNLOAD_TASK_TIMEOUT < Utc::now().naive_utc())
+    }
+
     /// Returns whether the persistent task downloads failed.
     pub fn is_failed(&self) -> bool {
         self.failed_at.is_some()
@@ -292,6 +337,25 @@ impl PersistentCacheTask {
     /// Returns whether the persistent cache task is expired.
     pub fn is_expired(&self) -> bool {
         self.created_at + self.ttl < Utc::now().naive_utc()
+    }
+
+    /// Returns whether the page cache of the persistent cache task needs to
+    /// be dropped: downloads finished, not uploading and no download or
+    /// upload activity within the idle timeout.
+    pub fn need_drop_page_cache(&self) -> bool {
+        self.is_finished()
+            && !self.is_uploading()
+            && self.updated_at + DEFAULT_PAGE_CACHE_IDLE_TIMEOUT < Utc::now().naive_utc()
+    }
+
+    /// Returns whether the persistent cache task needs to be evicted: not
+    /// persistent and the download is finished, failed, or has exceeded the
+    /// download timeout.
+    pub fn need_evict(&self) -> bool {
+        !self.is_persistent()
+            && (self.is_finished()
+                || self.is_failed()
+                || self.created_at + DEFAULT_DOWNLOAD_TASK_TIMEOUT < Utc::now().naive_utc())
     }
 
     /// Returns whether the persistent cache task downloads failed.
@@ -1630,6 +1694,46 @@ impl Metadata<RocksdbStorageEngine> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_task_need_drop_page_cache() {
+        let mut task = Task {
+            finished_at: Some(Utc::now().naive_utc()),
+            ..Default::default()
+        };
+        assert!(task.need_drop_page_cache());
+
+        task.uploading_count = 1;
+        assert!(!task.need_drop_page_cache());
+
+        task.uploading_count = 0;
+        task.updated_at = Utc::now().naive_utc();
+        assert!(!task.need_drop_page_cache());
+
+        task.updated_at = NaiveDateTime::default();
+        task.finished_at = None;
+        assert!(!task.need_drop_page_cache());
+    }
+
+    #[test]
+    fn test_task_need_evict() {
+        let mut task = Task {
+            created_at: Utc::now().naive_utc(),
+            ..Default::default()
+        };
+        assert!(!task.need_evict());
+
+        task.failed_at = Some(Utc::now().naive_utc());
+        assert!(task.need_evict());
+
+        task.failed_at = None;
+        task.finished_at = Some(Utc::now().naive_utc());
+        assert!(task.need_evict());
+
+        task.finished_at = None;
+        task.created_at = NaiveDateTime::default();
+        assert!(task.need_evict());
+    }
 
     #[test]
     fn test_calculate_digest() {

--- a/dragonfly-client-storage/src/metadata.rs
+++ b/dragonfly-client-storage/src/metadata.rs
@@ -37,7 +37,7 @@ pub const DEFAULT_DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(24 * 60 
 /// The default timeout for the finished task to be considered cold, which covers
 /// the propagation window of the task and the reads of the hard linked
 /// destination. The page cache of the cold task is dropped.
-pub const DEFAULT_PAGE_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+pub const DEFAULT_PAGE_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(40 * 60);
 
 /// The metadata of the task.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/dragonfly-client-util/src/fs/fd.rs
+++ b/dragonfly-client-util/src/fs/fd.rs
@@ -21,6 +21,9 @@ use std::io;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tracing::warn;
+
+use super::fadvise_sequential;
 
 /// The default capacity of the file descriptor cache.
 pub const DEFAULT_FD_CACHE_CAPACITY: usize = 1024;
@@ -55,6 +58,15 @@ impl FDCache {
     /// caching it if it is absent. Concurrent misses may open the file more than
     /// once, the last inserted descriptor wins and the others are closed when
     /// their readers finish.
+    ///
+    /// The descriptor is advised for sequential reads, doubling its readahead
+    /// cap over the device read_ahead_kb: 128KiB -> 256KiB on the NVMe/SSD/HDD
+    /// default, 4MiB -> 8MiB on md/RAID commonly tuned by distributions. With
+    /// a 128KiB cap, one 512KiB positional read is served by several small
+    /// readahead I/Os. At 256KiB each I/O is larger and the async readahead
+    /// marker is placed earlier, keeping the disk ahead of the sequential
+    /// in-piece reads and sendfile. The cap only bounds detected sequential
+    /// streams, so it costs nothing on random reads.
     pub async fn open(&self, path: &Path) -> Result<Arc<File>> {
         if let Some(fd) = self.read_fds.lock()?.get(path) {
             return Ok(fd.clone());
@@ -64,7 +76,14 @@ impl FDCache {
         let fd = Arc::new(
             tokio::task::spawn_blocking({
                 let path = path.clone();
-                move || File::open(path)
+                move || -> io::Result<File> {
+                    let f = File::open(path)?;
+                    fadvise_sequential(&f).unwrap_or_else(|err| {
+                        warn!("fadvise_sequential failed: {}", err);
+                    });
+
+                    Ok(f)
+                }
             })
             .await
             .map_err(io::Error::other)??,

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -22,7 +22,7 @@ pub mod fd;
 #[cfg(target_os = "linux")]
 use tracing::warn;
 
-/// fallocate allocates the space for the file and fills it with zero, only on Linux.
+/// Fallocate allocates the space for the file and fills it with zero, only on Linux.
 #[allow(unused_variables)]
 pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
     // No allocation needed for zero length. Avoids potential fallocate errors.
@@ -67,4 +67,98 @@ pub async fn fallocate(f: &fs::File, length: u64) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Fadvise dontneed advises the kernel to drop the cached pages of the whole
+/// file, only on Linux.
+#[allow(unused_variables)]
+pub async fn fadvise_dontneed(f: &fs::File) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        use dragonfly_client_core::Error;
+        use rustix::fs::{fadvise, Advice};
+        use std::os::unix::io::AsFd;
+        use tokio::io;
+
+        let f = f.try_clone().await?;
+        tokio::task::spawn_blocking(move || {
+            fadvise(f.as_fd(), 0, None, Advice::DontNeed)
+                .map_err(|err| Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
+        })
+        .await
+        .map_err(io::Error::other)??;
+    }
+
+    Ok(())
+}
+
+/// Sync file range initiates asynchronous writeback of the file range without
+/// waiting for it to complete, only on Linux.
+#[allow(unused_variables)]
+pub async fn sync_file_range(f: &std::fs::File, offset: u64, length: u64) -> Result<()> {
+    // No writeback needed for zero length. Avoids flushing from the offset
+    // to the end of file, which is the syscall behavior for zero.
+    if length == 0 {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use dragonfly_client_core::Error;
+        use std::os::unix::io::AsRawFd;
+        use tokio::io;
+
+        let f = f.try_clone()?;
+        tokio::task::spawn_blocking(move || {
+            match unsafe {
+                libc::sync_file_range(
+                    f.as_raw_fd(),
+                    offset as libc::off64_t,
+                    length as libc::off64_t,
+                    libc::SYNC_FILE_RANGE_WRITE,
+                )
+            } {
+                0 => Ok(()),
+                _ => Err(Error::IO(io::Error::last_os_error())),
+            }
+        })
+        .await
+        .map_err(io::Error::other)??;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_fadvise_dontneed() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        std::fs::write(&path, b"hello, world!").unwrap();
+
+        let f = fs::File::open(&path).await.unwrap();
+        fadvise_dontneed(&f).await.unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
+    }
+
+    #[tokio::test]
+    async fn test_sync_file_range() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        std::fs::write(&path, b"hello, world!").unwrap();
+
+        let f = std::fs::OpenOptions::new()
+            .truncate(false)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        sync_file_range(&f, 0, 13).await.unwrap();
+        sync_file_range(&f, 7, 5).await.unwrap();
+        sync_file_range(&f, 0, 0).await.unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
+    }
 }

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -109,6 +109,36 @@ pub fn fadvise_sequential(f: &std::fs::File) -> Result<()> {
     Ok(())
 }
 
+/// Fadvise willneed initiates nonblocking readahead of the file range,
+/// bypassing the sequential detection of the kernel, only on Linux.
+#[allow(unused_variables)]
+pub async fn fadvise_willneed(f: &std::fs::File, offset: u64, length: u64) -> Result<()> {
+    // No readahead needed for zero length. Avoids reading ahead from the
+    // offset to the end of file, which is the syscall behavior for zero.
+    if length == 0 {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use dragonfly_client_core::Error;
+        use rustix::fs::{fadvise, Advice};
+        use std::num::NonZeroU64;
+        use std::os::unix::io::AsFd;
+        use tokio::io;
+
+        let f = f.try_clone()?;
+        tokio::task::spawn_blocking(move || {
+            fadvise(f.as_fd(), offset, NonZeroU64::new(length), Advice::WillNeed)
+                .map_err(|err| Error::IO(io::Error::from_raw_os_error(err.raw_os_error())))
+        })
+        .await
+        .map_err(io::Error::other)??;
+    }
+
+    Ok(())
+}
+
 /// Sync file range initiates asynchronous writeback of the file range without
 /// waiting for it to complete, only on Linux.
 #[allow(unused_variables)]
@@ -170,6 +200,19 @@ mod tests {
 
         let f = std::fs::File::open(&path).unwrap();
         fadvise_sequential(&f).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
+    }
+
+    #[tokio::test]
+    async fn test_fadvise_willneed() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        std::fs::write(&path, b"hello, world!").unwrap();
+
+        let f = std::fs::File::open(&path).unwrap();
+        fadvise_willneed(&f, 0, 13).await.unwrap();
+        fadvise_willneed(&f, 7, 5).await.unwrap();
+        fadvise_willneed(&f, 0, 0).await.unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
     }
 

--- a/dragonfly-client-util/src/fs/mod.rs
+++ b/dragonfly-client-util/src/fs/mod.rs
@@ -92,6 +92,23 @@ pub async fn fadvise_dontneed(f: &fs::File) -> Result<()> {
     Ok(())
 }
 
+/// Fadvise sequential advises the kernel that the file will be read
+/// sequentially, doubling the readahead window, only on Linux.
+#[allow(unused_variables)]
+pub fn fadvise_sequential(f: &std::fs::File) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        use dragonfly_client_core::Error;
+        use rustix::fs::{fadvise, Advice};
+        use std::os::unix::io::AsFd;
+
+        fadvise(f.as_fd(), 0, None, Advice::Sequential)
+            .map_err(|err| Error::IO(std::io::Error::from_raw_os_error(err.raw_os_error())))?;
+    }
+
+    Ok(())
+}
+
 /// Sync file range initiates asynchronous writeback of the file range without
 /// waiting for it to complete, only on Linux.
 #[allow(unused_variables)]
@@ -142,6 +159,17 @@ mod tests {
 
         let f = fs::File::open(&path).await.unwrap();
         fadvise_dontneed(&f).await.unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
+    }
+
+    #[test]
+    fn test_fadvise_sequential() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("task");
+        std::fs::write(&path, b"hello, world!").unwrap();
+
+        let f = std::fs::File::open(&path).unwrap();
+        fadvise_sequential(&f).unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"hello, world!");
     }
 

--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -15,20 +15,14 @@
  */
 
 use crate::grpc::scheduler::SchedulerClient;
-use chrono::Utc;
 use dragonfly_api::scheduler::v2::DeleteTaskRequest;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::Result;
 use dragonfly_client_storage::{metadata, Storage};
 use dragonfly_client_util::shutdown;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
-use tracing::{error, info, instrument};
-
-/// Timeout for downloading tasks. Tasks that exceed this timeout will be
-/// garbage collected by disk usage. Default is 24 hours.
-pub const DOWNLOAD_TASK_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+use tracing::{debug, error, info, instrument};
 
 /// Garbage collector for dfdaemon.
 pub struct GC {
@@ -81,6 +75,11 @@ impl GC {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
+                    // Drop the page cache of the cold tasks.
+                    if let Err(err) = self.drop_task_page_cache().await {
+                        info!("failed to drop task page cache: {}", err);
+                    }
+
                     // Evict the task by ttl.
                     if let Err(err) = self.evict_task_by_ttl().await {
                         info!("failed to evict task by ttl: {}", err);
@@ -91,6 +90,11 @@ impl GC {
                         info!("failed to evict task by disk usage: {}", err);
                     }
 
+                    // Drop the page cache of the cold persistent cache tasks.
+                    if let Err(err) = self.drop_persistent_cache_task_page_cache().await {
+                        info!("failed to drop persistent cache task page cache: {}", err);
+                    }
+
                     // Evict the persistent cache task by ttl.
                     if let Err(err) = self.evict_persistent_cache_task_by_ttl().await {
                         info!("failed to evict persistent cache task by ttl: {}", err);
@@ -99,6 +103,11 @@ impl GC {
                     // Evict the cache by disk usage.
                     if let Err(err) = self.evict_persistent_cache_task_by_disk_usage().await {
                         info!("failed to evict persistent cache task by disk usage: {}", err);
+                    }
+
+                    // Drop the page cache of the cold persistent tasks.
+                    if let Err(err) = self.drop_persistent_task_page_cache().await {
+                        info!("failed to drop persistent task page cache: {}", err);
                     }
 
                     // Evict the persistent task by ttl.
@@ -136,6 +145,28 @@ impl GC {
         }
 
         info!("evict by task ttl done");
+        Ok(())
+    }
+
+    /// Drops the page cache of the cold tasks, so the
+    /// write-once content does not occupy the page cache of the node.
+    #[instrument(skip_all)]
+    async fn drop_task_page_cache(&self) -> Result<()> {
+        info!("start to drop task page cache");
+        for task in self.storage.get_tasks()? {
+            // The drop is idempotent, so the task heated by new uploads is
+            // dropped again after it cools down.
+            if task.need_drop_page_cache() {
+                self.storage
+                    .fadvise_dontneed_task(&task.id)
+                    .await
+                    .unwrap_or_else(|err| {
+                        debug!("failed to drop page cache of task {}: {}", task.id, err);
+                    });
+            }
+        }
+
+        info!("drop task page cache done");
         Ok(())
     }
 
@@ -200,14 +231,9 @@ impl GC {
                 }
             };
 
-            //  If the task is started and not finished, and the task download is not timeout,
-            //  skip it.
-            if task.is_started()
-                && !task.is_finished()
-                && !task.is_failed()
-                && (task.created_at + DOWNLOAD_TASK_TIMEOUT > Utc::now().naive_utc())
-            {
-                info!("task {} is started and not finished, skip it", task.id);
+            // If the task does not need to be evicted, skip it.
+            if !task.need_evict() {
+                info!("task {} does not need to be evicted, skip it", task.id);
                 continue;
             }
 
@@ -253,6 +279,31 @@ impl GC {
         }
 
         info!("evict by persistent task ttl done");
+        Ok(())
+    }
+
+    /// Drops the page cache of the cold persistent tasks,
+    /// so the write-once content does not occupy the page cache of the node.
+    #[instrument(skip_all)]
+    async fn drop_persistent_task_page_cache(&self) -> Result<()> {
+        info!("start to drop persistent task page cache");
+        for task in self.storage.get_persistent_tasks()? {
+            // Unlike the evictions, the persistent task is not skipped, since
+            // dropping the page cache does not delete the content.
+            if task.need_drop_page_cache() {
+                self.storage
+                    .fadvise_dontneed_persistent_task(&task.id)
+                    .await
+                    .unwrap_or_else(|err| {
+                        debug!(
+                            "failed to drop page cache of persistent task {}: {}",
+                            task.id, err
+                        );
+                    });
+            }
+        }
+
+        info!("drop persistent task page cache done");
         Ok(())
     }
 
@@ -305,6 +356,31 @@ impl GC {
         Ok(())
     }
 
+    /// Drops the page cache of the cold persistent cache tasks, so the write-once content does not occupy the page cache of the
+    /// node.
+    #[instrument(skip_all)]
+    async fn drop_persistent_cache_task_page_cache(&self) -> Result<()> {
+        info!("start to drop persistent cache task page cache");
+        for task in self.storage.get_persistent_cache_tasks()? {
+            // Unlike the evictions, the persistent task is not skipped, since
+            // dropping the page cache does not delete the content.
+            if task.need_drop_page_cache() {
+                self.storage
+                    .fadvise_dontneed_persistent_cache_task(&task.id)
+                    .await
+                    .unwrap_or_else(|err| {
+                        debug!(
+                            "failed to drop page cache of persistent cache task {}: {}",
+                            task.id, err
+                        );
+                    });
+            }
+        }
+
+        info!("drop persistent cache task page cache done");
+        Ok(())
+    }
+
     /// Evicts persistent cache tasks when disk usage exceeds the threshold.
     #[instrument(skip_all)]
     async fn evict_persistent_cache_task_by_disk_usage(&self) -> Result<()> {
@@ -351,20 +427,10 @@ impl GC {
                 break;
             }
 
-            // If the persistent task is persistent, skip it.
-            if task.is_persistent() {
-                continue;
-            }
-
-            //  If the task is started and not finished, and the task download is not timeout,
-            //  skip it.
-            if task.is_started()
-                && !task.is_finished()
-                && !task.is_failed()
-                && (task.created_at + DOWNLOAD_TASK_TIMEOUT > Utc::now().naive_utc())
-            {
+            // If the persistent task does not need to be evicted, skip it.
+            if !task.need_evict() {
                 info!(
-                    "persistent task {} is started and not finished, skip it",
+                    "persistent task {} does not need to be evicted, skip it",
                     task.id
                 );
                 continue;
@@ -396,20 +462,10 @@ impl GC {
                 break;
             }
 
-            // If the persistent cache task is persistent, skip it.
-            if task.is_persistent() {
-                continue;
-            }
-
-            //  If the task is started and not finished, and the task download is not timeout,
-            //  skip it.
-            if task.is_started()
-                && !task.is_finished()
-                && !task.is_failed()
-                && (task.created_at + DOWNLOAD_TASK_TIMEOUT > Utc::now().naive_utc())
-            {
+            // If the persistent cache task does not need to be evicted, skip it.
+            if !task.need_evict() {
                 info!(
-                    "persistent cache task {} is started and not finished, skip it",
+                    "persistent cache task {} does not need to be evicted, skip it",
                     task.id
                 );
                 continue;

--- a/dragonfly-client/src/gc/mod.rs
+++ b/dragonfly-client/src/gc/mod.rs
@@ -156,7 +156,7 @@ impl GC {
         for task in self.storage.get_tasks()? {
             // The drop is idempotent, so the task heated by new uploads is
             // dropped again after it cools down.
-            if task.need_drop_page_cache() {
+            if task.need_drop_page_cache(self.config.gc.policy.page_cache_idle_timeout) {
                 self.storage
                     .fadvise_dontneed_task(&task.id)
                     .await
@@ -290,7 +290,7 @@ impl GC {
         for task in self.storage.get_persistent_tasks()? {
             // Unlike the evictions, the persistent task is not skipped, since
             // dropping the page cache does not delete the content.
-            if task.need_drop_page_cache() {
+            if task.need_drop_page_cache(self.config.gc.policy.page_cache_idle_timeout) {
                 self.storage
                     .fadvise_dontneed_persistent_task(&task.id)
                     .await
@@ -364,7 +364,7 @@ impl GC {
         for task in self.storage.get_persistent_cache_tasks()? {
             // Unlike the evictions, the persistent task is not skipped, since
             // dropping the page cache does not delete the content.
-            if task.need_drop_page_cache() {
+            if task.need_drop_page_cache(self.config.gc.policy.page_cache_idle_timeout) {
                 self.storage
                     .fadvise_dontneed_persistent_cache_task(&task.id)
                     .await

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -36,14 +36,8 @@ use std::time::Instant;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 use tracing::{debug, error, instrument, warn, Span};
 
-/// The maximum piece count. If the piece count is upper
-/// than MAX_PIECE_COUNT, the piece length will be optimized by the file length.
-/// When piece length became the MAX_PIECE_LENGTH, the piece count
-/// probably will be upper than MAX_PIECE_COUNT.
-pub const MAX_PIECE_COUNT: u64 = 500;
-
 /// The minimum piece length.
-pub const MIN_PIECE_LENGTH: u64 = 4 * 1024 * 1024;
+pub use dragonfly_client_config::MIN_PIECE_LENGTH;
 
 /// The maximum piece length.
 pub const MAX_PIECE_LENGTH: u64 = 64 * 1024 * 1024;
@@ -290,6 +284,12 @@ impl Piece {
 
     /// Calculates the piece size by content_length.
     pub fn calculate_piece_length(&self, strategy: PieceLengthStrategy) -> u64 {
+        // The maximum piece count. If the piece count is upper than
+        // MAX_PIECE_COUNT, the piece length will be optimized by the file
+        // length. When piece length became the MAX_PIECE_LENGTH, the piece
+        // count probably will be upper than MAX_PIECE_COUNT.
+        const MAX_PIECE_COUNT: u64 = 500;
+
         match strategy {
             PieceLengthStrategy::OptimizeByFileLength(content_length) => {
                 let piece_length = (content_length as f64 / MAX_PIECE_COUNT as f64) as u64;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces enhancements to the page cache management and I/O efficiency for task content in the Dragonfly client, across both Linux and macOS implementations. The main improvements are the addition of explicit APIs for dropping cached pages, better control over page cache idle timeouts, and optimizations for readahead and writeback behaviors during file operations. These changes aim to improve resource usage and performance, especially under heavy workloads.

**Page Cache Management Enhancements:**

* Added new methods (`fadvise_dontneed_task`, `fadvise_dontneed_persistent_task`, `fadvise_dontneed_persistent_cache_task`) to explicitly drop cached pages for task, persistent task, and persistent cache task content, improving memory management. [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R249-R255) [[2]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R596-R602) [[3]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R882-R888) [[4]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cR277-R283) [[5]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cR624-R630)
* Introduced a configurable `page_cache_idle_timeout` field in the `Policy` struct, with a default of 40 minutes, allowing automatic dropping of page cache for inactive tasks. This is now included in the default configuration and test profiles. [[1]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1091-R1099) [[2]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR324-R330) [[3]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR1144) [[4]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR2188) [[5]](diffhunk://#diff-1d4c7839a6a08bcaef14196c90b20366303b24b2826e1bc9123574a815e7c1ddR2199)

**I/O Performance Optimizations:**

* After copying task, persistent task, or persistent cache task content, the code now explicitly triggers writeback using `sync_file_range`, reducing the risk of dirty page accumulation and improving I/O responsiveness. [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L218-R227) [[2]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L436-R467) [[3]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L699-R752) [[4]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL246-R255) [[5]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL464-R495) [[6]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL727-R780)
* When reading pieces of content, explicit readahead is queued using `fadvise_willneed` to compensate for interleaved uploads, which can break the kernel's sequential read detection. [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R275-R280) [[2]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R491-R496) [[3]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60R776-R781) [[4]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cR303-R308) [[5]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cR519-R524) [[6]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cR804-R809)

**Testing Improvements:**

* Added comprehensive async tests for the new `fadvise_dontneed_*` APIs to ensure correct cache dropping behavior and error handling when content is missing.

**Dependency and Import Updates:**

* Updated imports in both Linux and macOS content modules to include new fs utility functions (`fadvise_dontneed`, `fadvise_willneed`, `sync_file_range`). [[1]](diffhunk://#diff-14656a0beba1f862d613174e11202e6acc58af3a312f47bfe34424eb27e87d60L23-R24) [[2]](diffhunk://#diff-6450500e03c490063aaf315db98d87f267b81ecdfb583e9de82ab08f5c485f8cL23-R24)

These changes collectively provide finer control over memory and I/O resource usage, making the client more robust and efficient under various workloads.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
