### PR TITLE
chore(tests): install crypto provider before backend tests

### DIFF
--- a/dragonfly-client-backend/src/hdfs.rs
+++ b/dragonfly-client-backend/src/hdfs.rs
@@ -302,6 +302,8 @@ mod tests {
 
     #[tokio::test]
     async fn should_get_operator() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let url: Url = Url::parse("hdfs://127.0.0.1:9870/file").unwrap();
         let operator = Hdfs::new().operator(url, None, Duration::from_secs(10));
 

--- a/dragonfly-client-backend/src/object_storage.rs
+++ b/dragonfly-client-backend/src/object_storage.rs
@@ -1015,6 +1015,8 @@ mod tests {
 
     #[test]
     fn should_get_operator() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             (
                 Scheme::S3,
@@ -1083,6 +1085,8 @@ mod tests {
 
     #[test]
     fn should_get_s3_operator_with_extra_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             ObjectStorageInfo {
                 access_key_id: Some("access_key_id".into()),
@@ -1123,6 +1127,8 @@ mod tests {
 
     #[test]
     fn should_get_gcs_operator_with_extra_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             ObjectStorageInfo {
                 credential_path: Some("credential_path".into()),
@@ -1174,6 +1180,8 @@ mod tests {
 
     #[test]
     fn should_return_error_when_lacks_of_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let url: Url = "s3://test-bucket/file".parse().unwrap();
         let parsed_url: ParsedURL = url.try_into().unwrap();
 
@@ -1190,6 +1198,8 @@ mod tests {
 
     #[test]
     fn should_return_error_when_abs_lacks_of_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             (
                 ObjectStorageInfo::default(),
@@ -1234,6 +1244,8 @@ mod tests {
 
     #[test]
     fn should_return_error_when_oss_lacks_of_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             (
                 ObjectStorageInfo::default(),
@@ -1278,6 +1290,8 @@ mod tests {
 
     #[test]
     fn should_return_error_when_obs_lacks_of_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             (
                 ObjectStorageInfo::default(),
@@ -1322,6 +1336,8 @@ mod tests {
 
     #[test]
     fn should_return_error_when_cos_lacks_of_info() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             (
                 ObjectStorageInfo::default(),
@@ -1366,6 +1382,8 @@ mod tests {
 
     #[test]
     fn should_handle_insecure_skip_verify_parameter() {
+        dragonfly_client_util::tls::install_crypto_provider();
+
         let test_cases = vec![
             ObjectStorageInfo {
                 endpoint: Some("https://oss-cn-beijing.aliyuncs.com".into()),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

All backend tests for HDFS and object storage now call `install_crypto_provider()` at the start to ensure the TLS crypto provider is initialized before operator construction.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
