### PR TITLE
Refactor QUIC client to reuse connection for multiple streams

### DIFF
--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -22,7 +22,7 @@ use dragonfly_client_core::{
 };
 use futures::StreamExt;
 use quinn::crypto::rustls::QuicClientConfig;
-use quinn::{AckFrequencyConfig, ClientConfig, Endpoint, RecvStream, SendStream, TransportConfig};
+use quinn::{AckFrequencyConfig, ClientConfig, Connection, Endpoint, RecvStream, TransportConfig};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -46,13 +46,63 @@ pub struct QUICClient {
 
     /// The address of the QUIC server.
     addr: String,
+
+    /// The connection to the server, multiplexing piece downloads as
+    /// bi-directional streams.
+    connection: Connection,
 }
 
 /// Implements the QUIC-based client for quic storage service.
 impl QUICClient {
-    /// Creates a new QUICClient instance.
-    pub fn new(config: Arc<Config>, addr: String) -> Self {
-        Self { config, addr }
+    /// Creates a new QUICClient connected to the server.
+    pub async fn new(config: Arc<Config>, addr: String) -> ClientResult<Self> {
+        let mut client_config = ClientConfig::new(Arc::new(
+            QuicClientConfig::try_from(
+                quinn::rustls::ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(NoVerifier::new())
+                    .with_no_client_auth(),
+            )
+            .map_err(|err| {
+                ClientError::Unknown(format!("failed to create quic client config: {err}"))
+            })?,
+        ));
+
+        let mut transport = TransportConfig::default();
+        transport.keep_alive_interval(Some(super::DEFAULT_KEEPALIVE_INTERVAL));
+        transport.max_idle_timeout(Some(super::DEFAULT_MAX_IDLE_TIMEOUT.try_into().unwrap()));
+        transport.ack_frequency_config(Some(AckFrequencyConfig::default()));
+        transport.send_window(super::DEFAULT_SEND_BUFFER_SIZE as u64);
+        transport.receive_window((super::DEFAULT_RECV_BUFFER_SIZE as u32).into());
+        transport.stream_receive_window((super::DEFAULT_RECV_BUFFER_SIZE as u32).into());
+        client_config.transport_config(Arc::new(transport));
+
+        // Port is zero to let the OS assign an ephemeral port, so each client
+        // is a distinct flow to the server.
+        let mut endpoint = Endpoint::client(SocketAddr::new(config.storage.server.ip.unwrap(), 0))?;
+        endpoint.set_default_client_config(client_config);
+
+        // Connect's server name used for verifying the certificate. Since we used
+        // NoVerifier, it can be anything.
+        let connecting = endpoint
+            .connect(addr.parse().or_err(ErrorType::ParseError)?, "d7y")
+            .or_err(ErrorType::ConnectError)?;
+
+        let connection = time::timeout(super::DEFAULT_CONNECT_TIMEOUT, connecting)
+            .await?
+            .inspect_err(|err| error!("failed to connect to {}: {}", addr, err))
+            .or_err(ErrorType::ConnectError)?;
+
+        Ok(Self {
+            config,
+            addr,
+            connection,
+        })
+    }
+
+    /// Returns true if the connection is closed.
+    pub fn is_closed(&self) -> bool {
+        self.connection.close_reason().is_some()
     }
 
     /// Converts the QUIC stream holding the piece content into a stream of
@@ -94,8 +144,8 @@ impl QUICClient {
     ///
     /// This method performs the actual protocol communication:
     /// 1. Creates a download piece request.
-    /// 2. Establishes QUIC connection and sends the request.
-    /// 3. Reads and validates the response header.
+    /// 2. Opens a stream over the connection and sends the request.
+    /// 3. Receives and validates the response header.
     /// 4. Processes the piece content based on the response type.
     #[instrument(skip_all)]
     async fn handle_download_piece(
@@ -109,12 +159,12 @@ impl QUICClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let mut reader = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PieceContent => {
                 let piece_content: piece_content::PieceContent = self
-                    .read_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
+                    .recv_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
                     .await?;
 
                 let metadata = piece_content.metadata();
@@ -124,7 +174,7 @@ impl QUICClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -167,12 +217,12 @@ impl QUICClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let mut reader = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PersistentPieceContent => {
                 let persistent_piece_content: persistent_piece_content::PersistentPieceContent =
-                    self.read_piece_content(
+                    self.recv_piece_content(
                         &mut reader,
                         persistent_piece_content::METADATA_LENGTH_SIZE,
                     )
@@ -185,7 +235,7 @@ impl QUICClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -228,12 +278,12 @@ impl QUICClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let mut reader = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PersistentCachePieceContent => {
                 let persistent_cache_piece_content: persistent_cache_piece_content::PersistentCachePieceContent =
-                self.read_piece_content(&mut reader, persistent_cache_piece_content::METADATA_LENGTH_SIZE)
+                self.recv_piece_content(&mut reader, persistent_cache_piece_content::METADATA_LENGTH_SIZE)
                 .await?;
 
                 let metadata = persistent_cache_piece_content.metadata();
@@ -243,7 +293,7 @@ impl QUICClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -251,54 +301,12 @@ impl QUICClient {
         }
     }
 
-    /// Establishes QUIC connection and writes a vortex protocol request.
-    ///
-    /// This is a low-level utility function that handles the QUIC connection
-    /// lifecycle and request transmission. It ensures proper error handling
-    /// and connection cleanup.
+    /// Sends a vortex protocol request over a new bi-directional stream and
+    /// returns the stream holding the response.
     #[instrument(skip_all)]
-    async fn connect_and_write_request(
-        &self,
-        request: Bytes,
-    ) -> ClientResult<(RecvStream, SendStream)> {
-        let mut client_config = ClientConfig::new(Arc::new(
-            QuicClientConfig::try_from(
-                quinn::rustls::ClientConfig::builder()
-                    .dangerous()
-                    .with_custom_certificate_verifier(NoVerifier::new())
-                    .with_no_client_auth(),
-            )
-            .map_err(|err| {
-                ClientError::Unknown(format!("failed to create quic client config: {err}"))
-            })?,
-        ));
-
-        let mut transport = TransportConfig::default();
-        transport.keep_alive_interval(Some(super::DEFAULT_KEEPALIVE_INTERVAL));
-        transport.max_idle_timeout(Some(super::DEFAULT_MAX_IDLE_TIMEOUT.try_into().unwrap()));
-        transport.ack_frequency_config(Some(AckFrequencyConfig::default()));
-        transport.send_window(super::DEFAULT_SEND_BUFFER_SIZE as u64);
-        transport.receive_window((super::DEFAULT_RECV_BUFFER_SIZE as u32).into());
-        transport.stream_receive_window((super::DEFAULT_RECV_BUFFER_SIZE as u32).into());
-        client_config.transport_config(Arc::new(transport));
-
-        // Port is zero to let the OS assign an ephemeral port.
-        let mut endpoint =
-            Endpoint::client(SocketAddr::new(self.config.storage.server.ip.unwrap(), 0))?;
-        endpoint.set_default_client_config(client_config);
-
-        // Connect's server name used for verifying the certificate. Since we used
-        // NoVerifier, it can be anything.
-        let connecting = endpoint
-            .connect(self.addr.parse().or_err(ErrorType::ParseError)?, "d7y")
-            .or_err(ErrorType::ConnectError)?;
-
-        let connection = tokio::time::timeout(super::DEFAULT_CONNECT_TIMEOUT, connecting)
-            .await?
-            .inspect_err(|err| error!("failed to connect to {}: {}", self.addr, err))
-            .or_err(ErrorType::ConnectError)?;
-
-        let (mut writer, reader) = connection
+    async fn send_request(&self, request: Bytes) -> ClientResult<RecvStream> {
+        let (mut writer, reader) = self
+            .connection
             .open_bi()
             .await
             .inspect_err(|err| error!("failed to open bi stream: {}", err))
@@ -310,16 +318,19 @@ impl QUICClient {
             .inspect_err(|err| error!("failed to send request: {}", err))
             .or_err(ErrorType::ConnectError)?;
 
-        Ok((reader, writer))
+        // Finish the send half so the request is delivered reliably instead
+        // of being reset when the writer drops.
+        writer.finish().or_err(ErrorType::ConnectError)?;
+        Ok(reader)
     }
 
-    /// Reads and parses a vortex protocol header from the QUIC stream.
+    /// Receives and parses a vortex protocol header from the QUIC stream.
     ///
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
     #[instrument(skip_all)]
-    async fn read_header(&self, reader: &mut RecvStream) -> ClientResult<Header> {
+    async fn recv_header(&self, reader: &mut RecvStream) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
         reader
@@ -331,13 +342,13 @@ impl QUICClient {
         Header::try_from(header_bytes.freeze()).map_err(Into::into)
     }
 
-    /// Reads and parses piece content with variable-length metadata.
+    /// Receives and parses piece content with variable-length metadata.
     ///
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
     #[instrument(skip_all)]
-    async fn read_piece_content<T>(
+    async fn recv_piece_content<T>(
         &self,
         reader: &mut RecvStream,
         metadata_length_size: usize,
@@ -368,13 +379,13 @@ impl QUICClient {
         content_bytes.freeze().try_into().map_err(Into::into)
     }
 
-    /// Reads and processes error responses from the server.
+    /// Receives and processes error responses from the server.
     ///
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
     #[instrument(skip_all)]
-    async fn read_error(&self, reader: &mut RecvStream, header_length: usize) -> ClientError {
+    async fn recv_error(&self, reader: &mut RecvStream, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);
         if let Err(err) = reader.read_exact(&mut error_bytes).await {

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -84,7 +84,7 @@ impl TCPClient {
     /// This method performs the actual protocol communication:
     /// 1. Creates a download piece request.
     /// 2. Establishes TCP connection and sends the request.
-    /// 3. Reads and validates the response header.
+    /// 3. Receives and validates the response header.
     /// 4. Processes the piece content based on the response type.
     #[instrument(skip_all)]
     async fn handle_download_piece(
@@ -98,12 +98,12 @@ impl TCPClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let (mut reader, _writer) = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PieceContent => {
                 let piece_content: piece_content::PieceContent = self
-                    .read_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
+                    .recv_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
                     .await?;
                 debug!("received piece content: {:?}", piece_content.metadata());
 
@@ -114,7 +114,7 @@ impl TCPClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -157,12 +157,12 @@ impl TCPClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let (mut reader, _writer) = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PersistentPieceContent => {
                 let persistent_piece_content: persistent_piece_content::PersistentPieceContent =
-                    self.read_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
+                    self.recv_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
                         .await?;
                 debug!(
                     "received piece content: {:?}",
@@ -176,7 +176,7 @@ impl TCPClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -219,12 +219,12 @@ impl TCPClient {
         )
         .into();
 
-        let (mut reader, _writer) = self.connect_and_write_request(request).await?;
-        let header = self.read_header(&mut reader).await?;
+        let (mut reader, _writer) = self.send_request(request).await?;
+        let header = self.recv_header(&mut reader).await?;
         match header.tag() {
             Tag::PersistentCachePieceContent => {
                 let persistent_cache_piece_content: persistent_cache_piece_content::PersistentCachePieceContent =
-                    self.read_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
+                    self.recv_piece_content(&mut reader, piece_content::METADATA_LENGTH_SIZE)
                         .await?;
                 debug!(
                     "received piece content: {:?}",
@@ -238,7 +238,7 @@ impl TCPClient {
                     metadata.digest,
                 ))
             }
-            Tag::Error => Err(self.read_error(&mut reader, header.length() as usize).await),
+            Tag::Error => Err(self.recv_error(&mut reader, header.length() as usize).await),
             _ => Err(ClientError::Unknown(format!(
                 "unexpected tag: {:?}",
                 header.tag()
@@ -246,16 +246,13 @@ impl TCPClient {
         }
     }
 
-    /// Establishes TCP connection and writes a vortex protocol request.
+    /// Establishes a TCP connection and sends a vortex protocol request.
     ///
     /// This is a low-level utility function that handles the TCP connection
     /// lifecycle and request transmission. It ensures proper error handling
     /// and connection cleanup.
     #[instrument(skip_all)]
-    async fn connect_and_write_request(
-        &self,
-        request: Bytes,
-    ) -> ClientResult<(OwnedReadHalf, OwnedWriteHalf)> {
+    async fn send_request(&self, request: Bytes) -> ClientResult<(OwnedReadHalf, OwnedWriteHalf)> {
         let stream = tokio::time::timeout(
             super::DEFAULT_CONNECT_TIMEOUT,
             tokio::net::TcpStream::connect(self.addr.clone()),
@@ -300,13 +297,13 @@ impl TCPClient {
         Ok((reader, writer))
     }
 
-    /// Reads and parses a vortex protocol header from the TCP stream.
+    /// Receives and parses a vortex protocol header from the TCP stream.
     ///
     /// The header contains metadata about the following message, including
     /// the message type (tag) and payload length. This is critical for
     /// proper protocol message framing.
     #[instrument(skip_all)]
-    async fn read_header(&self, reader: &mut OwnedReadHalf) -> ClientResult<Header> {
+    async fn recv_header(&self, reader: &mut OwnedReadHalf) -> ClientResult<Header> {
         let mut header_bytes = BytesMut::with_capacity(HEADER_SIZE);
         header_bytes.resize(HEADER_SIZE, 0);
         reader
@@ -319,13 +316,13 @@ impl TCPClient {
         Header::try_from(header_bytes.freeze()).map_err(Into::into)
     }
 
-    /// Reads and parses piece content with variable-length metadata.
+    /// Receives and parses piece content with variable-length metadata.
     ///
     /// This generic function handles the two-stage reading process for
     /// piece content: first reading the metadata length, then reading
     /// the actual metadata, and finally constructing the complete message.
     #[instrument(skip_all)]
-    async fn read_piece_content<T>(
+    async fn recv_piece_content<T>(
         &self,
         reader: &mut OwnedReadHalf,
         metadata_length_size: usize,
@@ -358,13 +355,13 @@ impl TCPClient {
         content_bytes.freeze().try_into().map_err(Into::into)
     }
 
-    /// Reads and processes error responses from the server.
+    /// Receives and processes error responses from the server.
     ///
     /// When the server responds with an error tag, this function reads
     /// the error payload and converts it into an appropriate client error.
     /// This provides structured error handling for protocol-level failures.
     #[instrument(skip_all)]
-    async fn read_error(&self, reader: &mut OwnedReadHalf, header_length: usize) -> ClientError {
+    async fn recv_error(&self, reader: &mut OwnedReadHalf, header_length: usize) -> ClientError {
         let mut error_bytes = BytesMut::with_capacity(header_length);
         error_bytes.resize(header_length, 0);
         if let Err(err) = reader.read_exact(&mut error_bytes).await {

--- a/dragonfly-client/src/resource/piece_downloader.rs
+++ b/dragonfly-client/src/resource/piece_downloader.rs
@@ -120,9 +120,9 @@ struct QUICClientFactory {
 impl Factory<String, QUICClient> for QUICClientFactory {
     type Error = Error;
 
-    /// Creates a new QUICClient for the given address.
+    /// Creates a new QUICClient connected to the given address.
     async fn make_client(&self, addr: &String) -> Result<QUICClient> {
-        Ok(QUICClient::new(self.config.clone(), addr.clone()))
+        QUICClient::new(self.config.clone(), addr.clone()).await
     }
 }
 
@@ -143,8 +143,15 @@ impl QUICDownloader {
         }
     }
 
-    /// Returns a client entry by the address.
+    /// Returns a client entry by the address, recreating the client if its
+    /// connection is closed.
     async fn get_client_entry(&self, key: String, addr: String) -> Result<Entry<QUICClient>> {
+        let entry = self.client_pool.entry(&key, &addr).await?;
+        if !entry.client.is_closed() {
+            return Ok(entry);
+        }
+
+        self.client_pool.remove_entry(&key).await;
         self.client_pool.entry(&key, &addr).await
     }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously a new QUIC connection (and endpoint) was created for every single request. Now QUICClient holds a single Connection established at construction time, and each download request opens a new bi-directional stream over that shared connection. The client pool checks whether the connection is still alive before reusing an entry, and recreates it when the connection has been closed. The send half of each stream is now explicitly finished so the request is delivered reliably. Internal helper methods are renamed from read_*/connect_and_write_request to recv_*/send_request to better reflect their role.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
