### PR TITLE
Handle transient accept errors in storage/server without aborting

### DIFF
--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -110,15 +110,22 @@ impl QUICServer {
         loop {
             tokio::select! {
                 Some(quic_accepted) = endpoint.accept() => {
-                    let quic = quic_accepted.await.or_err(
-                        ErrorType::ConnectError
-                    )?;
-                    let remote_address = quic.remote_address();
-                    debug!("accepted connection from {}", remote_address);
-
                     let handler = self.handler.clone();
                     tokio::spawn(async move {
-                       if let Err(err) = handler.handle(quic, remote_address).await {
+                        // Await the handshake in the task, so a slow or failed
+                        // handshake does not block or kill the accept loop.
+                        let quic = match quic_accepted.await {
+                            Ok(quic) => quic,
+                            Err(err) => {
+                                error!("failed to accept connection: {}", err);
+                                return;
+                            }
+                        };
+
+                        let remote_address = quic.remote_address();
+                        debug!("accepted connection from {}", remote_address);
+
+                        if let Err(err) = handler.handle(quic, remote_address).await {
                             error!("failed to handle connection from {}: {}", remote_address, err);
                         }
                     });

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -146,7 +146,15 @@ impl TCPServer {
         loop {
             tokio::select! {
                 tcp_accepted = listener.accept() => {
-                    let (tcp, remote_address) = tcp_accepted?;
+                    let (tcp, remote_address) = match tcp_accepted {
+                        Ok(accepted) => accepted,
+                        // Accept errors are transient (e.g. ECONNABORTED,
+                        // EMFILE), so keep serving.
+                        Err(err) => {
+                            error!("failed to accept connection: {}", err);
+                            continue;
+                        }
+                    };
                     debug!("accepted connection from {}", remote_address);
 
                     let handler = self.handler.clone();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, a failed TCP accept would propagate the error and terminate the accept loop, and a slow or failed QUIC handshake would block or kill the accept loop. Both servers now log the error and continue serving instead of aborting.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
