### PR TITLE
refactor(storage): move buffer size tuning from TCP to QUIC sockets

### DIFF
--- a/dragonfly-client-storage/src/client/quic.rs
+++ b/dragonfly-client-storage/src/client/quic.rs
@@ -22,8 +22,12 @@ use dragonfly_client_core::{
 };
 use futures::StreamExt;
 use quinn::crypto::rustls::QuicClientConfig;
-use quinn::{AckFrequencyConfig, ClientConfig, Connection, Endpoint, RecvStream, TransportConfig};
+use quinn::{
+    AckFrequencyConfig, ClientConfig, Connection, Endpoint, EndpointConfig, RecvStream,
+    TokioRuntime, TransportConfig,
+};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
+use socket2::{Domain, Protocol, Socket, Type};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::time;
@@ -79,7 +83,23 @@ impl QUICClient {
 
         // Port is zero to let the OS assign an ephemeral port, so each client
         // is a distinct flow to the server.
-        let mut endpoint = Endpoint::client(SocketAddr::new(config.storage.server.ip.unwrap(), 0))?;
+        let bind_addr = SocketAddr::new(config.storage.server.ip.unwrap(), 0);
+        let socket = Socket::new(
+            Domain::for_address(bind_addr),
+            Type::DGRAM,
+            Some(Protocol::UDP),
+        )?;
+        socket.set_nonblocking(true)?;
+        socket.set_send_buffer_size(super::DEFAULT_SEND_BUFFER_SIZE)?;
+        socket.set_recv_buffer_size(super::DEFAULT_RECV_BUFFER_SIZE)?;
+        socket.bind(&bind_addr.into())?;
+
+        let mut endpoint = Endpoint::new(
+            EndpointConfig::default(),
+            None,
+            socket.into(),
+            Arc::new(TokioRuntime),
+        )?;
         endpoint.set_default_client_config(client_config);
 
         // Connect's server name used for verifying the certificate. Since we used

--- a/dragonfly-client-storage/src/client/tcp.rs
+++ b/dragonfly-client-storage/src/client/tcp.rs
@@ -262,8 +262,6 @@ impl TCPClient {
         let socket = SockRef::from(&stream);
         socket.set_tcp_nodelay(true)?;
         socket.set_nonblocking(true)?;
-        socket.set_send_buffer_size(super::DEFAULT_SEND_BUFFER_SIZE)?;
-        socket.set_recv_buffer_size(super::DEFAULT_RECV_BUFFER_SIZE)?;
         socket.set_tcp_keepalive(
             &TcpKeepalive::new()
                 .with_interval(super::DEFAULT_KEEPALIVE_INTERVAL)

--- a/dragonfly-client-storage/src/server/quic.rs
+++ b/dragonfly-client-storage/src/server/quic.rs
@@ -29,7 +29,11 @@ use dragonfly_client_util::{
     id_generator::IDGenerator, shutdown, tls::generate_simple_self_signed_certs,
 };
 use leaky_bucket::RateLimiter;
-use quinn::{congestion::BbrConfig, AckFrequencyConfig, Endpoint, ServerConfig, TransportConfig};
+use quinn::{
+    congestion::BbrConfig, AckFrequencyConfig, Endpoint, EndpointConfig, ServerConfig,
+    TokioRuntime, TransportConfig,
+};
+use socket2::{Domain, Protocol, Socket, Type};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{copy_buf, AsyncBufRead};
@@ -104,7 +108,22 @@ impl QUICServer {
         transport.stream_receive_window((super::DEFAULT_RECV_BUFFER_SIZE as u32).into());
         server_config.transport_config(Arc::new(transport));
 
-        let endpoint = Endpoint::server(server_config, self.addr)?;
+        let socket = Socket::new(
+            Domain::for_address(self.addr),
+            Type::DGRAM,
+            Some(Protocol::UDP),
+        )?;
+        socket.set_nonblocking(true)?;
+        socket.set_send_buffer_size(super::DEFAULT_SEND_BUFFER_SIZE)?;
+        socket.set_recv_buffer_size(super::DEFAULT_RECV_BUFFER_SIZE)?;
+        socket.bind(&self.addr.into())?;
+
+        let endpoint = Endpoint::new(
+            EndpointConfig::default(),
+            Some(server_config),
+            socket.into(),
+            Arc::new(TokioRuntime),
+        )?;
         info!("storage quic server listening on {}", self.addr);
 
         loop {

--- a/dragonfly-client-storage/src/server/tcp.rs
+++ b/dragonfly-client-storage/src/server/tcp.rs
@@ -106,8 +106,6 @@ impl TCPServer {
         )?;
         socket.set_tcp_nodelay(true)?;
         socket.set_nonblocking(true)?;
-        socket.set_send_buffer_size(super::DEFAULT_SEND_BUFFER_SIZE)?;
-        socket.set_recv_buffer_size(super::DEFAULT_RECV_BUFFER_SIZE)?;
         socket.set_tcp_keepalive(
             &TcpKeepalive::new()
                 .with_interval(super::DEFAULT_KEEPALIVE_INTERVAL)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

TCP send/recv buffer sizes are removed from both client and server TCP sockets, where the OS defaults are generally adequate. Instead, explicit send/recv buffer sizes are now set on the UDP sockets backing the QUIC endpoints, which benefit more from larger buffers due to their connectionless, high-throughput nature. QUIC endpoints are also constructed via `Endpoint::new` with a manually configured `socket2` socket instead of the convenience constructors, enabling this control.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
