### PR TITLE
chore: bump version to 1.4.9 and optimize storage/read path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "cgroups-rs",
  "http",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "bytes",
  "dragonfly-api",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "bincode",
  "bytes",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "request"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "anyhow",
  "dragonfly-client-request",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.8"
+version = "1.4.9"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -36,15 +36,15 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.2.32"
-dragonfly-client = { path = "dragonfly-client", version = "1.4.8" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.8" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.8" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.8" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.8" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.8" }
-dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.8" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.8" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.8" }
+dragonfly-client = { path = "dragonfly-client", version = "1.4.9" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.4.9" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.4.9" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.4.9" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.4.9" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.4.9" }
+dragonfly-client-request = { path = "dragonfly-client-request", version = "1.4.9" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.4.9" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.4.9" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"
@@ -156,7 +156,7 @@ incremental = true
 [profile.release]
 opt-level = 3
 strip = "symbols"
-lto = "thin"
+lto = "fat"
 panic = "abort"
 codegen-units = 1
 

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -20,18 +20,43 @@ use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
+use dragonfly_client_metric::collect_read_piece_pagecache_metrics;
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
+use dragonfly_client_util::fs::{
+    fadvise_dontneed, fadvise_willneed, fallocate, pagecache_residency, sync_file_range,
+};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::AsyncRead;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use walkdir::WalkDir;
+
+/// The interval of the piece reads sampled for pagecache residency.
+const PAGECACHE_RESIDENCY_SAMPLE_INTERVAL: u64 = 128;
+
+/// Samples the pagecache residency of the piece range off the read path and
+/// collects the metrics.
+fn sample_pagecache_residency(fd: Arc<std::fs::File>, offset: u64, length: u64) {
+    static SAMPLES: AtomicU64 = AtomicU64::new(0);
+    if SAMPLES.fetch_add(1, Ordering::Relaxed) % PAGECACHE_RESIDENCY_SAMPLE_INTERVAL != 0 {
+        return;
+    }
+
+    tokio::spawn(async move {
+        match pagecache_residency(&fd, offset, length).await {
+            Ok((cached_pages, sampled_pages)) => {
+                collect_read_piece_pagecache_metrics(cached_pages, sampled_pages)
+            }
+            Err(err) => debug!("pagecache_residency failed: {}", err),
+        }
+    });
+}
 
 /// The content of a piece.
 pub struct Content {
@@ -282,6 +307,7 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
+        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,
@@ -501,6 +527,7 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
+        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,
@@ -789,6 +816,7 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
+        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -20,12 +20,9 @@ use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
-use dragonfly_client_metric::collect_read_piece_pagecache_metrics;
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{
-    fadvise_dontneed, fadvise_willneed, fallocate, pagecache_residency, sync_file_range,
-};
+use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -34,29 +31,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::AsyncRead;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 use walkdir::WalkDir;
-
-/// The interval of the piece reads sampled for pagecache residency.
-const PAGECACHE_RESIDENCY_SAMPLE_INTERVAL: u64 = 128;
-
-/// Samples the pagecache residency of the piece range off the read path and
-/// collects the metrics.
-fn sample_pagecache_residency(fd: Arc<std::fs::File>, offset: u64, length: u64) {
-    static SAMPLES: AtomicU64 = AtomicU64::new(0);
-    if SAMPLES.fetch_add(1, Ordering::Relaxed) % PAGECACHE_RESIDENCY_SAMPLE_INTERVAL != 0 {
-        return;
-    }
-
-    tokio::spawn(async move {
-        match pagecache_residency(&fd, offset, length).await {
-            Ok((cached_pages, sampled_pages)) => {
-                collect_read_piece_pagecache_metrics(cached_pages, sampled_pages)
-            }
-            Err(err) => debug!("pagecache_residency failed: {}", err),
-        }
-    });
-}
 
 /// The content of a piece.
 pub struct Content {
@@ -307,7 +283,6 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
-        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,
@@ -527,7 +502,6 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
-        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,
@@ -816,7 +790,6 @@ impl Content {
                 .unwrap_or_else(|err| warn!("fadvise_willneed failed: {}", err));
         }
 
-        sample_pagecache_residency(fd.clone(), target_offset, target_length);
         Ok(super::io::RangeReader::new(
             fd,
             target_offset,

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -27,7 +27,6 @@ use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::AsyncRead;

--- a/dragonfly-client-storage/src/storage_engine/rocksdb.rs
+++ b/dragonfly-client-storage/src/storage_engine/rocksdb.rs
@@ -105,6 +105,7 @@ impl RocksdbStorageEngine {
         block_options.set_block_size(Self::DEFAULT_BLOCK_SIZE);
         block_options.set_cache_index_and_filter_blocks(true);
         block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        block_options.set_bloom_filter(10.0, false);
         options.set_block_based_table_factory(&block_options);
 
         // Initialize column family options.
@@ -112,6 +113,7 @@ impl RocksdbStorageEngine {
         cf_options.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(64));
         cf_options.set_memtable_prefix_bloom_ratio(0.25);
         cf_options.optimize_level_style_compaction(Self::DEFAULT_MEMTABLE_MEMORY_BUDGET);
+        cf_options.set_block_based_table_factory(&block_options);
 
         // Initialize column families.
         let cfs = cf_names


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Bump all workspace crate versions from 1.4.8 to 1.4.9
- Switch LTO from "thin" to "fat" for better release build optimization
- Enable Bloom filters on RocksDB block table and column families to reduce false-positive key lookups
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
