### PR TITLE
feat(client): add OpenCSG download support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed2bff90fc09b87623a4b0767dba75968c74c3bc033f05954effb7ba6253322"
+checksum = "547ab7dcb66a4ea98cd267fbe9e19f3cb52991580bf3bcd766a889a317001902"
 dependencies = [
  "prost 0.14.4",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
-dragonfly-api = "=2.3.0"
+dragonfly-api = "=2.3.1"
 dragonfly-client = { path = "dragonfly-client", version = "1.5.1" }
 dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.1" }
 dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.1" }

--- a/dragonfly-client-backend/src/http.rs
+++ b/dragonfly-client-backend/src/http.rs
@@ -1113,6 +1113,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1146,6 +1147,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1188,6 +1190,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1221,6 +1224,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await;
 
@@ -1254,6 +1258,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1293,6 +1298,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1329,6 +1335,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1372,6 +1379,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1399,6 +1407,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1421,6 +1430,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await;
 
@@ -1444,6 +1454,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1469,6 +1480,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await;
 
@@ -1490,6 +1502,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1515,6 +1528,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1547,6 +1561,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1578,6 +1593,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1609,6 +1625,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await;
 
@@ -1770,6 +1787,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1791,6 +1809,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1836,6 +1855,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1857,6 +1877,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1904,6 +1925,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1927,6 +1949,7 @@ LJ8gCHKBOJy9dW62DcRWw6zzlTtt9y18/Btx0Hpawg==
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .unwrap();

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -456,31 +456,25 @@ impl Backend for HuggingFace {
                     &api_base_url,
                 )?;
 
-                let response = match self
+                let response = self
                     .client
                     .get(repository_revision_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
                     .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
+                    .map_err(|err| {
                         error!(
                             "stat request failed {} {}: {}",
                             request.task_id, repository_revision_url, err
                         );
 
-                        return Ok(StatResponse {
-                            success: false,
-                            content_length: None,
-                            http_header: None,
-                            http_status_code: None,
-                            entries: Vec::new(),
-                            error_message: Some(err.to_string()),
-                        });
-                    }
-                };
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
@@ -490,14 +484,16 @@ impl Backend for HuggingFace {
                 };
 
                 if !response.status().is_success() {
-                    return Ok(StatResponse {
-                        success: false,
-                        content_length: None,
-                        http_header: Some(response_header),
-                        http_status_code: response_status_code.into(),
-                        error_message: Some(response_status_code.to_string()),
-                        entries: Vec::new(),
-                    });
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, repository_revision_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
                 }
 
                 let text = response.text().await.map_err(|err| {
@@ -791,6 +787,12 @@ impl Backend for HuggingFace {
 mod tests {
     use super::*;
     use crate::DEFAULT_USER_AGENT;
+    use dragonfly_api::common::v2::HuggingFace as HuggingFaceOptions;
+    use std::time::Duration;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     #[test]
     fn test_parse_url_simple() {
@@ -990,5 +992,41 @@ mod tests {
             request_headers.get(RANGE).unwrap(),
             HeaderValue::from_static("bytes=0-1023")
         );
+    }
+
+    #[tokio::test]
+    async fn test_stat_repository_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/models/owner/repo"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let backend = HuggingFace::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "hf://owner/repo".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: Some(HuggingFaceOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+                model_scope: None,
+                open_csg: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::UNAUTHORIZED)
+        ));
     }
 }

--- a/dragonfly-client-backend/src/hugging_face.rs
+++ b/dragonfly-client-backend/src/hugging_face.rs
@@ -398,31 +398,25 @@ impl Backend for HuggingFace {
                     &base_url,
                 )?;
 
-                let response = match self
+                let response = self
                     .client
                     .head(download_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
                     .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
+                    .map_err(|err| {
                         error!(
                             "stat request failed {} {}: {}",
                             request.task_id, download_url, err
                         );
 
-                        return Ok(StatResponse {
-                            success: false,
-                            content_length: None,
-                            http_header: None,
-                            http_status_code: None,
-                            entries: Vec::new(),
-                            error_message: Some(err.to_string()),
-                        });
-                    }
-                };
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
@@ -430,6 +424,19 @@ impl Backend for HuggingFace {
                     Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
                     None => response.content_length(),
                 };
+
+                if !response.status().is_success() {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, download_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
+                }
 
                 debug!(
                     "stat response {} {}: {:?} {:?} {:?}",
@@ -992,6 +999,42 @@ mod tests {
             request_headers.get(RANGE).unwrap(),
             HeaderValue::from_static("bytes=0-1023")
         );
+    }
+
+    #[tokio::test]
+    async fn test_stat_file_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let backend = HuggingFace::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "hf://owner/repo/model.bin".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: Some(HuggingFaceOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+                model_scope: None,
+                open_csg: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::NOT_FOUND)
+        ));
     }
 
     #[tokio::test]

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -107,7 +107,7 @@ pub struct StatRequest {
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
 
-    /// OpenCSG protocol information.
+    /// OpenCSG is the OpenCSG related information.
     pub open_csg: Option<OpenCsg>,
 }
 
@@ -169,7 +169,7 @@ pub struct GetRequest {
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
 
-    /// OpenCSG protocol information.
+    /// OpenCSG is the OpenCSG related information.
     pub open_csg: Option<OpenCsg>,
 }
 
@@ -250,7 +250,7 @@ pub struct ExistsRequest {
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
 
-    /// OpenCSG protocol information.
+    /// OpenCSG is the OpenCSG related information.
     pub open_csg: Option<OpenCsg>,
 }
 
@@ -286,7 +286,7 @@ pub struct PutRequest {
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
 
-    /// OpenCSG protocol information.
+    /// OpenCSG is the OpenCSG related information.
     pub open_csg: Option<OpenCsg>,
 }
 

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -720,7 +720,8 @@ mod tests {
             "libhdfs.so"
         };
 
-        std::fs::rename(
+        // Copy the shared build artifact because these tests can run concurrently.
+        std::fs::copy(
             format!("../target/debug/{plugin_file}"),
             backend_dir.join(plugin_file),
         )

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -16,7 +16,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use dragonfly_api::common::v2::{Hdfs, HuggingFace, ModelScope, ObjectStorage, Range};
+use dragonfly_api::common::v2::{Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, Range};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -42,6 +42,7 @@ pub mod hugging_face;
 pub mod model_scope;
 pub mod object_storage;
 pub mod oci;
+pub mod opencsg;
 
 /// The max idle connections per host.
 const POOL_MAX_IDLE_PER_HOST: usize = 1024;
@@ -105,6 +106,9 @@ pub struct StatRequest {
 
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
+
+    /// OpenCSG protocol information.
+    pub open_csg: Option<OpenCsg>,
 }
 
 /// The stat response for backend.
@@ -164,6 +168,9 @@ pub struct GetRequest {
 
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
+
+    /// OpenCSG protocol information.
+    pub open_csg: Option<OpenCsg>,
 }
 
 /// The get response for backend.
@@ -242,6 +249,9 @@ pub struct ExistsRequest {
 
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
+
+    /// OpenCSG protocol information.
+    pub open_csg: Option<OpenCsg>,
 }
 
 /// The put request for backend.
@@ -275,6 +285,9 @@ pub struct PutRequest {
 
     /// Model Scope is the model scope related information.
     pub model_scope: Option<ModelScope>,
+
+    /// OpenCSG protocol information.
+    pub open_csg: Option<OpenCsg>,
 }
 
 /// The put response for backend.
@@ -497,6 +510,12 @@ impl BackendFactory {
         );
         info!("load [hf] builtin backend");
 
+        self.backends.insert(
+            opencsg::SCHEME.to_string(),
+            Box::new(opencsg::OpenCsg::new(self.config.clone())?),
+        );
+        info!("load [opencsg] builtin backend");
+
         Ok(())
     }
 
@@ -567,6 +586,7 @@ mod tests {
             "hdfs",
             "hf",
             "modelscope",
+            "opencsg",
         ];
         for backend in expected_backends {
             assert!(factory.backends.contains_key(backend));
@@ -598,7 +618,7 @@ mod tests {
         let plugin_dir = dir.path().join("non_existent_plugin_dir");
 
         let factory = BackendFactory::new(Arc::new(Config::default()), Some(&plugin_dir)).unwrap();
-        assert_eq!(factory.backends.len(), 11);
+        assert_eq!(factory.backends.len(), 12);
     }
 
     #[test]
@@ -642,7 +662,18 @@ mod tests {
 
         let factory = BackendFactory::new(Arc::new(Config::default()), Some(&plugin_dir)).unwrap();
         let schemes = vec![
-            "http", "https", "s3", "gs", "abs", "oss", "obs", "cos", "hdfs", "hf",
+            "http",
+            "https",
+            "s3",
+            "gs",
+            "abs",
+            "oss",
+            "obs",
+            "cos",
+            "hdfs",
+            "hf",
+            "modelscope",
+            "opencsg",
         ];
 
         for scheme in schemes {

--- a/dragonfly-client-backend/src/lib.rs
+++ b/dragonfly-client-backend/src/lib.rs
@@ -720,7 +720,6 @@ mod tests {
             "libhdfs.so"
         };
 
-        // Copy the shared build artifact because these tests can run concurrently.
         std::fs::copy(
             format!("../target/debug/{plugin_file}"),
             backend_dir.join(plugin_file),

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -1080,6 +1080,7 @@ mod tests {
                     token: None,
                     base_url: Some(server.uri()),
                 }),
+                open_csg: None,
             })
             .await
             .unwrap();
@@ -1125,6 +1126,7 @@ mod tests {
                     token: None,
                     base_url: Some(server.uri()),
                 }),
+                open_csg: None,
             })
             .await
             .unwrap();

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -426,31 +426,26 @@ impl Backend for ModelScope {
             None => {
                 let file_list_url =
                     Self::build_file_list_url(&parsed_url, &model_scope.revision, &api_base_url)?;
-                let response = match self
+
+                let response = self
                     .client
                     .get(file_list_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
                     .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
+                    .map_err(|err| {
                         error!(
                             "stat request failed {} {}: {}",
                             request.task_id, file_list_url, err
                         );
 
-                        return Ok(StatResponse {
-                            success: false,
-                            content_length: None,
-                            http_header: None,
-                            http_status_code: None,
-                            entries: Vec::new(),
-                            error_message: Some(err.to_string()),
-                        });
-                    }
-                };
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
@@ -460,14 +455,16 @@ impl Backend for ModelScope {
                 };
 
                 if !response.status().is_success() {
-                    return Ok(StatResponse {
-                        success: false,
-                        content_length: None,
-                        http_header: Some(response_header),
-                        http_status_code: response_status_code.into(),
-                        error_message: Some(response_status_code.to_string()),
-                        entries: Vec::new(),
-                    });
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, file_list_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
                 }
 
                 let text = response.text().await.map_err(|err| {
@@ -1137,5 +1134,41 @@ mod tests {
             .error_message
             .unwrap()
             .contains("expected 206 Partial Content"));
+    }
+
+    #[tokio::test]
+    async fn test_stat_repository_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/models/owner/repo/repo/files"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let backend = ModelScope::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "modelscope://owner/repo".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: Some(ModelScopeOptions {
+                    revision: "master".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+                open_csg: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::UNAUTHORIZED)
+        ));
     }
 }

--- a/dragonfly-client-backend/src/model_scope.rs
+++ b/dragonfly-client-backend/src/model_scope.rs
@@ -371,31 +371,25 @@ impl Backend for ModelScope {
                     &base_url,
                 )?;
 
-                let response = match self
+                let response = self
                     .client
                     .get(download_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
                     .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
+                    .map_err(|err| {
                         error!(
                             "stat request failed {} {}: {}",
                             request.task_id, download_url, err
                         );
 
-                        return Ok(StatResponse {
-                            success: false,
-                            content_length: None,
-                            http_header: None,
-                            http_status_code: None,
-                            entries: Vec::new(),
-                            error_message: Some(err.to_string()),
-                        });
-                    }
-                };
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
@@ -403,6 +397,19 @@ impl Backend for ModelScope {
                     Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
                     None => response.content_length(),
                 };
+
+                if !response.status().is_success() {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, download_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
+                }
 
                 debug!(
                     "stat response {} {}: {:?} {:?} {:?}",
@@ -1134,6 +1141,42 @@ mod tests {
             .error_message
             .unwrap()
             .contains("expected 206 Partial Content"));
+    }
+
+    #[tokio::test]
+    async fn test_stat_file_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/models/owner/repo/resolve/master/config.json"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let backend = ModelScope::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "modelscope://owner/repo/config.json".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: Some(ModelScopeOptions {
+                    revision: "master".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+                open_csg: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::NOT_FOUND)
+        ));
     }
 
     #[tokio::test]

--- a/dragonfly-client-backend/src/opencsg.rs
+++ b/dragonfly-client-backend/src/opencsg.rs
@@ -339,7 +339,10 @@ impl OpenCsg {
     fn build_opencsg_url(parsed_url: &ParsedURL, filename: &str) -> Result<Url> {
         let url = match parsed_url.repository_type {
             RepositoryType::Model => {
-                format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename)
+                format!(
+                    "{}://models/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
             }
             RepositoryType::Dataset => {
                 format!(
@@ -1015,7 +1018,7 @@ mod tests {
         let url = OpenCsg::build_opencsg_url(&parsed_url, "model.safetensors").unwrap();
         assert_eq!(
             url.as_str(),
-            "opencsg://OpenCSG/csg-wukong-1B/model.safetensors"
+            "opencsg://models/OpenCSG/csg-wukong-1B/model.safetensors"
         );
     }
 
@@ -1131,7 +1134,7 @@ mod tests {
         assert_eq!(
             response.entries[0],
             DirEntry {
-                url: "opencsg://owner/repo/nested/config%20file.json".to_string(),
+                url: "opencsg://models/owner/repo/nested/config%20file.json".to_string(),
                 content_length: 12,
                 is_dir: false,
             }

--- a/dragonfly-client-backend/src/opencsg.rs
+++ b/dragonfly-client-backend/src/opencsg.rs
@@ -14,12 +14,24 @@
  * limitations under the License.
  */
 
-//! OpenCSG repository backend.
+//! OpenCSG backend implementation for downloading models and datasets.
 //!
-//! OpenCSG exposes Hugging Face compatible SDK routes below `/csg`. Repository
-//! metadata is used for recursive downloads and file resolve routes are used
-//! for ranged piece downloads. Authentication is deliberately kept in the
-//! request options, so it never becomes part of a task URL.
+//! This module provides support for the `opencsg://` URL scheme to download files
+//! from OpenCSG Hub repositories through its Hugging Face compatible SDK API. It
+//! handles both regular files and Git LFS files.
+//!
+//! # URL Format
+//!
+//! The URL format is: `opencsg://[<repository_type>/]<owner>/<repository>[/<path>]`
+//!
+//! Examples:
+//! - `opencsg://OpenCSG/csg-wukong-1B` - Download entire repository
+//! - `opencsg://OpenCSG/csg-wukong-1B/model.safetensors` - Download specific file
+//! - `opencsg://datasets/OpenCSG/chinese-fineweb-edu` - Download a dataset repository
+//!
+//! # Authentication
+//!
+//! For private repositories, use the `--csg-token` flag.
 
 use crate::{
     empty_body, Backend, Body, DirEntry, ExistsRequest, GetRequest, GetResponse, PutRequest,
@@ -27,7 +39,7 @@ use crate::{
     POOL_MAX_IDLE_PER_HOST,
 };
 use async_trait::async_trait;
-use dragonfly_api::common::v2::{OpenCsg as OpenCsgOptions, Range};
+use dragonfly_api::common::v2::Range;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{BackendError, ErrorType, OrErr},
@@ -43,84 +55,131 @@ use std::error::Error as _;
 use std::io::Error as IOError;
 use std::sync::Arc;
 use tokio_util::io::StreamReader;
-use tracing::{error, instrument};
+use tracing::{debug, error, instrument};
 use url::Url;
 
-/// The URL scheme for OpenCSG repositories.
+/// The URL scheme for OpenCSG backend.
 pub const SCHEME: &str = "opencsg";
 
-/// The default OpenCSG SDK endpoint. The `/csg/` prefix is significant.
+/// The base URL for OpenCSG Hub, the `/csg/` path prefix routes to the SDK API.
 const OPEN_CSG_BASE_URL: &str = "https://hub.opencsg.com/csg/";
 
-/// OpenCSG repository kinds exposed by the SDK mapping routes.
+/// Represents the OpenCSG repository information returned by the API.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+struct Repository {
+    siblings: Option<Vec<Sibling>>,
+}
+
+/// Represents a file or directory in the OpenCSG repository.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+struct Sibling {
+    rfilename: String,
+    size: Option<u64>,
+    lfs: Option<Lfs>,
+    r#type: Option<String>,
+}
+
+/// Represents Git LFS metadata for large files in the OpenCSG repository.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+struct Lfs {
+    size: Option<u64>,
+}
+
+/// A parsed representation of an OpenCSG URL.
+///
+/// Format: `opencsg://[<repository_type>/]<owner>/<repository>[/<path>]`
+#[derive(Debug, Clone)]
+pub struct ParsedURL {
+    /// The original, unparsed URL.
+    pub url: Url,
+
+    /// The repository identifier in `<owner>/<repository>` format (e.g., `"OpenCSG/csg-wukong-1B"`).
+    pub repository_id: String,
+
+    /// The type of repository: model, dataset, space, code, mcp, or skill.
+    pub repository_type: RepositoryType,
+
+    /// An optional file path within the repository (e.g., `"path/to/weights.bin"`).
+    pub file_path: Option<String>,
+}
+
+/// The type of an OpenCSG repository.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepositoryType {
-    /// A model repository, the default kind.
+    /// A model repository. This is the default when no type prefix is specified,
+    /// or when explicitly prefixed with `models/`.
     Model,
-    /// A dataset repository.
+
+    /// A dataset repository, prefixed with `datasets/`.
     Dataset,
-    /// A space repository.
+
+    /// A space repository, prefixed with `spaces/`.
     Space,
-    /// A code repository.
+
+    /// A code repository, prefixed with `codes/`.
     Code,
-    /// An MCP server repository.
+
+    /// An MCP server repository, prefixed with `mcps/`.
     Mcp,
-    /// A skill repository.
+
+    /// A skill repository, prefixed with `skills/`.
     Skill,
 }
 
+/// Implements methods for getting string representations and API paths.
 impl RepositoryType {
-    /// Returns the route segment used by OpenCSG.
-    pub fn as_str(self) -> &'static str {
+    /// Returns the canonical route segment (e.g., `"models"`, `"datasets"`).
+    pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Model => "models",
-            Self::Dataset => "datasets",
-            Self::Space => "spaces",
-            Self::Code => "codes",
-            Self::Mcp => "mcps",
-            Self::Skill => "skills",
+            RepositoryType::Model => "models",
+            RepositoryType::Dataset => "datasets",
+            RepositoryType::Space => "spaces",
+            RepositoryType::Code => "codes",
+            RepositoryType::Mcp => "mcps",
+            RepositoryType::Skill => "skills",
         }
     }
 
-    /// Parses a canonical repository type route segment.
+    /// Parses a canonical route segment into a repository type.
     fn from_segment(segment: &str) -> Option<Self> {
         match segment {
-            "models" => Some(Self::Model),
-            "datasets" => Some(Self::Dataset),
-            "spaces" => Some(Self::Space),
-            "codes" => Some(Self::Code),
-            "mcps" => Some(Self::Mcp),
-            "skills" => Some(Self::Skill),
+            "models" => Some(RepositoryType::Model),
+            "datasets" => Some(RepositoryType::Dataset),
+            "spaces" => Some(RepositoryType::Space),
+            "codes" => Some(RepositoryType::Code),
+            "mcps" => Some(RepositoryType::Mcp),
+            "skills" => Some(RepositoryType::Skill),
             _ => None,
         }
     }
 }
 
-/// Parsed representation of an `opencsg://` URL.
-#[derive(Debug, Clone)]
-pub struct ParsedURL {
-    /// Original URL.
-    pub url: Url,
-    /// Repository identifier in `owner/name` form.
-    pub repository_id: String,
-    /// OpenCSG repository kind.
-    pub repository_type: RepositoryType,
-    /// Optional repository-relative file path.
-    pub file_path: Option<String>,
-}
-
+/// Parses an OpenCSG URL into its constituent components.
+///
+/// URL Format: opencsg://[<repository_type>/]<owner>/<repository>[/<path>]
+/// - repository_type  Optional. One of "models" (default), "datasets", "spaces",
+///   "codes", "mcps", or "skills".
+/// - owner/repository Required. For example, "OpenCSG/csg-wukong-1B".
+/// - path             Optional file path within the repository.
 impl TryFrom<Url> for ParsedURL {
     type Error = Error;
 
-    /// Parses `opencsg://[type/]owner/repository[/path]`.
+    /// Parses the URL and returns a ParsedURL.
     fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
         if url.scheme() != SCHEME {
             return Err(Error::InvalidURI(url.to_string()));
         }
+
         let host = url
             .host_str()
             .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
         let raw_path = format!("{}{}", host, url.path().trim_end_matches('/'));
+
+        // Decode each segment so it is re-encoded canonically when building
+        // provider URLs, and reject decoded separators and NUL bytes.
         let segments: Vec<String> = raw_path
             .trim_matches('/')
             .split('/')
@@ -131,88 +190,75 @@ impl TryFrom<Url> for ParsedURL {
                     .map_err(|_| Error::InvalidURI(url.to_string()))
             })
             .collect::<Result<_>>()?;
-        if segments.iter().any(|segment| {
-            segment.contains('/') || segment.contains('\\') || segment.contains('\0')
-        }) {
+        if segments
+            .iter()
+            .any(|segment| segment.contains(['/', '\\', '\0']))
+        {
             return Err(Error::InvalidURI(url.to_string()));
         }
+
         let (repository_type, offset) = match segments.first() {
             Some(segment) => match RepositoryType::from_segment(segment) {
-                Some(kind) => (kind, 1),
+                Some(repository_type) => (repository_type, 1),
                 None => (RepositoryType::Model, 0),
             },
             None => return Err(Error::InvalidParameter),
         };
+
+        // After stripping the optional type prefix, at least two non-empty
+        // segments (owner and repository name) must remain.
         let remaining = &segments[offset..];
         if remaining.len() < 2 || remaining.iter().any(|segment| segment.is_empty()) {
             return Err(Error::InvalidParameter);
         }
-        Ok(Self {
+
+        let repository_id = format!("{}/{}", remaining[0], remaining[1]);
+        let file_path = if remaining.len() > 2 {
+            Some(remaining[2..].join("/"))
+        } else {
+            None
+        };
+
+        Ok(ParsedURL {
             url,
-            repository_id: format!("{}/{}", remaining[0], remaining[1]),
             repository_type,
-            file_path: (remaining.len() > 2).then(|| remaining[2..].join("/")),
+            repository_id,
+            file_path,
         })
     }
 }
 
+/// Implements TryFrom for &str.
 impl TryFrom<&str> for ParsedURL {
     type Error = Error;
 
-    /// Parses a string URL.
+    /// Try to parse a string URL into a ParsedURL struct.
     fn try_from(url: &str) -> std::result::Result<Self, Self::Error> {
-        ParsedURL::try_from(Url::parse(url).or_err(ErrorType::ParseError)?)
+        let parsed_url = Url::parse(url).or_err(ErrorType::ParseError)?;
+        ParsedURL::try_from(parsed_url)
     }
 }
 
-/// Repository metadata returned by OpenCSG SDK-compatible APIs.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default)]
-struct Metadata {
-    /// Files contained in the requested repository revision.
-    siblings: Option<Vec<Sibling>>,
-}
-
-/// A repository metadata entry.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct Sibling {
-    /// Repository-relative file name.
-    #[serde(rename = "rfilename")]
-    filename: String,
-    /// File size when provided by the metadata endpoint.
-    size: Option<u64>,
-    /// Git LFS metadata when the entry is backed by LFS.
-    lfs: Option<Lfs>,
-    /// Entry kind when returned by a compatible endpoint.
-    #[serde(rename = "type")]
-    entry_type: Option<String>,
-}
-
-/// Relevant Git LFS metadata for a repository entry.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-struct Lfs {
-    /// Downloadable LFS object size.
-    size: Option<u64>,
-}
-
-/// OpenCSG backend implementation.
+/// The OpenCSG backend implementation.
 pub struct OpenCsg {
-    /// Registered backend scheme.
+    /// The scheme of the OpenCSG backend.
     scheme: String,
-    /// HTTP client used for metadata and resolve requests.
+
+    /// HTTP client for making requests.
     client: Client,
 }
 
+/// Implements the OpenCSG interface.
 impl OpenCsg {
-    /// Creates an OpenCSG backend using dfdaemon's common TLS and DNS settings.
+    /// Create a new OpenCsg backend.
     pub fn new(config: Arc<Config>) -> Result<Self> {
+        // Default TLS client config with no validation.
         let client_config_builder = rustls::ClientConfig::builder()
             .dangerous()
             .with_custom_certificate_verifier(NoVerifier::new())
             .with_no_client_auth();
-        let client = Client::builder()
+
+        let client = reqwest::Client::builder()
             .no_gzip()
             .no_brotli()
             .no_zstd()
@@ -223,54 +269,58 @@ impl OpenCsg {
             .tcp_keepalive(KEEP_ALIVE_INTERVAL)
             .tcp_nodelay(true)
             .build()?;
+
         Ok(Self {
             scheme: SCHEME.to_string(),
             client,
         })
     }
 
-    /// Normalizes a base URL while retaining any user-supplied path prefix.
+    /// Resolves the base URLs from gRPC OpenCSG options, keeping any path prefix
+    /// (e.g., `/csg/`) from custom endpoints.
     fn resolve_base_urls(base_url: Option<&str>) -> Result<(Url, Url)> {
-        let mut base = Url::parse(base_url.unwrap_or(OPEN_CSG_BASE_URL))?;
-        if !base.path().ends_with('/') {
-            let path = format!("{}/", base.path());
-            base.set_path(&path);
+        let mut base_url = Url::parse(base_url.unwrap_or(OPEN_CSG_BASE_URL))?;
+        if !base_url.path().ends_with('/') {
+            let path = format!("{}/", base_url.path());
+            base_url.set_path(&path);
         }
-        let api = base.join("api/")?;
-        Ok((base, api))
+
+        let api_base_url = base_url.join("api/")?;
+        Ok((base_url, api_base_url))
     }
 
     /// Appends already-decoded path segments so `Url` performs canonical escaping.
-    fn append_segments(mut base: Url, segments: impl IntoIterator<Item = String>) -> Result<Url> {
-        let base_string = base.to_string();
+    fn append_segments(
+        mut base_url: Url,
+        segments: impl IntoIterator<Item = String>,
+    ) -> Result<Url> {
         {
-            let mut path = base
+            let mut path_segments = base_url
                 .path_segments_mut()
-                .map_err(|_| Error::InvalidURI(base_string))?;
-            path.pop_if_empty();
+                .map_err(|_| Error::InvalidParameter)?;
+            path_segments.pop_if_empty();
             for segment in segments {
-                path.push(&segment);
+                path_segments.push(&segment);
             }
         }
-        Ok(base)
+
+        Ok(base_url)
     }
 
-    /// Splits a repository-relative path and rejects components unsafe for local output paths.
+    /// Splits a repository-relative path and rejects components unsafe for local
+    /// output paths.
     fn repository_path_segments(path: &str) -> Result<Vec<String>> {
         let segments: Vec<&str> = path.split('/').collect();
-        if segments.is_empty()
-            || segments
-                .iter()
-                .any(|segment| segment.is_empty() || matches!(*segment, "." | ".."))
-            || segments.iter().any(|segment| segment.contains('\\'))
-            || segments.iter().any(|segment| segment.contains('\0'))
-        {
+        if segments.iter().any(|segment| {
+            segment.is_empty() || matches!(*segment, "." | "..") || segment.contains(['\\', '\0'])
+        }) {
             return Err(Error::InvalidParameter);
         }
+
         Ok(segments.into_iter().map(str::to_string).collect())
     }
 
-    /// Builds a provider resolve URL for a file.
+    /// Builds the download URL for a file based on the repository type and path.
     fn build_download_url(
         parsed_url: &ParsedURL,
         file_path: &str,
@@ -281,6 +331,7 @@ impl OpenCsg {
         if parsed_url.repository_type != RepositoryType::Model {
             segments.push(parsed_url.repository_type.as_str().to_string());
         }
+
         segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
         segments.push("resolve".to_string());
         segments.push(revision.to_string());
@@ -288,236 +339,341 @@ impl OpenCsg {
         Self::append_segments(base_url.clone(), segments)
     }
 
-    /// Builds the revision metadata URL used for recursive repository listing.
-    fn build_metadata_url(parsed_url: &ParsedURL, revision: &str, api_base: &Url) -> Result<Url> {
+    /// Builds the API URL for fetching repository information at a specific revision.
+    fn build_repository_revision_url(
+        parsed_url: &ParsedURL,
+        revision: &str,
+        api_base_url: &Url,
+    ) -> Result<Url> {
         let mut segments = vec![parsed_url.repository_type.as_str().to_string()];
         segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
         segments.push("revision".to_string());
         segments.push(revision.to_string());
-        let mut url = Self::append_segments(api_base.clone(), segments)?;
+
+        let mut url = Self::append_segments(api_base_url.clone(), segments)?;
         if parsed_url.repository_type == RepositoryType::Model {
             url.query_pairs_mut().append_pair("blobs", "true");
         }
+
         Ok(url)
     }
 
-    /// Builds an `opencsg://` child URL that keeps downloads on this backend.
+    /// Builds an `opencsg://` URL for a file so downstream downloads continue to
+    /// use the OpenCSG backend (preserving auth and URL semantics).
     fn build_opencsg_url(parsed_url: &ParsedURL, filename: &str) -> Result<Url> {
-        let repository_segments: Vec<&str> = parsed_url.repository_id.split('/').collect();
-        let owner = repository_segments.first().ok_or(Error::InvalidParameter)?;
-        let repository = repository_segments.get(1).ok_or(Error::InvalidParameter)?;
-        let explicit_model = parsed_url.repository_type == RepositoryType::Model
-            && parsed_url.url.host_str() == Some(RepositoryType::Model.as_str());
-        let (authority, mut path) = if explicit_model {
-            (
-                RepositoryType::Model.as_str(),
-                vec![(*owner).to_string(), (*repository).to_string()],
-            )
-        } else if parsed_url.repository_type == RepositoryType::Model {
-            (*owner, vec![(*repository).to_string()])
-        } else {
-            (
-                parsed_url.repository_type.as_str(),
-                vec![(*owner).to_string(), (*repository).to_string()],
-            )
+        let (owner, repository) = parsed_url
+            .repository_id
+            .split_once('/')
+            .ok_or(Error::InvalidParameter)?;
+        let (authority, mut segments) = match parsed_url.repository_type {
+            RepositoryType::Model => (owner, vec![repository.to_string()]),
+            repository_type => (
+                repository_type.as_str(),
+                vec![owner.to_string(), repository.to_string()],
+            ),
         };
-        let mut url = Url::parse(&format!("{SCHEME}://{authority}"))?;
-        path.extend(Self::repository_path_segments(filename)?);
-        let url_string = url.to_string();
-        {
-            let mut path_segments = url
-                .path_segments_mut()
-                .map_err(|_| Error::InvalidURI(url_string))?;
-            for segment in path {
-                path_segments.push(&segment);
-            }
-        }
-        Ok(url)
+
+        segments.extend(Self::repository_path_segments(filename)?);
+        Self::append_segments(Url::parse(&format!("{SCHEME}://{authority}"))?, segments)
     }
 
-    /// Builds Authorization, User-Agent and optional single-range headers.
+    /// Build the request headers for OpenCSG API requests, including authentication if a
+    /// token is provided by the `--csg-token` CLI flag.
     fn build_request_headers(token: Option<String>, range: Option<Range>) -> Result<HeaderMap> {
-        let mut headers = HeaderMap::new();
-        if let Some(range) = range {
+        let mut request_header = HeaderMap::new();
+
+        // Add Range header if present in the request.
+        if let Some(range) = &range {
             if range.length == 0 {
                 return Err(Error::InvalidParameter);
             }
+
             let end = range
                 .start
                 .checked_add(range.length - 1)
                 .ok_or(Error::InvalidParameter)?;
-            headers.insert(RANGE, format!("bytes={}-{end}", range.start).parse()?);
-        }
-        headers
+            request_header.insert(RANGE, format!("bytes={}-{}", range.start, end).parse()?);
+        };
+
+        // Make the user agent if not specified in header.
+        request_header
             .entry(USER_AGENT)
             .or_insert(HeaderValue::from_static(DEFAULT_USER_AGENT));
+
+        // Add the Authorization header for OpenCSG API authentication.
         if let Some(token) = token {
-            headers.insert(
-                AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {token}"))
-                    .map_err(|_| Error::InvalidParameter)?,
-            );
+            request_header.insert(AUTHORIZATION, format!("Bearer {token}").parse()?);
         }
-        Ok(headers)
-    }
 
-    /// Wraps response decoding failures as backend errors.
-    fn backend_error(message: impl Into<String>) -> Error {
-        Error::BackendError(Box::new(BackendError {
-            message: message.into(),
-            status_code: None,
-            header: None,
-        }))
-    }
-
-    /// Validates options that are required by every OpenCSG request.
-    fn validate_options(options: &OpenCsgOptions) -> Result<()> {
-        if options.revision.trim().is_empty() {
-            return Err(Error::InvalidParameter);
-        }
-        Ok(())
+        Ok(request_header)
     }
 }
 
+/// Backend implementation for OpenCSG.
 #[async_trait]
 impl Backend for OpenCsg {
-    /// Returns the OpenCSG URL scheme.
+    /// Returns the scheme of the backend.
     fn scheme(&self) -> String {
         self.scheme.clone()
     }
 
-    /// Stats a file with HEAD or lists repository metadata with GET.
+    /// Stat the file or repository information.
     #[instrument(skip_all)]
     async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
-        let options = request.open_csg.as_ref().ok_or_else(|| {
+        debug!(
+            "stat request {} {}: {:?}",
+            request.task_id, request.url, request.http_header
+        );
+
+        // Get the OpenCSG information from the request, request must contain OpenCSG
+        // information for stat request, otherwise return error.
+        let open_csg = request.open_csg.as_ref().ok_or_else(|| {
             error!(
                 "stat request {} {}: missing OpenCSG information",
                 request.task_id, request.url
             );
+
             Error::InvalidParameter
         })?;
-        Self::validate_options(options)?;
-        let headers = Self::build_request_headers(options.token.clone(), None)?;
-        let parsed = ParsedURL::try_from(request.url.as_str())?;
-        let (base, api) = Self::resolve_base_urls(options.base_url.as_deref())?;
-        let response = if let Some(file_path) = parsed.file_path.as_deref() {
-            let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
-            self.client
-                .head(url)
-                .headers(headers)
-                .timeout(request.timeout)
-                .send()
-                .await
-        } else {
-            let url = Self::build_metadata_url(&parsed, &options.revision, &api)?;
-            self.client
-                .get(url)
-                .headers(headers)
-                .timeout(request.timeout)
-                .send()
-                .await
-        };
-        let response = match response {
-            Ok(response) => response,
-            Err(err) => {
-                return Ok(StatResponse {
-                    success: false,
-                    content_length: None,
-                    http_header: None,
-                    http_status_code: None,
-                    entries: vec![],
-                    error_message: Some(err.to_string()),
-                });
-            }
-        };
-        let status = response.status();
-        let response_headers = response.headers().clone();
-        let content_length = response_headers
-            .get(CONTENT_LENGTH)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.parse::<u64>().ok())
-            .or(response.content_length());
-        if parsed.file_path.is_some() {
-            return Ok(StatResponse {
-                success: status.is_success(),
-                content_length,
-                http_header: Some(response_headers),
-                http_status_code: Some(status),
-                entries: vec![],
-                error_message: Some(status.to_string()),
-            });
-        }
-        if !status.is_success() {
-            return Ok(StatResponse {
-                success: false,
-                content_length: None,
-                http_header: Some(response_headers),
-                http_status_code: Some(status),
-                entries: vec![],
-                error_message: Some(status.to_string()),
-            });
-        }
-        let body = response
-            .text()
-            .await
-            .map_err(|err| Self::backend_error(err.to_string()))?;
-        let metadata: Metadata =
-            serde_json::from_str(&body).map_err(|err| Self::backend_error(err.to_string()))?;
-        let entries = metadata
-            .siblings
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|sibling| {
-                !sibling.filename.is_empty() && sibling.entry_type.as_deref() != Some("tree")
-            })
-            .map(|sibling| {
-                Ok(DirEntry {
-                    url: Self::build_opencsg_url(&parsed, &sibling.filename)?.to_string(),
-                    content_length: sibling
-                        .lfs
-                        .and_then(|lfs| lfs.size)
-                        .or(sibling.size)
-                        .unwrap_or_default() as usize,
-                    is_dir: false,
+
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(open_csg.token.clone(), None)?;
+
+        let parsed_url = ParsedURL::try_from(request.url.as_str())?;
+        let (base_url, api_base_url) = Self::resolve_base_urls(open_csg.base_url.as_deref())?;
+        match &parsed_url.file_path {
+            Some(file_path) => {
+                let download_url = Self::build_download_url(
+                    &parsed_url,
+                    file_path,
+                    &open_csg.revision,
+                    &base_url,
+                )?;
+
+                let response = match self
+                    .client
+                    .head(download_url.as_str())
+                    .headers(request_header)
+                    .timeout(request.timeout)
+                    .send()
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(err) => {
+                        error!(
+                            "stat request failed {} {}: {}",
+                            request.task_id, download_url, err
+                        );
+
+                        return Ok(StatResponse {
+                            success: false,
+                            content_length: None,
+                            http_header: None,
+                            http_status_code: None,
+                            entries: Vec::new(),
+                            error_message: Some(err.to_string()),
+                        });
+                    }
+                };
+
+                let response_status_code = response.status();
+                let response_header = response.headers().clone();
+                let content_length = match response_header.get(CONTENT_LENGTH) {
+                    Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
+                    None => response.content_length(),
+                };
+
+                debug!(
+                    "stat response {} {}: {:?} {:?} {:?}",
+                    request.task_id,
+                    download_url,
+                    response_status_code,
+                    content_length,
+                    response_header
+                );
+
+                Ok(StatResponse {
+                    success: response_status_code.is_success(),
+                    content_length,
+                    http_header: Some(response_header),
+                    http_status_code: Some(response_status_code),
+                    error_message: Some(response_status_code.to_string()),
+                    entries: Vec::new(),
                 })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(StatResponse {
-            success: true,
-            content_length,
-            http_header: Some(response_headers),
-            http_status_code: Some(status),
-            entries,
-            error_message: Some(status.to_string()),
-        })
+            }
+            None => {
+                let repository_revision_url = Self::build_repository_revision_url(
+                    &parsed_url,
+                    &open_csg.revision,
+                    &api_base_url,
+                )?;
+
+                // A failed listing must not be mistaken for an empty repository, so
+                // listing failures are returned as backend errors.
+                let response = self
+                    .client
+                    .get(repository_revision_url.as_str())
+                    .headers(request_header)
+                    .timeout(request.timeout)
+                    .send()
+                    .await
+                    .map_err(|err| {
+                        error!(
+                            "stat request failed {} {}: {}",
+                            request.task_id, repository_revision_url, err
+                        );
+
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
+
+                let response_status_code = response.status();
+                let response_header = response.headers().clone();
+                if !response_status_code.is_success() {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, repository_revision_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
+                }
+
+                let content_length = match response_header.get(CONTENT_LENGTH) {
+                    Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
+                    None => response.content_length(),
+                };
+
+                let text = response.text().await.map_err(|err| {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, repository_revision_url, err
+                    );
+
+                    Error::BackendError(Box::new(BackendError {
+                        message: err.to_string(),
+                        status_code: None,
+                        header: None,
+                    }))
+                })?;
+
+                let repository: Repository = serde_json::from_str(&text).map_err(|err| {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, repository_revision_url, err
+                    );
+
+                    Error::BackendError(Box::new(BackendError {
+                        message: err.to_string(),
+                        status_code: None,
+                        header: None,
+                    }))
+                })?;
+
+                let entries: Vec<DirEntry> = repository
+                    .siblings
+                    .unwrap_or_default()
+                    .into_iter()
+                    // OpenCSG lists files recursively, skip directory placeholders.
+                    .filter(|sibling| {
+                        !sibling.rfilename.is_empty() && sibling.r#type.as_deref() != Some("tree")
+                    })
+                    .map(|sibling| -> Result<DirEntry> {
+                        // Return opencsg:// URLs so downstream downloads continue to use
+                        // the OpenCSG backend (preserving auth and URL semantics).
+                        let opencsg_url = Self::build_opencsg_url(&parsed_url, &sibling.rfilename)?;
+                        let content_length = sibling
+                            .lfs
+                            .and_then(|lfs| lfs.size)
+                            .or(sibling.size)
+                            .unwrap_or(0);
+
+                        Ok(DirEntry {
+                            url: opencsg_url.to_string(),
+                            content_length: content_length as usize,
+                            is_dir: false,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                debug!(
+                    "stat response {} {}: {:?} {:?} {:?}",
+                    request.task_id,
+                    repository_revision_url,
+                    response_status_code,
+                    content_length,
+                    response_header
+                );
+
+                Ok(StatResponse {
+                    success: true,
+                    content_length,
+                    http_header: Some(response_header),
+                    http_status_code: Some(response_status_code),
+                    error_message: Some(response_status_code.to_string()),
+                    entries,
+                })
+            }
+        }
     }
 
-    /// Downloads a file through a single-range GET and streams the response.
+    /// Get the content from the backend.
     #[instrument(skip_all)]
     async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
-        let options = request.open_csg.as_ref().ok_or_else(|| {
+        debug!(
+            "get request {} {} {}: {:?}",
+            request.task_id, request.piece_id, request.url, request.http_header
+        );
+
+        // Get the OpenCSG information from the request, request must contain OpenCSG
+        // information for get request, otherwise return error.
+        let open_csg = request.open_csg.as_ref().ok_or_else(|| {
             error!(
                 "get request {} {}: missing OpenCSG information",
                 request.task_id, request.url
             );
+
             Error::InvalidParameter
         })?;
-        Self::validate_options(options)?;
-        let parsed = ParsedURL::try_from(request.url.as_str())?;
-        let file_path = parsed.file_path.as_deref().ok_or(Error::InvalidParameter)?;
-        let (base, _) = Self::resolve_base_urls(options.base_url.as_deref())?;
-        let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
-        let headers = Self::build_request_headers(options.token.clone(), request.range)?;
+
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(open_csg.token.clone(), request.range)?;
+
+        // Parse the URL and build the download URL for the specified file.
+        let parsed_url = ParsedURL::try_from(request.url.as_str())?;
+        let Some(file_path) = &parsed_url.file_path else {
+            error!(
+                "get request {} {}: URL must specify a file path",
+                request.task_id, request.url
+            );
+
+            return Err(Error::InvalidParameter);
+        };
+
+        let (base_url, _) = Self::resolve_base_urls(open_csg.base_url.as_deref())?;
+        let download_url =
+            Self::build_download_url(&parsed_url, file_path, &open_csg.revision, &base_url)?;
         let response = match self
             .client
-            .get(url)
-            .headers(headers)
+            .get(download_url.as_str())
+            .headers(request_header)
             .timeout(request.timeout)
             .send()
             .await
         {
             Ok(response) => response,
             Err(err) => {
+                error!(
+                    "get request failed {} {} {}: {}",
+                    request.task_id, request.piece_id, download_url, err
+                );
+
                 return Ok(GetResponse {
                     success: false,
                     http_header: None,
@@ -527,35 +683,30 @@ impl Backend for OpenCsg {
                 });
             }
         };
-        let response_headers = response.headers().clone();
-        let status = response.status();
-        if request.range.is_some()
-            && status.is_success()
-            && status != reqwest::StatusCode::PARTIAL_CONTENT
+
+        let response_header = response.headers().clone();
+        let response_status_code = response.status();
+        if let Err(err) =
+            validate_ranged_response(request.range, response_status_code, &response_header)
         {
+            error!(
+                "get request failed {} {} {}: {}",
+                request.task_id, request.piece_id, download_url, err
+            );
+
             return Ok(GetResponse {
                 success: false,
-                http_header: Some(response_headers),
-                http_status_code: Some(status),
-                reader: empty_body(),
-                error_message: Some(format!(
-                    "expected 206 Partial Content for ranged OpenCSG request, got {status}"
-                )),
-            });
-        }
-        if let Err(err) = validate_ranged_response(request.range, status, &response_headers) {
-            return Ok(GetResponse {
-                success: false,
-                http_header: Some(response_headers),
-                http_status_code: Some(status),
+                http_header: Some(response_header),
+                http_status_code: Some(response_status_code),
                 reader: empty_body(),
                 error_message: Some(err.to_string()),
             });
         }
-        let reader = StreamReader::new(
+
+        let response_reader = StreamReader::new(
             response
                 .bytes_stream()
-                .map_err(|err| {
+                .map_err(move |err| {
                     let mut chain = err.to_string();
                     let mut source = err.source();
                     while let Some(err) = source {
@@ -568,53 +719,90 @@ impl Backend for OpenCsg {
                 })
                 .boxed(),
         );
+
+        debug!(
+            "get response {} {}: {:?} {:?}",
+            request.task_id, request.piece_id, response_status_code, response_header,
+        );
+
         Ok(GetResponse {
-            success: status.is_success(),
-            http_header: Some(response_headers),
-            http_status_code: Some(status),
-            reader,
-            error_message: Some(status.to_string()),
+            success: response_status_code.is_success(),
+            http_header: Some(response_header),
+            http_status_code: Some(response_status_code),
+            reader: response_reader,
+            error_message: Some(response_status_code.to_string()),
         })
     }
 
-    /// OpenCSG upload is outside the download protocol.
-    #[instrument(skip_all)]
+    /// Put the content to the backend.
     async fn put(&self, _request: PutRequest) -> Result<PutResponse> {
         unimplemented!()
     }
 
-    /// Checks file existence with HEAD, or repository existence with metadata GET.
+    /// Exists checks whether the file or the repository exists in the backend.
     #[instrument(skip_all)]
     async fn exists(&self, request: ExistsRequest) -> Result<bool> {
-        let options = request.open_csg.as_ref().ok_or(Error::InvalidParameter)?;
-        Self::validate_options(options)?;
-        let headers = Self::build_request_headers(options.token.clone(), None)?;
-        let parsed = ParsedURL::try_from(request.url.as_str())?;
-        let (base, api) = Self::resolve_base_urls(options.base_url.as_deref())?;
-        let response = if let Some(file_path) = parsed.file_path.as_deref() {
-            let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
-            self.client
-                .head(url)
-                .headers(headers)
-                .timeout(request.timeout)
-                .send()
-                .await
-        } else {
-            let url = Self::build_metadata_url(&parsed, &options.revision, &api)?;
-            self.client
-                .get(url)
-                .headers(headers)
-                .timeout(request.timeout)
-                .send()
-                .await
-        }?;
-        Ok(response.status().is_success())
+        debug!(
+            "exists request {} {}: {:?}",
+            request.task_id, request.url, request.http_header
+        );
+
+        // Get the OpenCSG information from the request, request must contain OpenCSG
+        // information for exists request, otherwise return error.
+        let open_csg = request.open_csg.as_ref().ok_or_else(|| {
+            error!(
+                "exists request {} {}: missing OpenCSG information",
+                request.task_id, request.url
+            );
+
+            Error::InvalidParameter
+        })?;
+
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(open_csg.token.clone(), None)?;
+
+        let parsed_url = ParsedURL::try_from(request.url.as_str())?;
+        let (base_url, api_base_url) = Self::resolve_base_urls(open_csg.base_url.as_deref())?;
+        let url = match &parsed_url.file_path {
+            Some(file_path) => {
+                Self::build_download_url(&parsed_url, file_path, &open_csg.revision, &base_url)?
+            }
+            None => {
+                Self::build_repository_revision_url(&parsed_url, &open_csg.revision, &api_base_url)?
+            }
+        };
+
+        let response = self
+            .client
+            .head(url.as_str())
+            .headers(request_header)
+            .timeout(request.timeout)
+            .send()
+            .await
+            .inspect_err(|err| {
+                error!(
+                    "exists request failed {} {}: {}",
+                    request.task_id, request.url, err
+                );
+            })?;
+
+        let response_status_code = response.status();
+        debug!(
+            "exists response {} {}: {:?} {:?}",
+            request.task_id,
+            request.url,
+            response_status_code,
+            response.headers()
+        );
+
+        Ok(response_status_code.is_success())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dragonfly_api::common::v2::OpenCsg as OpenCsgOptions;
     use std::time::Duration;
     use wiremock::{
         matchers::{header, method, path, query_param},
@@ -644,39 +832,42 @@ mod tests {
             ("mcps", RepositoryType::Mcp),
             ("skills", RepositoryType::Skill),
         ] {
-            let parsed =
+            let parsed_url =
                 ParsedURL::try_from(format!("opencsg://{segment}/owner/repo").as_str()).unwrap();
-            assert_eq!(parsed.repository_type, repository_type);
+            assert_eq!(parsed_url.repository_type, repository_type);
         }
     }
 
-    /// Verifies resolve and metadata URLs retain custom endpoint path prefixes.
+    /// Verifies resolve and revision URLs retain custom endpoint path prefixes.
     #[test]
     fn builds_urls_and_preserves_csg_prefix() {
-        let parsed = ParsedURL::try_from("opencsg://owner/repo/model%20file.bin").unwrap();
-        let (base, api) =
+        let parsed_url = ParsedURL::try_from("opencsg://owner/repo/model%20file.bin").unwrap();
+        let (base_url, api_base_url) =
             OpenCsg::resolve_base_urls(Some("https://example.test/private/csg")).unwrap();
-        let download =
-            OpenCsg::build_download_url(&parsed, "model file.bin", "main", &base).unwrap();
+        let download_url =
+            OpenCsg::build_download_url(&parsed_url, "model file.bin", "main", &base_url).unwrap();
         assert_eq!(
-            download.as_str(),
+            download_url.as_str(),
             "https://example.test/private/csg/owner/repo/resolve/main/model%20file.bin"
         );
-        let metadata = OpenCsg::build_metadata_url(&parsed, "main", &api).unwrap();
+        let repository_revision_url =
+            OpenCsg::build_repository_revision_url(&parsed_url, "main", &api_base_url).unwrap();
         assert_eq!(
-            metadata.as_str(),
+            repository_revision_url.as_str(),
             "https://example.test/private/csg/api/models/owner/repo/revision/main?blobs=true"
         );
 
         let dataset = ParsedURL::try_from("opencsg://datasets/owner/repo/data.json").unwrap();
-        let download = OpenCsg::build_download_url(&dataset, "data.json", "dev", &base).unwrap();
+        let download_url =
+            OpenCsg::build_download_url(&dataset, "data.json", "dev", &base_url).unwrap();
         assert_eq!(
-            download.as_str(),
+            download_url.as_str(),
             "https://example.test/private/csg/datasets/owner/repo/resolve/dev/data.json"
         );
-        let metadata = OpenCsg::build_metadata_url(&dataset, "dev", &api).unwrap();
+        let repository_revision_url =
+            OpenCsg::build_repository_revision_url(&dataset, "dev", &api_base_url).unwrap();
         assert_eq!(
-            metadata.as_str(),
+            repository_revision_url.as_str(),
             "https://example.test/private/csg/api/datasets/owner/repo/revision/dev"
         );
         assert_eq!(
@@ -691,7 +882,7 @@ mod tests {
             OpenCsg::build_opencsg_url(&explicit_model, "model.bin")
                 .unwrap()
                 .as_str(),
-            "opencsg://models/owner/repo/model.bin"
+            "opencsg://owner/repo/model.bin"
         );
     }
 
@@ -716,8 +907,8 @@ mod tests {
     /// Verifies an empty repository represented by JSON null is accepted.
     #[test]
     fn accepts_null_siblings_for_empty_repository() {
-        let metadata: Metadata = serde_json::from_str(r#"{"siblings":null}"#).unwrap();
-        assert!(metadata.siblings.unwrap_or_default().is_empty());
+        let repository: Repository = serde_json::from_str(r#"{"siblings":null}"#).unwrap();
+        assert!(repository.siblings.unwrap_or_default().is_empty());
     }
 
     /// Verifies recursive model metadata, authentication, sizes and child URLs.
@@ -816,6 +1007,40 @@ mod tests {
         );
     }
 
+    /// Verifies a failed repository listing returns a backend error instead of an
+    /// empty repository.
+    #[tokio::test]
+    async fn stats_repository_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/models/owner/repo/revision/main"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://owner/repo".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::UNAUTHORIZED)
+        ));
+    }
+
     /// Verifies file HEAD uses the resolve route and reports its length.
     #[tokio::test]
     async fn stats_file_with_head() {
@@ -889,43 +1114,6 @@ mod tests {
         assert_eq!(response.text().await.unwrap(), "partial content here");
     }
 
-    /// Verifies a successful full-body response cannot satisfy a Range request.
-    #[tokio::test]
-    async fn rejects_full_body_for_range_from_zero() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/owner/repo/resolve/main/model.bin"))
-            .and(header("range", "bytes=0-19"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("full body"))
-            .mount(&server)
-            .await;
-
-        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
-        let response = backend
-            .get(GetRequest {
-                task_id: "task".to_string(),
-                piece_id: "piece".to_string(),
-                url: "opencsg://owner/repo/model.bin".to_string(),
-                range: Some(Range {
-                    start: 0,
-                    length: 20,
-                }),
-                http_header: None,
-                timeout: Duration::from_secs(5),
-                client_cert: None,
-                object_storage: None,
-                hdfs: None,
-                hugging_face: None,
-                model_scope: None,
-                open_csg: Some(options(&server)),
-            })
-            .await
-            .unwrap();
-
-        assert!(!response.success);
-        assert_eq!(response.http_status_code, Some(reqwest::StatusCode::OK));
-    }
-
     /// Verifies LFS redirects retain the Range request and stream the object response.
     #[tokio::test]
     async fn follows_lfs_redirect() {
@@ -980,7 +1168,8 @@ mod tests {
         assert!(object_requests[0].headers.get("authorization").is_none());
     }
 
-    /// Verifies existence checks select HEAD for files and metadata GET for repositories.
+    /// Verifies existence checks select the resolve route for files and the
+    /// revision route for repositories.
     #[tokio::test]
     async fn checks_file_and_repository_existence() {
         let server = MockServer::start().await;
@@ -989,7 +1178,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
-        Mock::given(method("GET"))
+        Mock::given(method("HEAD"))
             .and(path("/api/models/owner/repo/revision/main"))
             .and(query_param("blobs", "true"))
             .respond_with(ResponseTemplate::new(200))

--- a/dragonfly-client-backend/src/opencsg.rs
+++ b/dragonfly-client-backend/src/opencsg.rs
@@ -47,7 +47,6 @@ use dragonfly_client_core::{
 };
 use dragonfly_client_util::{http::validate_ranged_response, tls::NoVerifier};
 use futures::{StreamExt, TryStreamExt};
-use percent_encoding::percent_decode_str;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, RANGE, USER_AGENT};
 use reqwest::Client;
 use serde::Deserialize;
@@ -142,19 +141,6 @@ impl RepositoryType {
             RepositoryType::Skill => "skills",
         }
     }
-
-    /// Parses a canonical route segment into a repository type.
-    fn from_segment(segment: &str) -> Option<Self> {
-        match segment {
-            "models" => Some(RepositoryType::Model),
-            "datasets" => Some(RepositoryType::Dataset),
-            "spaces" => Some(RepositoryType::Space),
-            "codes" => Some(RepositoryType::Code),
-            "mcps" => Some(RepositoryType::Mcp),
-            "skills" => Some(RepositoryType::Skill),
-            _ => None,
-        }
-    }
 }
 
 /// Parses an OpenCSG URL into its constituent components.
@@ -169,46 +155,25 @@ impl TryFrom<Url> for ParsedURL {
 
     /// Parses the URL and returns a ParsedURL.
     fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
-        if url.scheme() != SCHEME {
-            return Err(Error::InvalidURI(url.to_string()));
-        }
-
         let host = url
             .host_str()
             .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
         let raw_path = format!("{}{}", host, url.path().trim_end_matches('/'));
-
-        // Decode each segment so it is re-encoded canonically when building
-        // provider URLs, and reject decoded separators and NUL bytes.
-        let segments: Vec<String> = raw_path
-            .trim_matches('/')
-            .split('/')
-            .map(|segment| {
-                percent_decode_str(segment)
-                    .decode_utf8()
-                    .map(|segment| segment.into_owned())
-                    .map_err(|_| Error::InvalidURI(url.to_string()))
-            })
-            .collect::<Result<_>>()?;
-        if segments
-            .iter()
-            .any(|segment| segment.contains(['/', '\\', '\0']))
-        {
-            return Err(Error::InvalidURI(url.to_string()));
-        }
-
+        let segments: Vec<&str> = raw_path.trim_matches('/').split('/').collect();
         let (repository_type, offset) = match segments.first() {
-            Some(segment) => match RepositoryType::from_segment(segment) {
-                Some(repository_type) => (repository_type, 1),
-                None => (RepositoryType::Model, 0),
-            },
-            None => return Err(Error::InvalidParameter),
+            Some(&"datasets") => (RepositoryType::Dataset, 1),
+            Some(&"spaces") => (RepositoryType::Space, 1),
+            Some(&"codes") => (RepositoryType::Code, 1),
+            Some(&"mcps") => (RepositoryType::Mcp, 1),
+            Some(&"skills") => (RepositoryType::Skill, 1),
+            Some(&"models") => (RepositoryType::Model, 1),
+            _ => (RepositoryType::Model, 0),
         };
 
-        // After stripping the optional type prefix, at least two non-empty
-        // segments (owner and repository name) must remain.
+        // After stripping the optional type prefix, at least two segments
+        // (owner and repository name) must remain.
         let remaining = &segments[offset..];
-        if remaining.len() < 2 || remaining.iter().any(|segment| segment.is_empty()) {
+        if remaining.len() < 2 {
             return Err(Error::InvalidParameter);
         }
 
@@ -276,48 +241,12 @@ impl OpenCsg {
         })
     }
 
-    /// Resolves the base URLs from gRPC OpenCSG options, keeping any path prefix
-    /// (e.g., `/csg/`) from custom endpoints.
+    /// Resolves the base URLs from gRPC OpenCSG options. The API is nested under
+    /// the endpoint's path prefix (e.g., `/csg/api/`), so the join is relative.
     fn resolve_base_urls(base_url: Option<&str>) -> Result<(Url, Url)> {
-        let mut base_url = Url::parse(base_url.unwrap_or(OPEN_CSG_BASE_URL))?;
-        if !base_url.path().ends_with('/') {
-            let path = format!("{}/", base_url.path());
-            base_url.set_path(&path);
-        }
-
+        let base_url = Url::parse(base_url.unwrap_or(OPEN_CSG_BASE_URL))?;
         let api_base_url = base_url.join("api/")?;
         Ok((base_url, api_base_url))
-    }
-
-    /// Appends already-decoded path segments so `Url` performs canonical escaping.
-    fn append_segments(
-        mut base_url: Url,
-        segments: impl IntoIterator<Item = String>,
-    ) -> Result<Url> {
-        {
-            let mut path_segments = base_url
-                .path_segments_mut()
-                .map_err(|_| Error::InvalidParameter)?;
-            path_segments.pop_if_empty();
-            for segment in segments {
-                path_segments.push(&segment);
-            }
-        }
-
-        Ok(base_url)
-    }
-
-    /// Splits a repository-relative path and rejects components unsafe for local
-    /// output paths.
-    fn repository_path_segments(path: &str) -> Result<Vec<String>> {
-        let segments: Vec<&str> = path.split('/').collect();
-        if segments.iter().any(|segment| {
-            segment.is_empty() || matches!(*segment, "." | "..") || segment.contains(['\\', '\0'])
-        }) {
-            return Err(Error::InvalidParameter);
-        }
-
-        Ok(segments.into_iter().map(str::to_string).collect())
     }
 
     /// Builds the download URL for a file based on the repository type and path.
@@ -327,16 +256,46 @@ impl OpenCsg {
         revision: &str,
         base_url: &Url,
     ) -> Result<Url> {
-        let mut segments = vec![];
-        if parsed_url.repository_type != RepositoryType::Model {
-            segments.push(parsed_url.repository_type.as_str().to_string());
-        }
+        let path = match parsed_url.repository_type {
+            RepositoryType::Model => {
+                format!(
+                    "{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+            RepositoryType::Dataset => {
+                format!(
+                    "datasets/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+            RepositoryType::Space => {
+                format!(
+                    "spaces/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+            RepositoryType::Code => {
+                format!(
+                    "codes/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+            RepositoryType::Mcp => {
+                format!(
+                    "mcps/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+            RepositoryType::Skill => {
+                format!(
+                    "skills/{}/resolve/{}/{}",
+                    parsed_url.repository_id, revision, file_path
+                )
+            }
+        };
 
-        segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
-        segments.push("resolve".to_string());
-        segments.push(revision.to_string());
-        segments.extend(Self::repository_path_segments(file_path)?);
-        Self::append_segments(base_url.clone(), segments)
+        Ok(base_url.join(&path)?)
     }
 
     /// Builds the API URL for fetching repository information at a specific revision.
@@ -345,36 +304,76 @@ impl OpenCsg {
         revision: &str,
         api_base_url: &Url,
     ) -> Result<Url> {
-        let mut segments = vec![parsed_url.repository_type.as_str().to_string()];
-        segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
-        segments.push("revision".to_string());
-        segments.push(revision.to_string());
+        let path = match parsed_url.repository_type {
+            RepositoryType::Model => {
+                format!(
+                    "models/{}/revision/{}?blobs=true",
+                    parsed_url.repository_id, revision
+                )
+            }
+            RepositoryType::Dataset => {
+                format!(
+                    "datasets/{}/revision/{}",
+                    parsed_url.repository_id, revision
+                )
+            }
+            RepositoryType::Space => {
+                format!("spaces/{}/revision/{}", parsed_url.repository_id, revision)
+            }
+            RepositoryType::Code => {
+                format!("codes/{}/revision/{}", parsed_url.repository_id, revision)
+            }
+            RepositoryType::Mcp => {
+                format!("mcps/{}/revision/{}", parsed_url.repository_id, revision)
+            }
+            RepositoryType::Skill => {
+                format!("skills/{}/revision/{}", parsed_url.repository_id, revision)
+            }
+        };
 
-        let mut url = Self::append_segments(api_base_url.clone(), segments)?;
-        if parsed_url.repository_type == RepositoryType::Model {
-            url.query_pairs_mut().append_pair("blobs", "true");
-        }
-
-        Ok(url)
+        Ok(api_base_url.join(&path)?)
     }
 
     /// Builds an `opencsg://` URL for a file so downstream downloads continue to
     /// use the OpenCSG backend (preserving auth and URL semantics).
     fn build_opencsg_url(parsed_url: &ParsedURL, filename: &str) -> Result<Url> {
-        let (owner, repository) = parsed_url
-            .repository_id
-            .split_once('/')
-            .ok_or(Error::InvalidParameter)?;
-        let (authority, mut segments) = match parsed_url.repository_type {
-            RepositoryType::Model => (owner, vec![repository.to_string()]),
-            repository_type => (
-                repository_type.as_str(),
-                vec![owner.to_string(), repository.to_string()],
-            ),
+        let url = match parsed_url.repository_type {
+            RepositoryType::Model => {
+                format!("{}://{}/{}", SCHEME, parsed_url.repository_id, filename)
+            }
+            RepositoryType::Dataset => {
+                format!(
+                    "{}://datasets/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+            RepositoryType::Space => {
+                format!(
+                    "{}://spaces/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+            RepositoryType::Code => {
+                format!(
+                    "{}://codes/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+            RepositoryType::Mcp => {
+                format!(
+                    "{}://mcps/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
+            RepositoryType::Skill => {
+                format!(
+                    "{}://skills/{}/{}",
+                    SCHEME, parsed_url.repository_id, filename
+                )
+            }
         };
 
-        segments.extend(Self::repository_path_segments(filename)?);
-        Self::append_segments(Url::parse(&format!("{SCHEME}://{authority}"))?, segments)
+        Ok(Url::parse(&url)?)
     }
 
     /// Build the request headers for OpenCSG API requests, including authentication if a
@@ -384,15 +383,10 @@ impl OpenCsg {
 
         // Add Range header if present in the request.
         if let Some(range) = &range {
-            if range.length == 0 {
-                return Err(Error::InvalidParameter);
-            }
-
-            let end = range
-                .start
-                .checked_add(range.length - 1)
-                .ok_or(Error::InvalidParameter)?;
-            request_header.insert(RANGE, format!("bytes={}-{}", range.start, end).parse()?);
+            request_header.insert(
+                RANGE,
+                format!("bytes={}-{}", range.start, range.start + range.length - 1).parse()?,
+            );
         };
 
         // Make the user agent if not specified in header.
@@ -402,7 +396,10 @@ impl OpenCsg {
 
         // Add the Authorization header for OpenCSG API authentication.
         if let Some(token) = token {
-            request_header.insert(AUTHORIZATION, format!("Bearer {token}").parse()?);
+            request_header.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+            );
         }
 
         Ok(request_header)
@@ -425,6 +422,12 @@ impl Backend for OpenCsg {
             request.task_id, request.url, request.http_header
         );
 
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(
+            request.open_csg.as_ref().and_then(|csg| csg.token.clone()),
+            None,
+        )?;
+
         // Get the OpenCSG information from the request, request must contain OpenCSG
         // information for stat request, otherwise return error.
         let open_csg = request.open_csg.as_ref().ok_or_else(|| {
@@ -435,9 +438,6 @@ impl Backend for OpenCsg {
 
             Error::InvalidParameter
         })?;
-
-        // Build request headers, including authentication if provided OpenCSG token.
-        let request_header = Self::build_request_headers(open_csg.token.clone(), None)?;
 
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
         let (base_url, api_base_url) = Self::resolve_base_urls(open_csg.base_url.as_deref())?;
@@ -508,8 +508,6 @@ impl Backend for OpenCsg {
                     &api_base_url,
                 )?;
 
-                // A failed listing must not be mistaken for an empty repository, so
-                // listing failures are returned as backend errors.
                 let response = self
                     .client
                     .get(repository_revision_url.as_str())
@@ -532,7 +530,12 @@ impl Backend for OpenCsg {
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
-                if !response_status_code.is_success() {
+                let content_length = match response_header.get(CONTENT_LENGTH) {
+                    Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
+                    None => response.content_length(),
+                };
+
+                if !response.status().is_success() {
                     error!(
                         "stat request failed {} {}: {}",
                         request.task_id, repository_revision_url, response_status_code
@@ -544,11 +547,6 @@ impl Backend for OpenCsg {
                         header: Some(response_header),
                     })));
                 }
-
-                let content_length = match response_header.get(CONTENT_LENGTH) {
-                    Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
-                    None => response.content_length(),
-                };
 
                 let text = response.text().await.map_err(|err| {
                     error!(
@@ -581,16 +579,15 @@ impl Backend for OpenCsg {
                     .unwrap_or_default()
                     .into_iter()
                     // OpenCSG lists files recursively, skip directory placeholders.
-                    .filter(|sibling| {
-                        !sibling.rfilename.is_empty() && sibling.r#type.as_deref() != Some("tree")
-                    })
-                    .map(|sibling| -> Result<DirEntry> {
-                        // Return opencsg:// URLs so downstream downloads continue to use
-                        // the OpenCSG backend (preserving auth and URL semantics).
-                        let opencsg_url = Self::build_opencsg_url(&parsed_url, &sibling.rfilename)?;
-                        let content_length = sibling
+                    .filter(|sibling: &Sibling| sibling.r#type.as_deref() != Some("tree"))
+                    .map(|sibling: Sibling| -> Result<DirEntry> {
+                        // Return opencsg:// URLs so downstream downloads continue to use the
+                        // OpenCSG backend (preserving auth and URL semantics).
+                        let opencsg_url: Url =
+                            Self::build_opencsg_url(&parsed_url, &sibling.rfilename)?;
+                        let content_length: u64 = sibling
                             .lfs
-                            .and_then(|lfs| lfs.size)
+                            .and_then(|lfs: Lfs| lfs.size)
                             .or(sibling.size)
                             .unwrap_or(0);
 
@@ -612,7 +609,7 @@ impl Backend for OpenCsg {
                 );
 
                 Ok(StatResponse {
-                    success: true,
+                    success: response_status_code.is_success(),
                     content_length,
                     http_header: Some(response_header),
                     http_status_code: Some(response_status_code),
@@ -631,6 +628,12 @@ impl Backend for OpenCsg {
             request.task_id, request.piece_id, request.url, request.http_header
         );
 
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(
+            request.open_csg.as_ref().and_then(|csg| csg.token.clone()),
+            request.range,
+        )?;
+
         // Get the OpenCSG information from the request, request must contain OpenCSG
         // information for get request, otherwise return error.
         let open_csg = request.open_csg.as_ref().ok_or_else(|| {
@@ -641,9 +644,6 @@ impl Backend for OpenCsg {
 
             Error::InvalidParameter
         })?;
-
-        // Build request headers, including authentication if provided OpenCSG token.
-        let request_header = Self::build_request_headers(open_csg.token.clone(), request.range)?;
 
         // Parse the URL and build the download URL for the specified file.
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
@@ -747,6 +747,12 @@ impl Backend for OpenCsg {
             request.task_id, request.url, request.http_header
         );
 
+        // Build request headers, including authentication if provided OpenCSG token.
+        let request_header = Self::build_request_headers(
+            request.open_csg.as_ref().and_then(|csg| csg.token.clone()),
+            None,
+        )?;
+
         // Get the OpenCSG information from the request, request must contain OpenCSG
         // information for exists request, otherwise return error.
         let open_csg = request.open_csg.as_ref().ok_or_else(|| {
@@ -758,50 +764,82 @@ impl Backend for OpenCsg {
             Error::InvalidParameter
         })?;
 
-        // Build request headers, including authentication if provided OpenCSG token.
-        let request_header = Self::build_request_headers(open_csg.token.clone(), None)?;
-
         let parsed_url = ParsedURL::try_from(request.url.as_str())?;
         let (base_url, api_base_url) = Self::resolve_base_urls(open_csg.base_url.as_deref())?;
-        let url = match &parsed_url.file_path {
+        match &parsed_url.file_path {
             Some(file_path) => {
-                Self::build_download_url(&parsed_url, file_path, &open_csg.revision, &base_url)?
+                let download_url = Self::build_download_url(
+                    &parsed_url,
+                    file_path,
+                    &open_csg.revision,
+                    &base_url,
+                )?;
+
+                let response = self
+                    .client
+                    .head(download_url.as_str())
+                    .headers(request_header)
+                    .timeout(request.timeout)
+                    .send()
+                    .await
+                    .inspect_err(|err| {
+                        error!(
+                            "exists request failed {} {}: {}",
+                            request.task_id, request.url, err
+                        );
+                    })?;
+
+                let response_status_code = response.status();
+                debug!(
+                    "exists response {} {}: {:?} {:?}",
+                    request.task_id,
+                    request.url,
+                    response_status_code,
+                    response.headers()
+                );
+
+                Ok(response_status_code.is_success())
             }
             None => {
-                Self::build_repository_revision_url(&parsed_url, &open_csg.revision, &api_base_url)?
-            }
-        };
+                let repository_revision_url = Self::build_repository_revision_url(
+                    &parsed_url,
+                    &open_csg.revision,
+                    &api_base_url,
+                )?;
 
-        let response = self
-            .client
-            .head(url.as_str())
-            .headers(request_header)
-            .timeout(request.timeout)
-            .send()
-            .await
-            .inspect_err(|err| {
-                error!(
-                    "exists request failed {} {}: {}",
-                    request.task_id, request.url, err
+                let response = self
+                    .client
+                    .head(repository_revision_url.as_str())
+                    .headers(request_header)
+                    .timeout(request.timeout)
+                    .send()
+                    .await
+                    .inspect_err(|err| {
+                        error!(
+                            "exists request failed {} {}: {}",
+                            request.task_id, request.url, err
+                        );
+                    })?;
+
+                let response_status_code = response.status();
+                debug!(
+                    "exists response {} {}: {:?} {:?}",
+                    request.task_id,
+                    request.url,
+                    response_status_code,
+                    response.headers()
                 );
-            })?;
 
-        let response_status_code = response.status();
-        debug!(
-            "exists response {} {}: {:?} {:?}",
-            request.task_id,
-            request.url,
-            response_status_code,
-            response.headers()
-        );
-
-        Ok(response_status_code.is_success())
+                Ok(response_status_code.is_success())
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_USER_AGENT;
     use dragonfly_api::common::v2::OpenCsg as OpenCsgOptions;
     use std::time::Duration;
     use wiremock::{
@@ -809,111 +847,247 @@ mod tests {
         Mock, MockServer, ResponseTemplate,
     };
 
-    /// Creates OpenCSG request options targeting a test server.
-    fn options(server: &MockServer) -> OpenCsgOptions {
-        OpenCsgOptions {
-            token: Some("secret".to_string()),
-            revision: "main".to_string(),
-            base_url: Some(server.uri()),
-        }
+    #[test]
+    fn test_parse_url_simple() {
+        let parsed_url = ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B").unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/csg-wukong-1B");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Model);
+        assert!(parsed_url.file_path.is_none());
     }
 
-    /// Verifies all OpenCSG repository kinds are parsed from provider URLs.
     #[test]
-    fn parses_model_and_extended_repository_types() {
-        let model = ParsedURL::try_from("opencsg://owner/repo/a/b.bin").unwrap();
-        assert_eq!(model.repository_type, RepositoryType::Model);
-        assert_eq!(model.repository_id, "owner/repo");
-        assert_eq!(model.file_path.as_deref(), Some("a/b.bin"));
-        for (segment, repository_type) in [
-            ("datasets", RepositoryType::Dataset),
-            ("spaces", RepositoryType::Space),
-            ("codes", RepositoryType::Code),
-            ("mcps", RepositoryType::Mcp),
-            ("skills", RepositoryType::Skill),
-        ] {
-            let parsed_url =
-                ParsedURL::try_from(format!("opencsg://{segment}/owner/repo").as_str()).unwrap();
-            assert_eq!(parsed_url.repository_type, repository_type);
-        }
+    fn test_parse_url_with_file() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B/model.safetensors").unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/csg-wukong-1B");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Model);
+        assert_eq!(parsed_url.file_path, Some("model.safetensors".to_string()));
     }
 
-    /// Verifies resolve and revision URLs retain custom endpoint path prefixes.
     #[test]
-    fn builds_urls_and_preserves_csg_prefix() {
-        let parsed_url = ParsedURL::try_from("opencsg://owner/repo/model%20file.bin").unwrap();
+    fn test_parse_url_with_nested_path() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B/models/v1/model.bin").unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/csg-wukong-1B");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Model);
+        assert_eq!(
+            parsed_url.file_path,
+            Some("models/v1/model.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_url_dataset() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://datasets/OpenCSG/chinese-fineweb-edu").unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/chinese-fineweb-edu");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Dataset);
+        assert!(parsed_url.file_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_url_dataset_with_path() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://datasets/OpenCSG/chinese-fineweb-edu/train.json")
+                .unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/chinese-fineweb-edu");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Dataset);
+        assert_eq!(parsed_url.file_path, Some("train.json".to_string()));
+    }
+
+    #[test]
+    fn test_parse_url_space() {
+        let parsed_url = ParsedURL::try_from("opencsg://spaces/owner/repo").unwrap();
+        assert_eq!(parsed_url.repository_id, "owner/repo");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Space);
+        assert!(parsed_url.file_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_url_code() {
+        let parsed_url = ParsedURL::try_from("opencsg://codes/owner/repo").unwrap();
+        assert_eq!(parsed_url.repository_id, "owner/repo");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Code);
+        assert!(parsed_url.file_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_url_mcp() {
+        let parsed_url = ParsedURL::try_from("opencsg://mcps/owner/repo").unwrap();
+        assert_eq!(parsed_url.repository_id, "owner/repo");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Mcp);
+        assert!(parsed_url.file_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_url_skill() {
+        let parsed_url = ParsedURL::try_from("opencsg://skills/owner/repo").unwrap();
+        assert_eq!(parsed_url.repository_id, "owner/repo");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Skill);
+        assert!(parsed_url.file_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_url_explicit_model_type() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://models/OpenCSG/csg-wukong-1B/model.safetensors")
+                .unwrap();
+        assert_eq!(parsed_url.repository_id, "OpenCSG/csg-wukong-1B");
+        assert_eq!(parsed_url.repository_type, RepositoryType::Model);
+        assert_eq!(parsed_url.file_path, Some("model.safetensors".to_string()));
+    }
+
+    #[test]
+    fn test_parse_url_missing_repo() {
+        let result = ParsedURL::try_from("opencsg://owner");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_download_url_model() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B/model.safetensors").unwrap();
+        let url = OpenCsg::build_download_url(
+            &parsed_url,
+            "model.safetensors",
+            "main",
+            &Url::parse(OPEN_CSG_BASE_URL).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://hub.opencsg.com/csg/OpenCSG/csg-wukong-1B/resolve/main/model.safetensors"
+        );
+    }
+
+    #[test]
+    fn test_build_download_url_dataset() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://datasets/OpenCSG/chinese-fineweb-edu/train.json")
+                .unwrap();
+        let url = OpenCsg::build_download_url(
+            &parsed_url,
+            "train.json",
+            "main",
+            &Url::parse(OPEN_CSG_BASE_URL).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://hub.opencsg.com/csg/datasets/OpenCSG/chinese-fineweb-edu/resolve/main/train.json"
+        );
+    }
+
+    #[test]
+    fn test_build_repository_revision_url_model() {
+        let parsed_url = ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B").unwrap();
+        let url = OpenCsg::build_repository_revision_url(
+            &parsed_url,
+            "main",
+            &Url::parse("https://hub.opencsg.com/csg/api/").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://hub.opencsg.com/csg/api/models/OpenCSG/csg-wukong-1B/revision/main?blobs=true"
+        );
+    }
+
+    #[test]
+    fn test_build_repository_revision_url_dataset() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://datasets/OpenCSG/chinese-fineweb-edu").unwrap();
+        let url = OpenCsg::build_repository_revision_url(
+            &parsed_url,
+            "main",
+            &Url::parse("https://hub.opencsg.com/csg/api/").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://hub.opencsg.com/csg/api/datasets/OpenCSG/chinese-fineweb-edu/revision/main"
+        );
+    }
+
+    #[test]
+    fn test_build_opencsg_url_model() {
+        let parsed_url = ParsedURL::try_from("opencsg://OpenCSG/csg-wukong-1B").unwrap();
+        let url = OpenCsg::build_opencsg_url(&parsed_url, "model.safetensors").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "opencsg://OpenCSG/csg-wukong-1B/model.safetensors"
+        );
+    }
+
+    #[test]
+    fn test_build_opencsg_url_dataset() {
+        let parsed_url =
+            ParsedURL::try_from("opencsg://datasets/OpenCSG/chinese-fineweb-edu").unwrap();
+        let url = OpenCsg::build_opencsg_url(&parsed_url, "train.json").unwrap();
+        assert_eq!(
+            url.as_str(),
+            "opencsg://datasets/OpenCSG/chinese-fineweb-edu/train.json"
+        );
+    }
+
+    #[test]
+    fn test_resolve_base_urls() {
         let (base_url, api_base_url) =
-            OpenCsg::resolve_base_urls(Some("https://example.test/private/csg")).unwrap();
-        let download_url =
-            OpenCsg::build_download_url(&parsed_url, "model file.bin", "main", &base_url).unwrap();
+            OpenCsg::resolve_base_urls(Some("https://hub-mirror.example.com/csg/")).unwrap();
+        assert_eq!(base_url.as_str(), "https://hub-mirror.example.com/csg/");
         assert_eq!(
-            download_url.as_str(),
-            "https://example.test/private/csg/owner/repo/resolve/main/model%20file.bin"
-        );
-        let repository_revision_url =
-            OpenCsg::build_repository_revision_url(&parsed_url, "main", &api_base_url).unwrap();
-        assert_eq!(
-            repository_revision_url.as_str(),
-            "https://example.test/private/csg/api/models/owner/repo/revision/main?blobs=true"
-        );
-
-        let dataset = ParsedURL::try_from("opencsg://datasets/owner/repo/data.json").unwrap();
-        let download_url =
-            OpenCsg::build_download_url(&dataset, "data.json", "dev", &base_url).unwrap();
-        assert_eq!(
-            download_url.as_str(),
-            "https://example.test/private/csg/datasets/owner/repo/resolve/dev/data.json"
-        );
-        let repository_revision_url =
-            OpenCsg::build_repository_revision_url(&dataset, "dev", &api_base_url).unwrap();
-        assert_eq!(
-            repository_revision_url.as_str(),
-            "https://example.test/private/csg/api/datasets/owner/repo/revision/dev"
-        );
-        assert_eq!(
-            OpenCsg::build_opencsg_url(&dataset, "nested/data.json")
-                .unwrap()
-                .as_str(),
-            "opencsg://datasets/owner/repo/nested/data.json"
-        );
-
-        let explicit_model = ParsedURL::try_from("opencsg://models/owner/repo").unwrap();
-        assert_eq!(
-            OpenCsg::build_opencsg_url(&explicit_model, "model.bin")
-                .unwrap()
-                .as_str(),
-            "opencsg://owner/repo/model.bin"
+            api_base_url.as_str(),
+            "https://hub-mirror.example.com/csg/api/"
         );
     }
 
-    /// Verifies malformed URLs, unsafe paths and invalid ranges are rejected.
     #[test]
-    fn rejects_invalid_urls_and_empty_ranges() {
-        assert!(ParsedURL::try_from("hf://owner/repo").is_err());
-        assert!(ParsedURL::try_from("opencsg://owner").is_err());
-        assert!(OpenCsg::build_request_headers(
+    fn test_build_headers_default_user_agent() {
+        let request_header = OpenCsg::build_request_headers(None, None).unwrap();
+        assert_eq!(
+            request_header.get(USER_AGENT).unwrap(),
+            HeaderValue::from_static(DEFAULT_USER_AGENT)
+        );
+    }
+
+    #[test]
+    fn test_build_headers_preserves_request_headers() {
+        let request_headers =
+            OpenCsg::build_request_headers(Some("test-token".to_string()), None).unwrap();
+        assert_eq!(
+            request_headers.get(reqwest::header::AUTHORIZATION).unwrap(),
+            "Bearer test-token"
+        );
+        assert_eq!(
+            request_headers.get(USER_AGENT).unwrap(),
+            HeaderValue::from_static(DEFAULT_USER_AGENT)
+        );
+    }
+
+    #[test]
+    fn test_build_headers_with_range() {
+        let request_headers = OpenCsg::build_request_headers(
             None,
             Some(Range {
                 start: 0,
-                length: 0
-            })
+                length: 1024,
+            }),
         )
-        .is_err());
-        assert!(OpenCsg::repository_path_segments("../secret").is_err());
-        assert!(OpenCsg::repository_path_segments("dir\\secret").is_err());
-        assert!(OpenCsg::repository_path_segments("dir/secret\0file").is_err());
+        .unwrap();
+        assert_eq!(
+            request_headers.get(RANGE).unwrap(),
+            HeaderValue::from_static("bytes=0-1023")
+        );
     }
 
-    /// Verifies an empty repository represented by JSON null is accepted.
     #[test]
-    fn accepts_null_siblings_for_empty_repository() {
+    fn test_parse_repository_null_siblings() {
         let repository: Repository = serde_json::from_str(r#"{"siblings":null}"#).unwrap();
         assert!(repository.siblings.unwrap_or_default().is_empty());
     }
 
-    /// Verifies recursive model metadata, authentication, sizes and child URLs.
     #[tokio::test]
-    async fn stats_model_repository() {
+    async fn test_stat_repository() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/models/owner/repo/revision/main"))
@@ -943,7 +1117,11 @@ mod tests {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
-                open_csg: Some(options(&server)),
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: Some("secret".to_string()),
+                    base_url: Some(server.uri()),
+                }),
             })
             .await
             .unwrap();
@@ -962,13 +1140,11 @@ mod tests {
         assert_eq!(response.entries[2].content_length, 0);
     }
 
-    /// Verifies dataset metadata uses the typed route and tolerates omitted sizes.
     #[tokio::test]
-    async fn stats_dataset_repository_without_sizes() {
+    async fn test_stat_dataset_repository() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/datasets/owner/repo/revision/main"))
-            .and(header("authorization", "Bearer secret"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "siblings": [
                     {"rfilename": "nested/train.json"},
@@ -990,7 +1166,11 @@ mod tests {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
-                open_csg: Some(options(&server)),
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
             })
             .await
             .unwrap();
@@ -1007,10 +1187,42 @@ mod tests {
         );
     }
 
-    /// Verifies a failed repository listing returns a backend error instead of an
-    /// empty repository.
     #[tokio::test]
-    async fn stats_repository_with_error_status() {
+    async fn test_stat_file() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .respond_with(ResponseTemplate::new(200).insert_header("content-length", "4096"))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let response = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://owner/repo/model.bin".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.content_length, Some(4096));
+    }
+
+    #[tokio::test]
+    async fn test_stat_repository_with_error_status() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/models/owner/repo/revision/main"))
@@ -1030,7 +1242,11 @@ mod tests {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
-                open_csg: Some(options(&server)),
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
             })
             .await
             .unwrap_err();
@@ -1041,41 +1257,8 @@ mod tests {
         ));
     }
 
-    /// Verifies file HEAD uses the resolve route and reports its length.
     #[tokio::test]
-    async fn stats_file_with_head() {
-        let server = MockServer::start().await;
-        Mock::given(method("HEAD"))
-            .and(path("/owner/repo/resolve/main/model.bin"))
-            .and(header("authorization", "Bearer secret"))
-            .respond_with(ResponseTemplate::new(200).insert_header("content-length", "4096"))
-            .mount(&server)
-            .await;
-
-        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
-        let response = backend
-            .stat(StatRequest {
-                task_id: "task".to_string(),
-                url: "opencsg://owner/repo/model.bin".to_string(),
-                http_header: None,
-                timeout: Duration::from_secs(5),
-                client_cert: None,
-                object_storage: None,
-                hdfs: None,
-                hugging_face: None,
-                model_scope: None,
-                open_csg: Some(options(&server)),
-            })
-            .await
-            .unwrap();
-
-        assert!(response.success);
-        assert_eq!(response.content_length, Some(4096));
-    }
-
-    /// Verifies ranged content is streamed only from a valid 206 response.
-    #[tokio::test]
-    async fn gets_ranged_file() {
+    async fn test_get_propagates_range_header() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/owner/repo/resolve/main/model.bin"))
@@ -1105,7 +1288,11 @@ mod tests {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
-                open_csg: Some(options(&server)),
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
             })
             .await
             .unwrap();
@@ -1114,9 +1301,8 @@ mod tests {
         assert_eq!(response.text().await.unwrap(), "partial content here");
     }
 
-    /// Verifies LFS redirects retain the Range request and stream the object response.
     #[tokio::test]
-    async fn follows_lfs_redirect() {
+    async fn test_get_follows_lfs_redirect() {
         let server = MockServer::start().await;
         let object_server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -1156,7 +1342,11 @@ mod tests {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
-                open_csg: Some(options(&server)),
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: Some("secret".to_string()),
+                    base_url: Some(server.uri()),
+                }),
             })
             .await
             .unwrap();
@@ -1168,10 +1358,8 @@ mod tests {
         assert!(object_requests[0].headers.get("authorization").is_none());
     }
 
-    /// Verifies existence checks select the resolve route for files and the
-    /// revision route for repositories.
     #[tokio::test]
-    async fn checks_file_and_repository_existence() {
+    async fn test_exists() {
         let server = MockServer::start().await;
         Mock::given(method("HEAD"))
             .and(path("/owner/repo/resolve/main/model.bin"))
@@ -1202,7 +1390,11 @@ mod tests {
                     hdfs: None,
                     hugging_face: None,
                     model_scope: None,
-                    open_csg: Some(options(&server)),
+                    open_csg: Some(OpenCsgOptions {
+                        revision: "main".to_string(),
+                        token: None,
+                        base_url: Some(server.uri()),
+                    }),
                 })
                 .await
                 .unwrap();

--- a/dragonfly-client-backend/src/opencsg.rs
+++ b/dragonfly-client-backend/src/opencsg.rs
@@ -1,0 +1,1023 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! OpenCSG repository backend.
+//!
+//! OpenCSG exposes Hugging Face compatible SDK routes below `/csg`. Repository
+//! metadata is used for recursive downloads and file resolve routes are used
+//! for ranged piece downloads. Authentication is deliberately kept in the
+//! request options, so it never becomes part of a task URL.
+
+use crate::{
+    empty_body, Backend, Body, DirEntry, ExistsRequest, GetRequest, GetResponse, PutRequest,
+    PutResponse, StatRequest, StatResponse, DEFAULT_USER_AGENT, KEEP_ALIVE_INTERVAL,
+    POOL_MAX_IDLE_PER_HOST,
+};
+use async_trait::async_trait;
+use dragonfly_api::common::v2::{OpenCsg as OpenCsgOptions, Range};
+use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_core::{
+    error::{BackendError, ErrorType, OrErr},
+    Error, Result,
+};
+use dragonfly_client_util::{http::validate_ranged_response, tls::NoVerifier};
+use futures::{StreamExt, TryStreamExt};
+use percent_encoding::percent_decode_str;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, RANGE, USER_AGENT};
+use reqwest::Client;
+use serde::Deserialize;
+use std::error::Error as _;
+use std::io::Error as IOError;
+use std::sync::Arc;
+use tokio_util::io::StreamReader;
+use tracing::{error, instrument};
+use url::Url;
+
+/// The URL scheme for OpenCSG repositories.
+pub const SCHEME: &str = "opencsg";
+
+/// The default OpenCSG SDK endpoint. The `/csg/` prefix is significant.
+const OPEN_CSG_BASE_URL: &str = "https://hub.opencsg.com/csg/";
+
+/// OpenCSG repository kinds exposed by the SDK mapping routes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepositoryType {
+    /// A model repository, the default kind.
+    Model,
+    /// A dataset repository.
+    Dataset,
+    /// A space repository.
+    Space,
+    /// A code repository.
+    Code,
+    /// An MCP server repository.
+    Mcp,
+    /// A skill repository.
+    Skill,
+}
+
+impl RepositoryType {
+    /// Returns the route segment used by OpenCSG.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Model => "models",
+            Self::Dataset => "datasets",
+            Self::Space => "spaces",
+            Self::Code => "codes",
+            Self::Mcp => "mcps",
+            Self::Skill => "skills",
+        }
+    }
+
+    /// Parses a canonical repository type route segment.
+    fn from_segment(segment: &str) -> Option<Self> {
+        match segment {
+            "models" => Some(Self::Model),
+            "datasets" => Some(Self::Dataset),
+            "spaces" => Some(Self::Space),
+            "codes" => Some(Self::Code),
+            "mcps" => Some(Self::Mcp),
+            "skills" => Some(Self::Skill),
+            _ => None,
+        }
+    }
+}
+
+/// Parsed representation of an `opencsg://` URL.
+#[derive(Debug, Clone)]
+pub struct ParsedURL {
+    /// Original URL.
+    pub url: Url,
+    /// Repository identifier in `owner/name` form.
+    pub repository_id: String,
+    /// OpenCSG repository kind.
+    pub repository_type: RepositoryType,
+    /// Optional repository-relative file path.
+    pub file_path: Option<String>,
+}
+
+impl TryFrom<Url> for ParsedURL {
+    type Error = Error;
+
+    /// Parses `opencsg://[type/]owner/repository[/path]`.
+    fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != SCHEME {
+            return Err(Error::InvalidURI(url.to_string()));
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| Error::InvalidURI(url.to_string()))?;
+        let raw_path = format!("{}{}", host, url.path().trim_end_matches('/'));
+        let segments: Vec<String> = raw_path
+            .trim_matches('/')
+            .split('/')
+            .map(|segment| {
+                percent_decode_str(segment)
+                    .decode_utf8()
+                    .map(|segment| segment.into_owned())
+                    .map_err(|_| Error::InvalidURI(url.to_string()))
+            })
+            .collect::<Result<_>>()?;
+        if segments.iter().any(|segment| {
+            segment.contains('/') || segment.contains('\\') || segment.contains('\0')
+        }) {
+            return Err(Error::InvalidURI(url.to_string()));
+        }
+        let (repository_type, offset) = match segments.first() {
+            Some(segment) => match RepositoryType::from_segment(segment) {
+                Some(kind) => (kind, 1),
+                None => (RepositoryType::Model, 0),
+            },
+            None => return Err(Error::InvalidParameter),
+        };
+        let remaining = &segments[offset..];
+        if remaining.len() < 2 || remaining.iter().any(|segment| segment.is_empty()) {
+            return Err(Error::InvalidParameter);
+        }
+        Ok(Self {
+            url,
+            repository_id: format!("{}/{}", remaining[0], remaining[1]),
+            repository_type,
+            file_path: (remaining.len() > 2).then(|| remaining[2..].join("/")),
+        })
+    }
+}
+
+impl TryFrom<&str> for ParsedURL {
+    type Error = Error;
+
+    /// Parses a string URL.
+    fn try_from(url: &str) -> std::result::Result<Self, Self::Error> {
+        ParsedURL::try_from(Url::parse(url).or_err(ErrorType::ParseError)?)
+    }
+}
+
+/// Repository metadata returned by OpenCSG SDK-compatible APIs.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct Metadata {
+    /// Files contained in the requested repository revision.
+    siblings: Option<Vec<Sibling>>,
+}
+
+/// A repository metadata entry.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct Sibling {
+    /// Repository-relative file name.
+    #[serde(rename = "rfilename")]
+    filename: String,
+    /// File size when provided by the metadata endpoint.
+    size: Option<u64>,
+    /// Git LFS metadata when the entry is backed by LFS.
+    lfs: Option<Lfs>,
+    /// Entry kind when returned by a compatible endpoint.
+    #[serde(rename = "type")]
+    entry_type: Option<String>,
+}
+
+/// Relevant Git LFS metadata for a repository entry.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct Lfs {
+    /// Downloadable LFS object size.
+    size: Option<u64>,
+}
+
+/// OpenCSG backend implementation.
+pub struct OpenCsg {
+    /// Registered backend scheme.
+    scheme: String,
+    /// HTTP client used for metadata and resolve requests.
+    client: Client,
+}
+
+impl OpenCsg {
+    /// Creates an OpenCSG backend using dfdaemon's common TLS and DNS settings.
+    pub fn new(config: Arc<Config>) -> Result<Self> {
+        let client_config_builder = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(NoVerifier::new())
+            .with_no_client_auth();
+        let client = Client::builder()
+            .no_gzip()
+            .no_brotli()
+            .no_zstd()
+            .no_deflate()
+            .hickory_dns(config.backend.enable_hickory_dns)
+            .use_preconfigured_tls(client_config_builder)
+            .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(KEEP_ALIVE_INTERVAL)
+            .tcp_nodelay(true)
+            .build()?;
+        Ok(Self {
+            scheme: SCHEME.to_string(),
+            client,
+        })
+    }
+
+    /// Normalizes a base URL while retaining any user-supplied path prefix.
+    fn resolve_base_urls(base_url: Option<&str>) -> Result<(Url, Url)> {
+        let mut base = Url::parse(base_url.unwrap_or(OPEN_CSG_BASE_URL))?;
+        if !base.path().ends_with('/') {
+            let path = format!("{}/", base.path());
+            base.set_path(&path);
+        }
+        let api = base.join("api/")?;
+        Ok((base, api))
+    }
+
+    /// Appends already-decoded path segments so `Url` performs canonical escaping.
+    fn append_segments(mut base: Url, segments: impl IntoIterator<Item = String>) -> Result<Url> {
+        let base_string = base.to_string();
+        {
+            let mut path = base
+                .path_segments_mut()
+                .map_err(|_| Error::InvalidURI(base_string))?;
+            path.pop_if_empty();
+            for segment in segments {
+                path.push(&segment);
+            }
+        }
+        Ok(base)
+    }
+
+    /// Splits a repository-relative path and rejects components unsafe for local output paths.
+    fn repository_path_segments(path: &str) -> Result<Vec<String>> {
+        let segments: Vec<&str> = path.split('/').collect();
+        if segments.is_empty()
+            || segments
+                .iter()
+                .any(|segment| segment.is_empty() || matches!(*segment, "." | ".."))
+            || segments.iter().any(|segment| segment.contains('\\'))
+            || segments.iter().any(|segment| segment.contains('\0'))
+        {
+            return Err(Error::InvalidParameter);
+        }
+        Ok(segments.into_iter().map(str::to_string).collect())
+    }
+
+    /// Builds a provider resolve URL for a file.
+    fn build_download_url(
+        parsed_url: &ParsedURL,
+        file_path: &str,
+        revision: &str,
+        base_url: &Url,
+    ) -> Result<Url> {
+        let mut segments = vec![];
+        if parsed_url.repository_type != RepositoryType::Model {
+            segments.push(parsed_url.repository_type.as_str().to_string());
+        }
+        segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
+        segments.push("resolve".to_string());
+        segments.push(revision.to_string());
+        segments.extend(Self::repository_path_segments(file_path)?);
+        Self::append_segments(base_url.clone(), segments)
+    }
+
+    /// Builds the revision metadata URL used for recursive repository listing.
+    fn build_metadata_url(parsed_url: &ParsedURL, revision: &str, api_base: &Url) -> Result<Url> {
+        let mut segments = vec![parsed_url.repository_type.as_str().to_string()];
+        segments.extend(parsed_url.repository_id.split('/').map(str::to_string));
+        segments.push("revision".to_string());
+        segments.push(revision.to_string());
+        let mut url = Self::append_segments(api_base.clone(), segments)?;
+        if parsed_url.repository_type == RepositoryType::Model {
+            url.query_pairs_mut().append_pair("blobs", "true");
+        }
+        Ok(url)
+    }
+
+    /// Builds an `opencsg://` child URL that keeps downloads on this backend.
+    fn build_opencsg_url(parsed_url: &ParsedURL, filename: &str) -> Result<Url> {
+        let repository_segments: Vec<&str> = parsed_url.repository_id.split('/').collect();
+        let owner = repository_segments.first().ok_or(Error::InvalidParameter)?;
+        let repository = repository_segments.get(1).ok_or(Error::InvalidParameter)?;
+        let explicit_model = parsed_url.repository_type == RepositoryType::Model
+            && parsed_url.url.host_str() == Some(RepositoryType::Model.as_str());
+        let (authority, mut path) = if explicit_model {
+            (
+                RepositoryType::Model.as_str(),
+                vec![(*owner).to_string(), (*repository).to_string()],
+            )
+        } else if parsed_url.repository_type == RepositoryType::Model {
+            (*owner, vec![(*repository).to_string()])
+        } else {
+            (
+                parsed_url.repository_type.as_str(),
+                vec![(*owner).to_string(), (*repository).to_string()],
+            )
+        };
+        let mut url = Url::parse(&format!("{SCHEME}://{authority}"))?;
+        path.extend(Self::repository_path_segments(filename)?);
+        let url_string = url.to_string();
+        {
+            let mut path_segments = url
+                .path_segments_mut()
+                .map_err(|_| Error::InvalidURI(url_string))?;
+            for segment in path {
+                path_segments.push(&segment);
+            }
+        }
+        Ok(url)
+    }
+
+    /// Builds Authorization, User-Agent and optional single-range headers.
+    fn build_request_headers(token: Option<String>, range: Option<Range>) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        if let Some(range) = range {
+            if range.length == 0 {
+                return Err(Error::InvalidParameter);
+            }
+            let end = range
+                .start
+                .checked_add(range.length - 1)
+                .ok_or(Error::InvalidParameter)?;
+            headers.insert(RANGE, format!("bytes={}-{end}", range.start).parse()?);
+        }
+        headers
+            .entry(USER_AGENT)
+            .or_insert(HeaderValue::from_static(DEFAULT_USER_AGENT));
+        if let Some(token) = token {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {token}"))
+                    .map_err(|_| Error::InvalidParameter)?,
+            );
+        }
+        Ok(headers)
+    }
+
+    /// Wraps response decoding failures as backend errors.
+    fn backend_error(message: impl Into<String>) -> Error {
+        Error::BackendError(Box::new(BackendError {
+            message: message.into(),
+            status_code: None,
+            header: None,
+        }))
+    }
+
+    /// Validates options that are required by every OpenCSG request.
+    fn validate_options(options: &OpenCsgOptions) -> Result<()> {
+        if options.revision.trim().is_empty() {
+            return Err(Error::InvalidParameter);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Backend for OpenCsg {
+    /// Returns the OpenCSG URL scheme.
+    fn scheme(&self) -> String {
+        self.scheme.clone()
+    }
+
+    /// Stats a file with HEAD or lists repository metadata with GET.
+    #[instrument(skip_all)]
+    async fn stat(&self, request: StatRequest) -> Result<StatResponse> {
+        let options = request.open_csg.as_ref().ok_or_else(|| {
+            error!(
+                "stat request {} {}: missing OpenCSG information",
+                request.task_id, request.url
+            );
+            Error::InvalidParameter
+        })?;
+        Self::validate_options(options)?;
+        let headers = Self::build_request_headers(options.token.clone(), None)?;
+        let parsed = ParsedURL::try_from(request.url.as_str())?;
+        let (base, api) = Self::resolve_base_urls(options.base_url.as_deref())?;
+        let response = if let Some(file_path) = parsed.file_path.as_deref() {
+            let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
+            self.client
+                .head(url)
+                .headers(headers)
+                .timeout(request.timeout)
+                .send()
+                .await
+        } else {
+            let url = Self::build_metadata_url(&parsed, &options.revision, &api)?;
+            self.client
+                .get(url)
+                .headers(headers)
+                .timeout(request.timeout)
+                .send()
+                .await
+        };
+        let response = match response {
+            Ok(response) => response,
+            Err(err) => {
+                return Ok(StatResponse {
+                    success: false,
+                    content_length: None,
+                    http_header: None,
+                    http_status_code: None,
+                    entries: vec![],
+                    error_message: Some(err.to_string()),
+                });
+            }
+        };
+        let status = response.status();
+        let response_headers = response.headers().clone();
+        let content_length = response_headers
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+            .or(response.content_length());
+        if parsed.file_path.is_some() {
+            return Ok(StatResponse {
+                success: status.is_success(),
+                content_length,
+                http_header: Some(response_headers),
+                http_status_code: Some(status),
+                entries: vec![],
+                error_message: Some(status.to_string()),
+            });
+        }
+        if !status.is_success() {
+            return Ok(StatResponse {
+                success: false,
+                content_length: None,
+                http_header: Some(response_headers),
+                http_status_code: Some(status),
+                entries: vec![],
+                error_message: Some(status.to_string()),
+            });
+        }
+        let body = response
+            .text()
+            .await
+            .map_err(|err| Self::backend_error(err.to_string()))?;
+        let metadata: Metadata =
+            serde_json::from_str(&body).map_err(|err| Self::backend_error(err.to_string()))?;
+        let entries = metadata
+            .siblings
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|sibling| {
+                !sibling.filename.is_empty() && sibling.entry_type.as_deref() != Some("tree")
+            })
+            .map(|sibling| {
+                Ok(DirEntry {
+                    url: Self::build_opencsg_url(&parsed, &sibling.filename)?.to_string(),
+                    content_length: sibling
+                        .lfs
+                        .and_then(|lfs| lfs.size)
+                        .or(sibling.size)
+                        .unwrap_or_default() as usize,
+                    is_dir: false,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(StatResponse {
+            success: true,
+            content_length,
+            http_header: Some(response_headers),
+            http_status_code: Some(status),
+            entries,
+            error_message: Some(status.to_string()),
+        })
+    }
+
+    /// Downloads a file through a single-range GET and streams the response.
+    #[instrument(skip_all)]
+    async fn get(&self, request: GetRequest) -> Result<GetResponse<Body>> {
+        let options = request.open_csg.as_ref().ok_or_else(|| {
+            error!(
+                "get request {} {}: missing OpenCSG information",
+                request.task_id, request.url
+            );
+            Error::InvalidParameter
+        })?;
+        Self::validate_options(options)?;
+        let parsed = ParsedURL::try_from(request.url.as_str())?;
+        let file_path = parsed.file_path.as_deref().ok_or(Error::InvalidParameter)?;
+        let (base, _) = Self::resolve_base_urls(options.base_url.as_deref())?;
+        let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
+        let headers = Self::build_request_headers(options.token.clone(), request.range)?;
+        let response = match self
+            .client
+            .get(url)
+            .headers(headers)
+            .timeout(request.timeout)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                return Ok(GetResponse {
+                    success: false,
+                    http_header: None,
+                    http_status_code: None,
+                    reader: empty_body(),
+                    error_message: Some(err.to_string()),
+                });
+            }
+        };
+        let response_headers = response.headers().clone();
+        let status = response.status();
+        if request.range.is_some()
+            && status.is_success()
+            && status != reqwest::StatusCode::PARTIAL_CONTENT
+        {
+            return Ok(GetResponse {
+                success: false,
+                http_header: Some(response_headers),
+                http_status_code: Some(status),
+                reader: empty_body(),
+                error_message: Some(format!(
+                    "expected 206 Partial Content for ranged OpenCSG request, got {status}"
+                )),
+            });
+        }
+        if let Err(err) = validate_ranged_response(request.range, status, &response_headers) {
+            return Ok(GetResponse {
+                success: false,
+                http_header: Some(response_headers),
+                http_status_code: Some(status),
+                reader: empty_body(),
+                error_message: Some(err.to_string()),
+            });
+        }
+        let reader = StreamReader::new(
+            response
+                .bytes_stream()
+                .map_err(|err| {
+                    let mut chain = err.to_string();
+                    let mut source = err.source();
+                    while let Some(err) = source {
+                        chain.push_str(": ");
+                        chain.push_str(&err.to_string());
+                        source = err.source();
+                    }
+
+                    IOError::other(chain)
+                })
+                .boxed(),
+        );
+        Ok(GetResponse {
+            success: status.is_success(),
+            http_header: Some(response_headers),
+            http_status_code: Some(status),
+            reader,
+            error_message: Some(status.to_string()),
+        })
+    }
+
+    /// OpenCSG upload is outside the download protocol.
+    #[instrument(skip_all)]
+    async fn put(&self, _request: PutRequest) -> Result<PutResponse> {
+        unimplemented!()
+    }
+
+    /// Checks file existence with HEAD, or repository existence with metadata GET.
+    #[instrument(skip_all)]
+    async fn exists(&self, request: ExistsRequest) -> Result<bool> {
+        let options = request.open_csg.as_ref().ok_or(Error::InvalidParameter)?;
+        Self::validate_options(options)?;
+        let headers = Self::build_request_headers(options.token.clone(), None)?;
+        let parsed = ParsedURL::try_from(request.url.as_str())?;
+        let (base, api) = Self::resolve_base_urls(options.base_url.as_deref())?;
+        let response = if let Some(file_path) = parsed.file_path.as_deref() {
+            let url = Self::build_download_url(&parsed, file_path, &options.revision, &base)?;
+            self.client
+                .head(url)
+                .headers(headers)
+                .timeout(request.timeout)
+                .send()
+                .await
+        } else {
+            let url = Self::build_metadata_url(&parsed, &options.revision, &api)?;
+            self.client
+                .get(url)
+                .headers(headers)
+                .timeout(request.timeout)
+                .send()
+                .await
+        }?;
+        Ok(response.status().is_success())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use wiremock::{
+        matchers::{header, method, path, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    /// Creates OpenCSG request options targeting a test server.
+    fn options(server: &MockServer) -> OpenCsgOptions {
+        OpenCsgOptions {
+            token: Some("secret".to_string()),
+            revision: "main".to_string(),
+            base_url: Some(server.uri()),
+        }
+    }
+
+    /// Verifies all OpenCSG repository kinds are parsed from provider URLs.
+    #[test]
+    fn parses_model_and_extended_repository_types() {
+        let model = ParsedURL::try_from("opencsg://owner/repo/a/b.bin").unwrap();
+        assert_eq!(model.repository_type, RepositoryType::Model);
+        assert_eq!(model.repository_id, "owner/repo");
+        assert_eq!(model.file_path.as_deref(), Some("a/b.bin"));
+        for (segment, repository_type) in [
+            ("datasets", RepositoryType::Dataset),
+            ("spaces", RepositoryType::Space),
+            ("codes", RepositoryType::Code),
+            ("mcps", RepositoryType::Mcp),
+            ("skills", RepositoryType::Skill),
+        ] {
+            let parsed =
+                ParsedURL::try_from(format!("opencsg://{segment}/owner/repo").as_str()).unwrap();
+            assert_eq!(parsed.repository_type, repository_type);
+        }
+    }
+
+    /// Verifies resolve and metadata URLs retain custom endpoint path prefixes.
+    #[test]
+    fn builds_urls_and_preserves_csg_prefix() {
+        let parsed = ParsedURL::try_from("opencsg://owner/repo/model%20file.bin").unwrap();
+        let (base, api) =
+            OpenCsg::resolve_base_urls(Some("https://example.test/private/csg")).unwrap();
+        let download =
+            OpenCsg::build_download_url(&parsed, "model file.bin", "main", &base).unwrap();
+        assert_eq!(
+            download.as_str(),
+            "https://example.test/private/csg/owner/repo/resolve/main/model%20file.bin"
+        );
+        let metadata = OpenCsg::build_metadata_url(&parsed, "main", &api).unwrap();
+        assert_eq!(
+            metadata.as_str(),
+            "https://example.test/private/csg/api/models/owner/repo/revision/main?blobs=true"
+        );
+
+        let dataset = ParsedURL::try_from("opencsg://datasets/owner/repo/data.json").unwrap();
+        let download = OpenCsg::build_download_url(&dataset, "data.json", "dev", &base).unwrap();
+        assert_eq!(
+            download.as_str(),
+            "https://example.test/private/csg/datasets/owner/repo/resolve/dev/data.json"
+        );
+        let metadata = OpenCsg::build_metadata_url(&dataset, "dev", &api).unwrap();
+        assert_eq!(
+            metadata.as_str(),
+            "https://example.test/private/csg/api/datasets/owner/repo/revision/dev"
+        );
+        assert_eq!(
+            OpenCsg::build_opencsg_url(&dataset, "nested/data.json")
+                .unwrap()
+                .as_str(),
+            "opencsg://datasets/owner/repo/nested/data.json"
+        );
+
+        let explicit_model = ParsedURL::try_from("opencsg://models/owner/repo").unwrap();
+        assert_eq!(
+            OpenCsg::build_opencsg_url(&explicit_model, "model.bin")
+                .unwrap()
+                .as_str(),
+            "opencsg://models/owner/repo/model.bin"
+        );
+    }
+
+    /// Verifies malformed URLs, unsafe paths and invalid ranges are rejected.
+    #[test]
+    fn rejects_invalid_urls_and_empty_ranges() {
+        assert!(ParsedURL::try_from("hf://owner/repo").is_err());
+        assert!(ParsedURL::try_from("opencsg://owner").is_err());
+        assert!(OpenCsg::build_request_headers(
+            None,
+            Some(Range {
+                start: 0,
+                length: 0
+            })
+        )
+        .is_err());
+        assert!(OpenCsg::repository_path_segments("../secret").is_err());
+        assert!(OpenCsg::repository_path_segments("dir\\secret").is_err());
+        assert!(OpenCsg::repository_path_segments("dir/secret\0file").is_err());
+    }
+
+    /// Verifies an empty repository represented by JSON null is accepted.
+    #[test]
+    fn accepts_null_siblings_for_empty_repository() {
+        let metadata: Metadata = serde_json::from_str(r#"{"siblings":null}"#).unwrap();
+        assert!(metadata.siblings.unwrap_or_default().is_empty());
+    }
+
+    /// Verifies recursive model metadata, authentication, sizes and child URLs.
+    #[tokio::test]
+    async fn stats_model_repository() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/models/owner/repo/revision/main"))
+            .and(query_param("blobs", "true"))
+            .and(header("authorization", "Bearer secret"))
+            .and(header("user-agent", DEFAULT_USER_AGENT))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "siblings": [
+                    {"rfilename": "nested/config file.json", "size": 12},
+                    {"rfilename": "model.bin", "size": 128, "lfs": {"size": 4096}},
+                    {"rfilename": "README.md"},
+                    {"rfilename": "ignored", "type": "tree"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let response = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://owner/repo".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.entries.len(), 3);
+        assert_eq!(
+            response.entries[0],
+            DirEntry {
+                url: "opencsg://owner/repo/nested/config%20file.json".to_string(),
+                content_length: 12,
+                is_dir: false,
+            }
+        );
+        assert_eq!(response.entries[1].content_length, 4096);
+        assert_eq!(response.entries[2].content_length, 0);
+    }
+
+    /// Verifies dataset metadata uses the typed route and tolerates omitted sizes.
+    #[tokio::test]
+    async fn stats_dataset_repository_without_sizes() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/datasets/owner/repo/revision/main"))
+            .and(header("authorization", "Bearer secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "siblings": [
+                    {"rfilename": "nested/train.json"},
+                    {"rfilename": "README.md"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let response = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://datasets/owner/repo".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.entries.len(), 2);
+        assert_eq!(
+            response.entries[0],
+            DirEntry {
+                url: "opencsg://datasets/owner/repo/nested/train.json".to_string(),
+                content_length: 0,
+                is_dir: false,
+            }
+        );
+    }
+
+    /// Verifies file HEAD uses the resolve route and reports its length.
+    #[tokio::test]
+    async fn stats_file_with_head() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .and(header("authorization", "Bearer secret"))
+            .respond_with(ResponseTemplate::new(200).insert_header("content-length", "4096"))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let response = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://owner/repo/model.bin".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.content_length, Some(4096));
+    }
+
+    /// Verifies ranged content is streamed only from a valid 206 response.
+    #[tokio::test]
+    async fn gets_ranged_file() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .and(header("range", "bytes=10-29"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("content-range", "bytes 10-29/100")
+                    .set_body_string("partial content here"),
+            )
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let mut response = backend
+            .get(GetRequest {
+                task_id: "task".to_string(),
+                piece_id: "piece".to_string(),
+                url: "opencsg://owner/repo/model.bin".to_string(),
+                range: Some(Range {
+                    start: 10,
+                    length: 20,
+                }),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.text().await.unwrap(), "partial content here");
+    }
+
+    /// Verifies a successful full-body response cannot satisfy a Range request.
+    #[tokio::test]
+    async fn rejects_full_body_for_range_from_zero() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .and(header("range", "bytes=0-19"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("full body"))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let response = backend
+            .get(GetRequest {
+                task_id: "task".to_string(),
+                piece_id: "piece".to_string(),
+                url: "opencsg://owner/repo/model.bin".to_string(),
+                range: Some(Range {
+                    start: 0,
+                    length: 20,
+                }),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(!response.success);
+        assert_eq!(response.http_status_code, Some(reqwest::StatusCode::OK));
+    }
+
+    /// Verifies LFS redirects retain the Range request and stream the object response.
+    #[tokio::test]
+    async fn follows_lfs_redirect() {
+        let server = MockServer::start().await;
+        let object_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .and(header("range", "bytes=10-29"))
+            .respond_with(ResponseTemplate::new(302).insert_header(
+                "location",
+                format!("{}/objects/model.bin", object_server.uri()),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/objects/model.bin"))
+            .and(header("range", "bytes=10-29"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("content-range", "bytes 10-29/100")
+                    .set_body_string("redirected lfs data!"),
+            )
+            .mount(&object_server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let mut response = backend
+            .get(GetRequest {
+                task_id: "task".to_string(),
+                piece_id: "piece".to_string(),
+                url: "opencsg://owner/repo/model.bin".to_string(),
+                range: Some(Range {
+                    start: 10,
+                    length: 20,
+                }),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(options(&server)),
+            })
+            .await
+            .unwrap();
+
+        assert!(response.success);
+        assert_eq!(response.text().await.unwrap(), "redirected lfs data!");
+        let object_requests = object_server.received_requests().await.unwrap();
+        assert_eq!(object_requests.len(), 1);
+        assert!(object_requests[0].headers.get("authorization").is_none());
+    }
+
+    /// Verifies existence checks select HEAD for files and metadata GET for repositories.
+    #[tokio::test]
+    async fn checks_file_and_repository_existence() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/owner/repo/resolve/main/model.bin"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/models/owner/repo/revision/main"))
+            .and(query_param("blobs", "true"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        for (url, expected) in [
+            ("opencsg://owner/repo/model.bin", true),
+            ("opencsg://owner/repo", true),
+            ("opencsg://owner/repo/missing.bin", false),
+        ] {
+            let exists = backend
+                .exists(ExistsRequest {
+                    task_id: "task".to_string(),
+                    url: url.to_string(),
+                    http_header: None,
+                    timeout: Duration::from_secs(5),
+                    client_cert: None,
+                    object_storage: None,
+                    hdfs: None,
+                    hugging_face: None,
+                    model_scope: None,
+                    open_csg: Some(options(&server)),
+                })
+                .await
+                .unwrap();
+            assert_eq!(exists, expected);
+        }
+    }
+}

--- a/dragonfly-client-backend/src/opencsg.rs
+++ b/dragonfly-client-backend/src/opencsg.rs
@@ -453,31 +453,25 @@ impl Backend for OpenCsg {
                     &base_url,
                 )?;
 
-                let response = match self
+                let response = self
                     .client
                     .head(download_url.as_str())
                     .headers(request_header)
                     .timeout(request.timeout)
                     .send()
                     .await
-                {
-                    Ok(response) => response,
-                    Err(err) => {
+                    .map_err(|err| {
                         error!(
                             "stat request failed {} {}: {}",
                             request.task_id, download_url, err
                         );
 
-                        return Ok(StatResponse {
-                            success: false,
-                            content_length: None,
-                            http_header: None,
-                            http_status_code: None,
-                            entries: Vec::new(),
-                            error_message: Some(err.to_string()),
-                        });
-                    }
-                };
+                        Error::BackendError(Box::new(BackendError {
+                            message: err.to_string(),
+                            status_code: None,
+                            header: None,
+                        }))
+                    })?;
 
                 let response_status_code = response.status();
                 let response_header = response.headers().clone();
@@ -485,6 +479,19 @@ impl Backend for OpenCsg {
                     Some(content_length) => content_length.to_str()?.parse::<u64>().ok(),
                     None => response.content_length(),
                 };
+
+                if !response.status().is_success() {
+                    error!(
+                        "stat request failed {} {}: {}",
+                        request.task_id, download_url, response_status_code
+                    );
+
+                    return Err(Error::BackendError(Box::new(BackendError {
+                        message: response_status_code.to_string(),
+                        status_code: Some(response_status_code),
+                        header: Some(response_header),
+                    })));
+                }
 
                 debug!(
                     "stat response {} {}: {:?} {:?} {:?}",
@@ -1222,6 +1229,42 @@ mod tests {
 
         assert!(response.success);
         assert_eq!(response.content_length, Some(4096));
+    }
+
+    #[tokio::test]
+    async fn test_stat_file_with_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/monkey/Qwen/resolve/main/Qwen3.5-0.8B"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let backend = OpenCsg::new(Arc::new(Config::default())).unwrap();
+        let err = backend
+            .stat(StatRequest {
+                task_id: "task".to_string(),
+                url: "opencsg://monkey/Qwen/Qwen3.5-0.8B".to_string(),
+                http_header: None,
+                timeout: Duration::from_secs(5),
+                client_cert: None,
+                object_storage: None,
+                hdfs: None,
+                hugging_face: None,
+                model_scope: None,
+                open_csg: Some(OpenCsgOptions {
+                    revision: "main".to_string(),
+                    token: None,
+                    base_url: Some(server.uri()),
+                }),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BackendError(err) if err.status_code == Some(reqwest::StatusCode::NOT_FOUND)
+        ));
     }
 
     #[tokio::test]

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::digest;
-use dragonfly_api::common::v2::TaskType;
+use dragonfly_api::common::v2::{Download, TaskType};
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -72,6 +72,24 @@ pub enum PersistentCacheTaskIDParameter {
         tag: Option<String>,
         application: Option<String>,
     },
+}
+
+/// Returns the repository revision from the download options of the hub backends
+/// (Hugging Face, ModelScope or OpenCSG), used as the task id revision.
+pub fn repository_revision(download: &Download) -> Option<String> {
+    if let Some(hugging_face) = &download.hugging_face {
+        return Some(hugging_face.revision.clone());
+    }
+
+    if let Some(model_scope) = &download.model_scope {
+        return Some(model_scope.revision.clone());
+    }
+
+    if let Some(open_csg) = &download.open_csg {
+        return Some(open_csg.revision.clone());
+    }
+
+    None
 }
 
 /// Used to generate the id for the resources.
@@ -285,9 +303,42 @@ impl IDGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dragonfly_api::common::v2::{HuggingFace, ModelScope, OpenCsg};
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
+
+    #[test]
+    fn should_get_repository_revision() {
+        let download = Download {
+            hugging_face: Some(HuggingFace {
+                revision: "main".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(repository_revision(&download).as_deref(), Some("main"));
+
+        let download = Download {
+            model_scope: Some(ModelScope {
+                revision: "master".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(repository_revision(&download).as_deref(), Some("master"));
+
+        let download = Download {
+            open_csg: Some(OpenCsg {
+                revision: "main".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(repository_revision(&download).as_deref(), Some("main"));
+
+        assert!(repository_revision(&Download::default()).is_none());
+    }
 
     #[test]
     fn should_generate_host_id() {

--- a/dragonfly-client-util/src/types/redacted.rs
+++ b/dragonfly-client-util/src/types/redacted.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use dragonfly_api::common::v2::{Download, Hdfs, HuggingFace, ModelScope, ObjectStorage};
+use dragonfly_api::common::v2::{Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg};
 use dragonfly_api::dfdaemon::v2::DownloadPersistentTaskRequest;
 use http::header::{HOST, RANGE, USER_AGENT};
 use std::collections::HashMap;
@@ -46,6 +46,7 @@ const REDACTED: &str = "[REDACTED]";
 /// - `hdfs.delegation_token`
 /// - `hugging_face.token`
 /// - `model_scope.token`
+/// - `open_csg.token`
 ///
 /// Non-secret identifiers such as `object_storage.access_key_id` are left
 /// intact because an AKIA/ASIA-style ID on its own is not sufficient to
@@ -74,6 +75,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             remote_ip,
             hugging_face,
             model_scope,
+            open_csg,
             digest: _,
             r#type: _,
             priority: _,
@@ -112,6 +114,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             .field("hdfs", &scrubbed(hdfs, scrub_hdfs))
             .field("hugging_face", &scrubbed(hugging_face, scrub_hugging_face))
             .field("model_scope", &scrubbed(model_scope, scrub_model_scope))
+            .field("open_csg", &scrubbed(open_csg, scrub_open_csg))
             .finish_non_exhaustive()
     }
 }
@@ -258,6 +261,15 @@ fn scrub_model_scope(ms: &mut Option<ModelScope>) {
     }
 }
 
+/// Mutates the given `OpenCsg` by replacing any present token with [`REDACTED`].
+fn scrub_open_csg(csg: &mut Option<OpenCsg>) {
+    if let Some(csg) = csg.as_mut() {
+        if csg.token.is_some() {
+            csg.token = Some(REDACTED.to_string());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,6 +371,18 @@ mod tests {
         assert_eq!(ms.unwrap().token.as_deref(), Some(REDACTED));
     }
 
+    /// Verifies OpenCSG access tokens are replaced before logging.
+    #[test]
+    fn scrub_open_csg_redacts_token() {
+        let mut csg = Some(OpenCsg {
+            token: Some("csg_xxxxx".to_string()),
+            ..Default::default()
+        });
+
+        scrub_open_csg(&mut csg);
+        assert_eq!(csg.unwrap().token.as_deref(), Some(REDACTED));
+    }
+
     #[test]
     fn redacted_download_debug_does_not_leak_secrets() {
         let mut header = HashMap::new();
@@ -381,6 +405,10 @@ mod tests {
                 token: Some("MS_SECRET".to_string()),
                 ..Default::default()
             }),
+            open_csg: Some(OpenCsg {
+                token: Some("CSG_SECRET".to_string()),
+                ..Default::default()
+            }),
             request_header: header,
             ..Default::default()
         };
@@ -394,6 +422,7 @@ mod tests {
             "HDFS_SECRET",
             "HF_SECRET",
             "MS_SECRET",
+            "CSG_SECRET",
             "SECRET_BEARER",
         ] {
             assert!(!download.contains(secret),);

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -16,7 +16,9 @@
 
 use bytesize::ByteSize;
 use clap::Parser;
-use dragonfly_api::common::v2::{Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, TaskType};
+use dragonfly_api::common::v2::{
+    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, TaskType,
+};
 use dragonfly_api::dfdaemon::v2::{
     download_task_response, DownloadTaskRequest, ListTaskEntriesRequest,
 };
@@ -26,7 +28,7 @@ use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
 use dragonfly_client::terminal;
 use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_backend::{
-    hdfs, hugging_face, model_scope, object_storage, BackendFactory, DirEntry,
+    hdfs, hugging_face, model_scope, object_storage, opencsg, BackendFactory, DirEntry,
 };
 use dragonfly_client_config::VersionValueParser;
 use dragonfly_client_config::{self, dfdaemon, dfget};
@@ -110,6 +112,18 @@ Examples:
 
   # Download from ModelScope Hub with authentication token.
   $ dfget modelscope://<owner>/<repo>/<path> -O /tmp/model.safetensors --ms-token=<token>
+
+  # Download a single file from OpenCSG Hub.
+  $ dfget opencsg://<owner>/<repo>/<path> -O /tmp/model.safetensors
+
+  # Download an entire repository from OpenCSG Hub.
+  $ dfget opencsg://<owner>/<repo> -O /tmp/repo/ -r
+
+  # Download an OpenCSG repository at a specified revision.
+  $ dfget opencsg://<owner>/<repo> --csg-revision main -O /tmp/repo/ -r
+
+  # Download from OpenCSG Hub with authentication token.
+  $ dfget opencsg://<owner>/<repo>/<path> -O /tmp/model.safetensors --csg-token=<token>
 "#;
 
 #[derive(Debug, Parser, Clone)]
@@ -342,6 +356,28 @@ struct Args {
         help = "Specify the base URL of the ModelScope Hub endpoint (e.g., https://modelscope-mirror.example.com). If unspecified, it defaults to https://modelscope.cn"
     )]
     ms_base_url: Option<String>,
+
+    #[arg(
+        long = "csg-revision",
+        default_value = "main",
+        env = "DFGET_CSG_REVISION",
+        help = "Specify the revision version for OpenCSG Hub"
+    )]
+    csg_revision: String,
+
+    #[arg(
+        long = "csg-token",
+        env = "DFGET_CSG_TOKEN",
+        help = "Specify the authentication token for OpenCSG Hub"
+    )]
+    csg_token: Option<String>,
+
+    #[arg(
+        long = "csg-base-url",
+        env = "DFGET_CSG_BASE_URL",
+        help = "Specify the base URL of the OpenCSG Hub endpoint. If unspecified, it defaults to https://hub.opencsg.com/csg/"
+    )]
+    csg_base_url: Option<String>,
 
     #[arg(
         long,
@@ -623,6 +659,16 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
         None
     };
 
+    let open_csg = if url.scheme() == opencsg::SCHEME {
+        Some(OpenCsg {
+            revision: args.csg_revision.clone(),
+            token: args.csg_token.clone(),
+            base_url: args.csg_base_url.clone(),
+        })
+    } else {
+        None
+    };
+
     // Get all entries in the directory with include files filter.
     let entries: Vec<DirEntry> = get_all_entries(
         &args.url,
@@ -632,6 +678,7 @@ async fn download_dir(args: Args, download_client: DfdaemonDownloadClient) -> Re
         hdfs,
         hugging_face,
         model_scope,
+        open_csg,
         download_client.clone(),
     )
     .await?;
@@ -720,6 +767,7 @@ async fn get_all_entries(
     hdfs: Option<Hdfs>,
     hugging_face: Option<HuggingFace>,
     model_scope: Option<ModelScope>,
+    open_csg: Option<OpenCsg>,
     download_client: DfdaemonDownloadClient,
 ) -> Result<Vec<DirEntry>> {
     let urls: HashSet<Url> = match include_files {
@@ -772,6 +820,7 @@ async fn get_all_entries(
             hdfs.clone(),
             hugging_face.clone(),
             model_scope.clone(),
+            open_csg.clone(),
             download_client.clone(),
         )
         .await
@@ -870,6 +919,16 @@ async fn download(
         None
     };
 
+    let open_csg = if url.scheme() == opencsg::SCHEME {
+        Some(OpenCsg {
+            revision: args.csg_revision.clone(),
+            token: args.csg_token.clone(),
+            base_url: args.csg_base_url.clone(),
+        })
+    } else {
+        None
+    };
+
     // If the `filtered_query_params` is not provided, then use the default value.
     let filtered_query_params = args
         .filtered_query_params
@@ -914,6 +973,7 @@ async fn download(
                 hdfs,
                 hugging_face,
                 model_scope,
+                open_csg,
                 force_hard_link: args.force_hard_link,
                 content_for_calculating_task_id: args.content_for_calculating_task_id,
                 remote_ip: preferred_local_ip().map(|ip| ip.to_string()),
@@ -1121,6 +1181,7 @@ async fn download(
 /// various storage backends including object storage and HDFS by passing
 /// the appropriate credentials and configuration. The function converts
 /// the gRPC response into a local `DirEntry` format for further processing.
+#[allow(clippy::too_many_arguments)]
 async fn get_entries(
     url: &Url,
     header: Vec<String>,
@@ -1128,6 +1189,7 @@ async fn get_entries(
     hdfs: Option<Hdfs>,
     hugging_face: Option<HuggingFace>,
     model_scope: Option<ModelScope>,
+    open_csg: Option<OpenCsg>,
     download_client: DfdaemonDownloadClient,
 ) -> Result<Vec<DirEntry>> {
     info!("list task entries: {:?}", url);
@@ -1142,6 +1204,7 @@ async fn get_entries(
             hdfs,
             hugging_face,
             model_scope,
+            open_csg,
             remote_ip: preferred_local_ip().map(|ip| ip.to_string()),
         })
         .await
@@ -1220,6 +1283,25 @@ fn convert_args(mut args: Args) -> Args {
 /// The validation prevents common user errors and potential security issues before
 /// starting the download process.
 fn validate_args(args: &Args) -> Result<()> {
+    if args.url.scheme() == opencsg::SCHEME {
+        if args.csg_revision.trim().is_empty() {
+            return Err(Error::ValidationError(
+                "OpenCSG revision must not be empty".to_string(),
+            ));
+        }
+
+        if let Some(base_url) = args.csg_base_url.as_deref() {
+            let base_url = Url::parse(base_url).map_err(|err| {
+                Error::ValidationError(format!("invalid OpenCSG base URL: {err}"))
+            })?;
+            if !matches!(base_url.scheme(), "http" | "https") || base_url.cannot_be_a_base() {
+                return Err(Error::ValidationError(
+                    "OpenCSG base URL must be an HTTP or HTTPS base URL".to_string(),
+                ));
+            }
+        }
+    }
+
     // If the URL is a directory, the output path should be a directory.
     if args.url.path().ends_with('/') && !args.output.is_dir() {
         return Err(Error::ValidationError(format!(
@@ -1308,6 +1390,76 @@ mod tests {
     use mocktail::prelude::*;
     use std::collections::HashMap;
     use tempfile::tempdir;
+
+    /// Verifies explicit OpenCSG CLI options are parsed and accepted.
+    #[test]
+    fn should_parse_open_csg_options() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "opencsg://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+            "--csg-revision",
+            "release-v1",
+            "--csg-token",
+            "secret",
+            "--csg-base-url",
+            "https://mirror.example/private/csg/",
+        ]);
+
+        assert_eq!(args.csg_revision, "release-v1");
+        assert_eq!(args.csg_token.as_deref(), Some("secret"));
+        assert_eq!(
+            args.csg_base_url.as_deref(),
+            Some("https://mirror.example/private/csg/")
+        );
+        assert!(validate_args(&args).is_ok());
+    }
+
+    /// Verifies OpenCSG downloads default to the main revision without credentials.
+    #[test]
+    fn should_use_default_open_csg_revision() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "opencsg://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+        ]);
+
+        assert_eq!(args.csg_revision, "main");
+        assert!(args.csg_token.is_none());
+        assert!(args.csg_base_url.is_none());
+    }
+
+    /// Verifies invalid OpenCSG revisions and endpoint schemes are rejected.
+    #[test]
+    fn should_reject_invalid_open_csg_options() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let empty_revision = Args::parse_from([
+            "dfget",
+            "opencsg://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+            "--csg-revision",
+            " ",
+        ]);
+        assert!(validate_args(&empty_revision).is_err());
+
+        let invalid_endpoint = Args::parse_from([
+            "dfget",
+            "opencsg://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+            "--csg-base-url",
+            "ftp://mirror.example/csg/",
+        ]);
+        assert!(validate_args(&invalid_endpoint).is_err());
+    }
 
     #[test]
     fn should_convert_args() {
@@ -1481,6 +1633,21 @@ mod tests {
         assert_eq!(result.unwrap(), output_path.join("dir/file.txt"));
     }
 
+    /// Verifies recursive OpenCSG entries retain their repository-relative output path.
+    #[test]
+    fn should_make_output_by_open_csg_entry() {
+        let url = Url::parse("opencsg://datasets/owner/repo/").unwrap();
+        let temp_dir = tempdir().unwrap();
+        let entry = DirEntry {
+            url: "opencsg://datasets/owner/repo/nested/train.json".to_string(),
+            content_length: 0,
+            is_dir: false,
+        };
+
+        let output = make_output_by_entry(url, temp_dir.path(), entry).unwrap();
+        assert_eq!(output, temp_dir.path().join("nested/train.json"));
+    }
+
     #[test]
     fn should_make_output_by_entry_no_trailing_slash_in_output() {
         let url = Url::parse("http://example.com/root/").unwrap();
@@ -1555,6 +1722,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             dfdaemon_download_client,
         )
         .await
@@ -1610,6 +1778,7 @@ mod tests {
         let entries = get_all_entries(
             &Url::parse("http://example.com/root/").unwrap(),
             Vec::new(),
+            None,
             None,
             None,
             None,
@@ -1701,6 +1870,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             dfdaemon_download_client,
         )
         .await
@@ -1782,6 +1952,7 @@ mod tests {
         let entries = get_all_entries(
             &Url::parse("http://example.com/root/").unwrap(),
             Vec::new(),
+            None,
             None,
             None,
             None,

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -358,7 +358,7 @@ struct Args {
     ms_base_url: Option<String>,
 
     #[arg(
-        long = "csg-revision",
+        long,
         default_value = "main",
         env = "DFGET_CSG_REVISION",
         help = "Specify the revision version for OpenCSG Hub"
@@ -366,16 +366,16 @@ struct Args {
     csg_revision: String,
 
     #[arg(
-        long = "csg-token",
+        long,
         env = "DFGET_CSG_TOKEN",
         help = "Specify the authentication token for OpenCSG Hub"
     )]
     csg_token: Option<String>,
 
     #[arg(
-        long = "csg-base-url",
+        long,
         env = "DFGET_CSG_BASE_URL",
-        help = "Specify the base URL of the OpenCSG Hub endpoint. If unspecified, it defaults to https://hub.opencsg.com/csg/"
+        help = "Specify the base URL of the OpenCSG Hub endpoint (e.g., https://hub-mirror.example.com/csg). If unspecified, it defaults to https://hub.opencsg.com/csg/"
     )]
     csg_base_url: Option<String>,
 
@@ -1283,25 +1283,6 @@ fn convert_args(mut args: Args) -> Args {
 /// The validation prevents common user errors and potential security issues before
 /// starting the download process.
 fn validate_args(args: &Args) -> Result<()> {
-    if args.url.scheme() == opencsg::SCHEME {
-        if args.csg_revision.trim().is_empty() {
-            return Err(Error::ValidationError(
-                "OpenCSG revision must not be empty".to_string(),
-            ));
-        }
-
-        if let Some(base_url) = args.csg_base_url.as_deref() {
-            let base_url = Url::parse(base_url).map_err(|err| {
-                Error::ValidationError(format!("invalid OpenCSG base URL: {err}"))
-            })?;
-            if !matches!(base_url.scheme(), "http" | "https") || base_url.cannot_be_a_base() {
-                return Err(Error::ValidationError(
-                    "OpenCSG base URL must be an HTTP or HTTPS base URL".to_string(),
-                ));
-            }
-        }
-    }
-
     // If the URL is a directory, the output path should be a directory.
     if args.url.path().ends_with('/') && !args.output.is_dir() {
         return Err(Error::ValidationError(format!(
@@ -1415,7 +1396,6 @@ mod tests {
             args.csg_base_url.as_deref(),
             Some("https://mirror.example/private/csg/")
         );
-        assert!(validate_args(&args).is_ok());
     }
 
     /// Verifies OpenCSG downloads default to the main revision without credentials.
@@ -1433,32 +1413,6 @@ mod tests {
         assert_eq!(args.csg_revision, "main");
         assert!(args.csg_token.is_none());
         assert!(args.csg_base_url.is_none());
-    }
-
-    /// Verifies invalid OpenCSG revisions and endpoint schemes are rejected.
-    #[test]
-    fn should_reject_invalid_open_csg_options() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let output = tempdir.path().join("model.bin");
-        let empty_revision = Args::parse_from([
-            "dfget",
-            "opencsg://owner/repo/model.bin",
-            "--output",
-            output.to_str().unwrap(),
-            "--csg-revision",
-            " ",
-        ]);
-        assert!(validate_args(&empty_revision).is_err());
-
-        let invalid_endpoint = Args::parse_from([
-            "dfget",
-            "opencsg://owner/repo/model.bin",
-            "--output",
-            output.to_str().unwrap(),
-            "--csg-base-url",
-            "ftp://mirror.example/csg/",
-        ]);
-        assert!(validate_args(&invalid_endpoint).is_err());
     }
 
     #[test]

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -1372,7 +1372,6 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::tempdir;
 
-    /// Verifies explicit OpenCSG CLI options are parsed and accepted.
     #[test]
     fn should_parse_open_csg_options() {
         let tempdir = tempfile::tempdir().unwrap();
@@ -1398,7 +1397,6 @@ mod tests {
         );
     }
 
-    /// Verifies OpenCSG downloads default to the main revision without credentials.
     #[test]
     fn should_use_default_open_csg_revision() {
         let tempdir = tempfile::tempdir().unwrap();
@@ -1413,6 +1411,85 @@ mod tests {
         assert_eq!(args.csg_revision, "main");
         assert!(args.csg_token.is_none());
         assert!(args.csg_base_url.is_none());
+    }
+
+    #[test]
+    fn should_parse_hugging_face_options() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "hf://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+            "--hf-revision",
+            "release-v1",
+            "--hf-token",
+            "secret",
+            "--hf-base-url",
+            "https://hf-mirror.com/",
+        ]);
+
+        assert_eq!(args.hf_revision, "release-v1");
+        assert_eq!(args.hf_token.as_deref(), Some("secret"));
+        assert_eq!(args.hf_base_url.as_deref(), Some("https://hf-mirror.com/"));
+    }
+
+    #[test]
+    fn should_use_default_hugging_face_revision() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "hf://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+        ]);
+
+        assert_eq!(args.hf_revision, "main");
+        assert!(args.hf_token.is_none());
+        assert!(args.hf_base_url.is_none());
+    }
+
+    #[test]
+    fn should_parse_model_scope_options() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "modelscope://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+            "--ms-revision",
+            "release-v1",
+            "--ms-token",
+            "secret",
+            "--ms-base-url",
+            "https://modelscope-mirror.example.com/",
+        ]);
+
+        assert_eq!(args.ms_revision, "release-v1");
+        assert_eq!(args.ms_token.as_deref(), Some("secret"));
+        assert_eq!(
+            args.ms_base_url.as_deref(),
+            Some("https://modelscope-mirror.example.com/")
+        );
+    }
+
+    #[test]
+    fn should_use_default_model_scope_revision() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let output = tempdir.path().join("model.bin");
+        let args = Args::parse_from([
+            "dfget",
+            "modelscope://owner/repo/model.bin",
+            "--output",
+            output.to_str().unwrap(),
+        ]);
+
+        assert_eq!(args.ms_revision, "master");
+        assert!(args.ms_token.is_none());
+        assert!(args.ms_base_url.is_none());
     }
 
     #[test]
@@ -1587,13 +1664,40 @@ mod tests {
         assert_eq!(result.unwrap(), output_path.join("dir/file.txt"));
     }
 
-    /// Verifies recursive OpenCSG entries retain their repository-relative output path.
     #[test]
     fn should_make_output_by_open_csg_entry() {
         let url = Url::parse("opencsg://datasets/owner/repo/").unwrap();
         let temp_dir = tempdir().unwrap();
         let entry = DirEntry {
             url: "opencsg://datasets/owner/repo/nested/train.json".to_string(),
+            content_length: 0,
+            is_dir: false,
+        };
+
+        let output = make_output_by_entry(url, temp_dir.path(), entry).unwrap();
+        assert_eq!(output, temp_dir.path().join("nested/train.json"));
+    }
+
+    #[test]
+    fn should_make_output_by_hugging_face_entry() {
+        let url = Url::parse("hf://datasets/owner/repo/").unwrap();
+        let temp_dir = tempdir().unwrap();
+        let entry = DirEntry {
+            url: "hf://datasets/owner/repo/nested/train.json".to_string(),
+            content_length: 0,
+            is_dir: false,
+        };
+
+        let output = make_output_by_entry(url, temp_dir.path(), entry).unwrap();
+        assert_eq!(output, temp_dir.path().join("nested/train.json"));
+    }
+
+    #[test]
+    fn should_make_output_by_model_scope_entry() {
+        let url = Url::parse("modelscope://datasets/owner/repo/").unwrap();
+        let temp_dir = tempdir().unwrap();
+        let entry = DirEntry {
+            url: "modelscope://datasets/owner/repo/nested/train.json".to_string(),
             content_length: 0,
             is_dir: false,
         };

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -41,7 +41,7 @@ use dragonfly_api::dfdaemon::v2::{
 };
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_api::scheduler::v2::DeleteHostRequest as SchedulerDeleteHostRequest;
-use dragonfly_client_backend::{StatRequest, StatResponse};
+use dragonfly_client_backend::StatRequest;
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -98,53 +98,6 @@ use url::Url;
 
 use super::interceptor::{ExtractTracingInterceptor, InjectTracingInterceptor};
 use super::middleware::BBRLayer;
-
-/// Converts a backend stat response into a list task entries response.
-fn convert_list_task_entries_response(
-    response: StatResponse,
-) -> Result<ListTaskEntriesResponse, Status> {
-    let StatResponse {
-        success,
-        content_length,
-        http_header,
-        http_status_code,
-        entries,
-        error_message,
-    } = response;
-
-    if !success {
-        let message = error_message.unwrap_or_else(|| "list task entries failed".to_string());
-        let backend = Backend {
-            message: message.clone(),
-            header: headermap_to_hashmap(&http_header.unwrap_or_default()),
-            status_code: http_status_code.map(|code| code.as_u16() as i32),
-        };
-        let details = serde_json::to_vec(&backend).map_err(|err| {
-            error!("serialize backend error: {}", err);
-            Status::internal(err.to_string())
-        })?;
-
-        return Err(Status::with_details(
-            Code::Internal,
-            message,
-            details.into(),
-        ));
-    }
-
-    Ok(ListTaskEntriesResponse {
-        content_length: content_length.unwrap_or_default(),
-        response_header: headermap_to_hashmap(&http_header.unwrap_or_default()),
-        status_code: http_status_code.map(|code| code.as_u16().into()),
-        entries: entries
-            .into_iter()
-            .map(|dir_entry| Entry {
-                url: dir_entry.url,
-                content_length: dir_entry.content_length as u64,
-                is_dir: dir_entry.is_dir,
-            })
-            .collect(),
-    })
-}
 
 /// gRPC Unix server for download operations.
 pub struct DfdaemonDownloadServer {
@@ -1017,13 +970,20 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 Status::internal(err.to_string())
             })?;
 
-        let response = convert_list_task_entries_response(response).inspect_err(|err| {
-            // Collect the list tasks failure metrics.
-            collect_list_task_entries_failure_metrics(TaskType::Standard as i32);
-            error!("convert list task entries response: {}", err);
-        })?;
-
-        Ok(Response::new(response))
+        Ok(Response::new(ListTaskEntriesResponse {
+            content_length: response.content_length.unwrap_or_default(),
+            response_header: headermap_to_hashmap(&response.http_header.unwrap_or_default()),
+            status_code: response.http_status_code.map(|code| code.as_u16().into()),
+            entries: response
+                .entries
+                .into_iter()
+                .map(|dir_entry| Entry {
+                    url: dir_entry.url,
+                    content_length: dir_entry.content_length as u64,
+                    is_dir: dir_entry.is_dir,
+                })
+                .collect(),
+        }))
     }
 
     /// Deletes the task's content and metadata from local storage, and removes
@@ -2714,53 +2674,5 @@ impl DfdaemonDownloadClient {
         let mut request = tonic::Request::new(request);
         request.set_timeout(super::REQUEST_TIMEOUT);
         request
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use reqwest::StatusCode;
-
-    /// Verifies that a failed backend stat response becomes a typed gRPC error.
-    #[test]
-    fn converts_failed_stat_response_to_grpc_status() {
-        let status = convert_list_task_entries_response(StatResponse {
-            success: false,
-            content_length: None,
-            http_header: None,
-            http_status_code: Some(StatusCode::UNAUTHORIZED),
-            entries: vec![],
-            error_message: Some("401 Unauthorized".to_string()),
-        })
-        .expect_err("failed stat response should return an error");
-
-        assert_eq!(status.code(), Code::Internal);
-        assert_eq!(status.message(), "401 Unauthorized");
-
-        let backend: Backend =
-            serde_json::from_slice(status.details()).expect("backend details should be valid JSON");
-        assert_eq!(backend.message, "401 Unauthorized");
-        assert_eq!(backend.status_code, Some(401));
-        assert!(backend.header.is_empty());
-    }
-
-    /// Verifies that a successful empty directory remains a successful response.
-    #[test]
-    fn converts_successful_empty_stat_response() {
-        let response = convert_list_task_entries_response(StatResponse {
-            success: true,
-            content_length: None,
-            http_header: None,
-            http_status_code: Some(StatusCode::OK),
-            entries: vec![],
-            error_message: None,
-        })
-        .expect("successful stat response should remain successful");
-
-        assert_eq!(response.content_length, 0);
-        assert_eq!(response.status_code, Some(200));
-        assert!(response.response_header.is_empty());
-        assert!(response.entries.is_empty());
     }
 }

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -63,7 +63,10 @@ use dragonfly_client_metric::{
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
     http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
-    id_generator::{PersistentCacheTaskIDParameter, PersistentTaskIDParameter, TaskIDParameter},
+    id_generator::{
+        repository_revision, PersistentCacheTaskIDParameter, PersistentTaskIDParameter,
+        TaskIDParameter,
+    },
     ratelimiter::bbr::BBR,
     shutdown,
     types::redacted::{RedactedDownload, RedactedDownloadPersistentTaskRequest},
@@ -352,20 +355,13 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                     TaskIDParameter::BlobDigestBased(download.url.clone())
                 } else {
-                    let revision = download
-                        .hugging_face
-                        .as_ref()
-                        .map(|hf| hf.revision.clone())
-                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
-                        .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
-
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),
                         piece_length: download.piece_length,
                         tag: download.tag.clone(),
                         application: download.application.clone(),
                         filtered_query_params: download.filtered_query_params.clone(),
-                        revision,
+                        revision: repository_revision(&download),
                     }
                 },
             )

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -41,7 +41,7 @@ use dragonfly_api::dfdaemon::v2::{
 };
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_api::scheduler::v2::DeleteHostRequest as SchedulerDeleteHostRequest;
-use dragonfly_client_backend::StatRequest;
+use dragonfly_client_backend::{StatRequest, StatResponse};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -98,6 +98,53 @@ use url::Url;
 
 use super::interceptor::{ExtractTracingInterceptor, InjectTracingInterceptor};
 use super::middleware::BBRLayer;
+
+/// Converts a backend stat response into a list task entries response.
+fn convert_list_task_entries_response(
+    response: StatResponse,
+) -> Result<ListTaskEntriesResponse, Status> {
+    let StatResponse {
+        success,
+        content_length,
+        http_header,
+        http_status_code,
+        entries,
+        error_message,
+    } = response;
+
+    if !success {
+        let message = error_message.unwrap_or_else(|| "list task entries failed".to_string());
+        let backend = Backend {
+            message: message.clone(),
+            header: headermap_to_hashmap(&http_header.unwrap_or_default()),
+            status_code: http_status_code.map(|code| code.as_u16() as i32),
+        };
+        let details = serde_json::to_vec(&backend).map_err(|err| {
+            error!("serialize backend error: {}", err);
+            Status::internal(err.to_string())
+        })?;
+
+        return Err(Status::with_details(
+            Code::Internal,
+            message,
+            details.into(),
+        ));
+    }
+
+    Ok(ListTaskEntriesResponse {
+        content_length: content_length.unwrap_or_default(),
+        response_header: headermap_to_hashmap(&http_header.unwrap_or_default()),
+        status_code: http_status_code.map(|code| code.as_u16().into()),
+        entries: entries
+            .into_iter()
+            .map(|dir_entry| Entry {
+                url: dir_entry.url,
+                content_length: dir_entry.content_length as u64,
+                is_dir: dir_entry.is_dir,
+            })
+            .collect(),
+    })
+}
 
 /// gRPC Unix server for download operations.
 pub struct DfdaemonDownloadServer {
@@ -356,7 +403,8 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                         .hugging_face
                         .as_ref()
                         .map(|hf| hf.revision.clone())
-                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()));
+                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
+                        .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
 
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),
@@ -958,6 +1006,7 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 hdfs: request.hdfs.clone(),
                 hugging_face: request.hugging_face.clone(),
                 model_scope: request.model_scope.clone(),
+                open_csg: request.open_csg.clone(),
             })
             .await
             .map_err(|err| {
@@ -968,20 +1017,13 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                 Status::internal(err.to_string())
             })?;
 
-        Ok(Response::new(ListTaskEntriesResponse {
-            content_length: response.content_length.unwrap_or_default(),
-            response_header: headermap_to_hashmap(&response.http_header.unwrap_or_default()),
-            status_code: response.http_status_code.map(|code| code.as_u16().into()),
-            entries: response
-                .entries
-                .into_iter()
-                .map(|dir_entry| Entry {
-                    url: dir_entry.url,
-                    content_length: dir_entry.content_length as u64,
-                    is_dir: dir_entry.is_dir,
-                })
-                .collect(),
-        }))
+        let response = convert_list_task_entries_response(response).inspect_err(|err| {
+            // Collect the list tasks failure metrics.
+            collect_list_task_entries_failure_metrics(TaskType::Standard as i32);
+            error!("convert list task entries response: {}", err);
+        })?;
+
+        Ok(Response::new(response))
     }
 
     /// Deletes the task's content and metadata from local storage, and removes
@@ -2672,5 +2714,53 @@ impl DfdaemonDownloadClient {
         let mut request = tonic::Request::new(request);
         request.set_timeout(super::REQUEST_TIMEOUT);
         request
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    /// Verifies that a failed backend stat response becomes a typed gRPC error.
+    #[test]
+    fn converts_failed_stat_response_to_grpc_status() {
+        let status = convert_list_task_entries_response(StatResponse {
+            success: false,
+            content_length: None,
+            http_header: None,
+            http_status_code: Some(StatusCode::UNAUTHORIZED),
+            entries: vec![],
+            error_message: Some("401 Unauthorized".to_string()),
+        })
+        .expect_err("failed stat response should return an error");
+
+        assert_eq!(status.code(), Code::Internal);
+        assert_eq!(status.message(), "401 Unauthorized");
+
+        let backend: Backend =
+            serde_json::from_slice(status.details()).expect("backend details should be valid JSON");
+        assert_eq!(backend.message, "401 Unauthorized");
+        assert_eq!(backend.status_code, Some(401));
+        assert!(backend.header.is_empty());
+    }
+
+    /// Verifies that a successful empty directory remains a successful response.
+    #[test]
+    fn converts_successful_empty_stat_response() {
+        let response = convert_list_task_entries_response(StatResponse {
+            success: true,
+            content_length: None,
+            http_header: None,
+            http_status_code: Some(StatusCode::OK),
+            entries: vec![],
+            error_message: None,
+        })
+        .expect("successful stat response should remain successful");
+
+        assert_eq!(response.content_length, 0);
+        assert_eq!(response.status_code, Some(200));
+        assert!(response.response_header.is_empty());
+        assert!(response.entries.is_empty());
     }
 }

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -54,7 +54,7 @@ use dragonfly_client_metric::{
 use dragonfly_client_util::{
     digest::{is_blob_url, verify_file_digest, Digest},
     http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
-    id_generator::{PersistentTaskIDParameter, TaskIDParameter},
+    id_generator::{repository_revision, PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
     shutdown,
     sysinfo::SystemMonitor,
@@ -314,20 +314,13 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                 } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                     TaskIDParameter::BlobDigestBased(download.url.clone())
                 } else {
-                    let revision = download
-                        .hugging_face
-                        .as_ref()
-                        .map(|hf| hf.revision.clone())
-                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
-                        .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
-
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),
                         piece_length: download.piece_length,
                         tag: download.tag.clone(),
                         application: download.application.clone(),
                         filtered_query_params: download.filtered_query_params.clone(),
-                        revision,
+                        revision: repository_revision(&download),
                     }
                 },
             )

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -318,7 +318,8 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                         .hugging_face
                         .as_ref()
                         .map(|hf| hf.revision.clone())
-                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()));
+                        .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
+                        .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
 
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),
@@ -846,6 +847,7 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                 hdfs: request.hdfs.clone(),
                 hugging_face: request.hugging_face.clone(),
                 model_scope: request.model_scope.clone(),
+                open_csg: request.open_csg.clone(),
             })
             .await
             .map_err(|err| {

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1311,6 +1311,7 @@ fn make_download_task_request(
             hdfs: None,
             hugging_face: None,
             model_scope: None,
+            open_csg: None,
             is_prefetch: false,
             need_piece_content: false,
             force_hard_link: header::get_force_hard_link(header),

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -96,7 +96,8 @@ pub async fn download(
                     .hugging_face
                     .as_ref()
                     .map(|hf| hf.revision.clone())
-                    .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()));
+                    .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
+                    .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
 
                 TaskIDParameter::URLBased {
                     url: download.url.clone(),

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -31,7 +31,7 @@ use dragonfly_client_metric::{
 use dragonfly_client_util::{
     digest::is_blob_url,
     http::{headermap_to_hashmap, parse_range_header},
-    id_generator::TaskIDParameter,
+    id_generator::{repository_revision, TaskIDParameter},
     types::redacted::RedactedDownload,
 };
 use std::sync::Arc;
@@ -92,20 +92,13 @@ pub async fn download(
             } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                 TaskIDParameter::BlobDigestBased(download.url.clone())
             } else {
-                let revision = download
-                    .hugging_face
-                    .as_ref()
-                    .map(|hf| hf.revision.clone())
-                    .or_else(|| download.model_scope.as_ref().map(|ms| ms.revision.clone()))
-                    .or_else(|| download.open_csg.as_ref().map(|csg| csg.revision.clone()));
-
                 TaskIDParameter::URLBased {
                     url: download.url.clone(),
                     piece_length: download.piece_length,
                     tag: download.tag.clone(),
                     application: download.application.clone(),
                     filtered_query_params: download.filtered_query_params.clone(),
-                    revision,
+                    revision: repository_revision(&download),
                 }
             },
         )

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -18,7 +18,7 @@ use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
 use crate::resource::parent_selector::PersistentParentSelector;
 use chrono::DateTime;
 use dragonfly_api::common::v2::{
-    Hdfs, HuggingFace, ModelScope, ObjectStorage, PersistentPeer,
+    Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, PersistentPeer,
     PersistentTask as CommonPersistentTask, Piece, TrafficType,
 };
 use dragonfly_api::dfdaemon::{
@@ -586,6 +586,7 @@ impl PersistentTask {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .inspect_err(|err| {
@@ -2362,6 +2363,7 @@ impl PersistentTask {
                 hdfs: Option<Hdfs>,
                 hugging_face: Option<HuggingFace>,
                 model_scope: Option<ModelScope>,
+                open_csg: Option<OpenCsg>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 debug!("start to download piece {} from source", piece_id);
@@ -2379,6 +2381,7 @@ impl PersistentTask {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await?;
 
@@ -2522,6 +2525,7 @@ impl PersistentTask {
                         download_progress_tx,
                         in_stream_tx,
                         object_storage,
+                        None,
                         None,
                         None,
                         None,
@@ -2806,6 +2810,7 @@ impl PersistentTask {
                 hdfs: Option<Hdfs>,
                 hugging_face: Option<HuggingFace>,
                 model_scope: Option<ModelScope>,
+                open_csg: Option<OpenCsg>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 debug!("start to download piece {} from source", piece_id);
@@ -2823,6 +2828,7 @@ impl PersistentTask {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await?;
 
@@ -2946,6 +2952,7 @@ impl PersistentTask {
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await
                 }
@@ -3011,6 +3018,7 @@ impl PersistentTask {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .inspect_err(|err| {
@@ -3038,6 +3046,7 @@ impl PersistentTask {
                 hdfs: None,
                 hugging_face: None,
                 model_scope: None,
+                open_csg: None,
             })
             .await
             .inspect_err(|err| {

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -16,7 +16,9 @@
 
 use super::*;
 use chrono::Utc;
-use dragonfly_api::common::v2::{Hdfs, HuggingFace, ModelScope, ObjectStorage, Range, TrafficType};
+use dragonfly_api::common::v2::{
+    Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, Range, TrafficType,
+};
 use dragonfly_client_backend::{BackendFactory, GetRequest};
 use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{error::BackendError, Error, Result};
@@ -486,6 +488,7 @@ impl Piece {
         hdfs: Option<Hdfs>,
         hugging_face: Option<HuggingFace>,
         model_scope: Option<ModelScope>,
+        open_csg: Option<OpenCsg>,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
@@ -557,6 +560,7 @@ impl Piece {
                 hdfs,
                 hugging_face,
                 model_scope,
+                open_csg,
             })
             .await
             .inspect_err(|err| {
@@ -832,6 +836,7 @@ impl Piece {
         hdfs: Option<Hdfs>,
         hugging_face: Option<HuggingFace>,
         model_scope: Option<ModelScope>,
+        open_csg: Option<OpenCsg>,
     ) -> Result<metadata::Piece> {
         // Span record the piece_id.
         Span::current().record("piece_id", piece_id);
@@ -899,6 +904,7 @@ impl Piece {
                 hdfs,
                 hugging_face,
                 model_scope,
+                open_csg,
             })
             .await
             .inspect_err(|err| {

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -17,8 +17,8 @@
 use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
 use crate::resource::parent_selector::ParentSelector;
 use dragonfly_api::common::v2::{
-    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, Peer, Piece, Task as CommonTask,
-    TrafficType,
+    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, Peer, Piece,
+    Task as CommonTask, TrafficType,
 };
 use dragonfly_api::dfdaemon::{
     self,
@@ -214,6 +214,7 @@ impl Task {
                 hdfs: request.hdfs,
                 hugging_face: request.hugging_face,
                 model_scope: request.model_scope,
+                open_csg: request.open_csg,
             })
             .await
             .inspect_err(|_err| {
@@ -1635,6 +1636,7 @@ impl Task {
                 hdfs: Option<Hdfs>,
                 hugging_face: Option<HuggingFace>,
                 model_scope: Option<ModelScope>,
+                open_csg: Option<OpenCsg>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 debug!("start to download piece {} from source", piece_id);
@@ -1653,6 +1655,7 @@ impl Task {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await?;
 
@@ -1778,6 +1781,7 @@ impl Task {
             let hdfs = request.hdfs.clone();
             let hugging_face = request.hugging_face.clone();
             let model_scope = request.model_scope.clone();
+            let open_csg = request.open_csg.clone();
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             join_set.spawn(
                 async move {
@@ -1800,6 +1804,7 @@ impl Task {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await
                 }
@@ -2203,6 +2208,7 @@ impl Task {
                 hdfs: Option<Hdfs>,
                 hugging_face: Option<HuggingFace>,
                 model_scope: Option<ModelScope>,
+                open_csg: Option<OpenCsg>,
             ) -> ClientResult<metadata::Piece> {
                 let piece_id = piece_manager.id(task_id.as_str(), number);
                 debug!("start to download piece {} from source", piece_id);
@@ -2221,6 +2227,7 @@ impl Task {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await?;
 
@@ -2324,6 +2331,7 @@ impl Task {
             let hdfs = request.hdfs.clone();
             let hugging_face = request.hugging_face.clone();
             let model_scope = request.model_scope.clone();
+            let open_csg = request.open_csg.clone();
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             join_set.spawn(
                 async move {
@@ -2345,6 +2353,7 @@ impl Task {
                         hdfs,
                         hugging_face,
                         model_scope,
+                        open_csg,
                     )
                     .await
                 }


### PR DESCRIPTION
## Description

Add support for downloading models from OpenCSG repository.
It follows the same design pattern as existing HuggingFace and ModelScope repository implementations.

## Related Issue

No

## Motivation and Context

OpenCSG is a popular domestic AI model hub.
This change enables dragonfly to accelerate model artifacts downloading from OpenCSG, consistent with HuggingFace / ModelScope workflow.

## Screenshots (if appropriate)

<img width="2138" height="198" alt="image" src="https://github.com/user-attachments/assets/a4c91874-9ac7-4689-941c-81f84320b6a2" />

<img width="1924" height="1448" alt="image" src="https://github.com/user-attachments/assets/1000b967-980d-40ed-bec8-5a47b07ea180" />

<img width="2276" height="618" alt="image" src="https://github.com/user-attachments/assets/f4329c30-d542-4bb4-887a-4525ce4b72d4" />
