### PR TITLE
refactor(client): replace inline termion formatting with terminal helper functions

### DIFF
--- a/dragonfly-client/src/bin/dfcache/export.rs
+++ b/dragonfly-client/src/bin/dfcache/export.rs
@@ -19,6 +19,7 @@ use dragonfly_api::dfdaemon::v2::{
     download_persistent_cache_task_response, DownloadPersistentCacheTaskRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
+use dragonfly_client::terminal;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -29,7 +30,6 @@ use path_absolutize::*;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{cmp::min, fmt::Write};
-use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tracing::{debug, error, info};
@@ -162,38 +162,10 @@ impl ExportCommand {
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {
-            println!(
-                "{}{}{}Validating Failed!{}",
-                color::Fg(color::Red),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}Message:{} {}",
-                color::Fg(color::Cyan),
-                style::Italic,
-                style::Bold,
-                style::Reset,
-                err,
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
+            terminal::error("Validating Failed!");
+            terminal::separator();
+            terminal::field("Message:", err);
+            terminal::separator();
 
             std::process::exit(1);
         }
@@ -203,39 +175,17 @@ impl ExportCommand {
             match get_dfdaemon_download_client(self.endpoint.to_path_buf()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -247,197 +197,62 @@ impl ExportCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Exporting Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Exporting Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Exporting Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Exporting Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Exporting Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Exporting Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Exporting Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Exporting Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfcache/import.rs
+++ b/dragonfly-client/src/bin/dfcache/import.rs
@@ -18,6 +18,7 @@ use bytesize::ByteSize;
 use clap::Parser;
 use dragonfly_api::dfdaemon::v2::UploadPersistentCacheTaskRequest;
 use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
+use dragonfly_client::terminal;
 use dragonfly_client_config::dfcache::default_dfcache_persistent_replica_count;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -28,7 +29,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use path_absolutize::*;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use termion::{color, style};
 use tracing::info;
 
 use super::*;
@@ -152,38 +152,10 @@ impl ImportCommand {
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {
-            println!(
-                "{}{}{}Validating Failed!{}",
-                color::Fg(color::Red),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}Message:{} {}",
-                color::Fg(color::Cyan),
-                style::Italic,
-                style::Bold,
-                style::Reset,
-                err,
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
+            terminal::error("Validating Failed!");
+            terminal::separator();
+            terminal::field("Message:", err);
+            terminal::separator();
 
             std::process::exit(1);
         }
@@ -193,39 +165,17 @@ impl ImportCommand {
             match get_dfdaemon_download_client(self.endpoint.to_path_buf()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -234,106 +184,25 @@ impl ImportCommand {
         // Warn user if content_for_calculating_task_id is not set, which may lead to slow SHA256
         // computation.
         if self.content_for_calculating_task_id.is_none() {
-            println!(
-                "{}{}Warning: SHA256 hash computation from file content is slow for large files. Use {}--content-for-calculating-task-id{}{}{} to improve performance.{}",
-                color::Fg(color::Yellow),
-                style::Bold,
-                style::Italic,
-                style::Reset,
-                color::Fg(color::Yellow),
-                style::Bold,
-                style::Reset,
-            );
+            terminal::warn("Warning: SHA256 hash computation from file content is slow for large files. Use --content-for-calculating-task-id to improve performance.");
         }
 
         // Run import sub command.
         if let Err(err) = self.run(dfdaemon_download_client).await {
             match err {
                 Error::TonicStatus(status) => {
-                    println!(
-                        "{}{}{}Importing Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Bad Code:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.code()
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.message()
-                    );
-
-                    println!(
-                        "{}{}{}Details:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        std::str::from_utf8(status.details()).unwrap()
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Importing Failed!");
+                    terminal::separator();
+                    terminal::error_field("Bad Code:", status.code());
+                    terminal::field("Message:", status.message());
+                    terminal::field("Details:", std::str::from_utf8(status.details()).unwrap());
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Importing Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Importing Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfcache/stat.rs
+++ b/dragonfly-client/src/bin/dfcache/stat.rs
@@ -17,6 +17,7 @@
 use chrono::{DateTime, Local};
 use clap::Parser;
 use dragonfly_api::dfdaemon::v2::StatPersistentCacheTaskRequest;
+use dragonfly_client::terminal;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -28,7 +29,6 @@ use tabled::{
     settings::{object::Rows, Alignment, Modify, Style},
     Table, Tabled,
 };
-use termion::{color, style};
 use tracing::error;
 
 use super::*;
@@ -87,39 +87,17 @@ impl StatCommand {
             match get_dfdaemon_download_client(self.endpoint.to_path_buf()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -129,90 +107,18 @@ impl StatCommand {
         if let Err(err) = self.run(dfdaemon_download_client).await {
             match err {
                 Error::TonicStatus(status) => {
-                    println!(
-                        "{}{}{}Stating Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Bad Code:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.code()
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.message()
-                    );
-
-                    println!(
-                        "{}{}{}Details:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        std::str::from_utf8(status.details()).unwrap()
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Stating Failed!");
+                    terminal::separator();
+                    terminal::error_field("Bad Code:", status.code());
+                    terminal::field("Message:", status.message());
+                    terminal::field("Details:", std::str::from_utf8(status.details()).unwrap());
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Stating Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Stating Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfctl/persistent_cache_task.rs
+++ b/dragonfly-client/src/bin/dfctl/persistent_cache_task.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Local};
 use clap::{Parser, Subcommand};
 use dragonfly_api::dfdaemon::v2::ListLocalPersistentCacheTasksRequest;
 use dragonfly_api::errordetails::v2::Backend;
+use dragonfly_client::terminal;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::net::preferred_local_ip;
 use std::path::PathBuf;
@@ -25,7 +26,6 @@ use tabled::{
     settings::{object::Rows, Alignment, Modify, Style},
     Table, Tabled,
 };
-use termion::{color, style};
 use tracing::Level;
 
 use super::*;
@@ -100,39 +100,17 @@ impl LsCommand {
             match get_dfdaemon_download_client(self.endpoint.clone()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -144,197 +122,62 @@ impl LsCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Listing Persistent Cache Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Listing Persistent Cache Tasks Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Listing Persistent Cache Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Listing Persistent Cache Tasks Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Listing Persistent Cache Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Listing Persistent Cache Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Listing Persistent Cache Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Listing Persistent Cache Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfctl/persistent_task.rs
+++ b/dragonfly-client/src/bin/dfctl/persistent_task.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Local};
 use clap::{Parser, Subcommand};
 use dragonfly_api::dfdaemon::v2::ListLocalPersistentTasksRequest;
 use dragonfly_api::errordetails::v2::Backend;
+use dragonfly_client::terminal;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::net::preferred_local_ip;
 use std::path::PathBuf;
@@ -25,7 +26,6 @@ use tabled::{
     settings::{object::Rows, Alignment, Modify, Style},
     Table, Tabled,
 };
-use termion::{color, style};
 use tracing::Level;
 
 use super::*;
@@ -104,39 +104,17 @@ impl LsCommand {
             match get_dfdaemon_download_client(self.endpoint.clone()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -148,197 +126,62 @@ impl LsCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Listing Persistent Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Listing Persistent Tasks Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Listing Persistent Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Listing Persistent Tasks Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Listing Persistent Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Listing Persistent Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Listing Persistent Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Listing Persistent Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfctl/task.rs
+++ b/dragonfly-client/src/bin/dfctl/task.rs
@@ -24,6 +24,7 @@ use dragonfly_api::scheduler::v2::{
     scheduler_client::SchedulerClient as SchedulerGRPCClient, PreheatFileRequest,
     PreheatImageRequest,
 };
+use dragonfly_client::terminal;
 use dragonfly_client_backend::{hdfs, object_storage, oci};
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -44,7 +45,6 @@ use tabled::{
     settings::{object::Rows, Alignment, Modify, Style},
     Table, Tabled,
 };
-use termion::{color, style};
 use tonic::transport::Channel;
 use tracing::Level;
 use url::Url;
@@ -147,39 +147,17 @@ impl LsCommand {
             match get_dfdaemon_download_client(self.endpoint.clone()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -191,197 +169,62 @@ impl LsCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Listing Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Listing Tasks Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Listing Tasks Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Listing Tasks Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Listing Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Listing Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Listing Tasks Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Listing Tasks Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 
@@ -535,39 +378,17 @@ impl RmCommand {
             match get_dfdaemon_download_client(self.endpoint.clone()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -579,197 +400,62 @@ impl RmCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Removing Task Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Removing Task Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Removing Task Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Removing Task Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Removing Task Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Removing Task Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Removing Task Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Removing Task Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 
@@ -791,13 +477,7 @@ impl RmCommand {
             })
             .await?;
 
-        println!(
-            "{}{}{}Task Removed!{}",
-            color::Fg(color::Green),
-            style::Italic,
-            style::Bold,
-            style::Reset
-        );
+        terminal::success("Task Removed!");
 
         Ok(())
     }
@@ -1093,150 +773,46 @@ impl PreheatCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Preheating Task Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Preheating Task Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Preheating Task Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Preheating Task Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 err => {
-                    println!(
-                        "{}{}{}Preheating Task Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Preheating Task Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 
@@ -1310,12 +886,7 @@ impl PreheatCommand {
         };
 
         client.preheat_image(request).await?;
-        println!(
-            "{}{}Preheat Succeeded!{}",
-            color::Fg(color::Green),
-            style::Bold,
-            style::Reset
-        );
+        terminal::success("Preheat Succeeded!");
 
         Ok(())
     }
@@ -1385,12 +956,7 @@ impl PreheatCommand {
         };
 
         client.preheat_file(request).await?;
-        println!(
-            "{}{}Preheat Succeeded!{}",
-            color::Fg(color::Green),
-            style::Bold,
-            style::Reset
-        );
+        terminal::success("Preheat Succeeded!");
 
         Ok(())
     }
@@ -1439,12 +1005,7 @@ impl PreheatCommand {
             .await
             .map_err(|err| Error::Unknown(format!("preheat failed: {err}")))?;
 
-        println!(
-            "{}{}Preheat Succeeded!{}",
-            color::Fg(color::Green),
-            style::Bold,
-            style::Reset
-        );
+        terminal::success("Preheat Succeeded!");
 
         Ok(())
     }
@@ -1485,12 +1046,7 @@ impl PreheatCommand {
             .await
             .map_err(|err| Error::Unknown(format!("preheat failed: {err}")))?;
 
-        println!(
-            "{}{}Preheat Succeeded!{}",
-            color::Fg(color::Green),
-            style::Bold,
-            style::Reset
-        );
+        terminal::success("Preheat Succeeded!");
 
         Ok(())
     }

--- a/dragonfly-client/src/bin/dfdaemon/main.rs
+++ b/dragonfly-client/src/bin/dfdaemon/main.rs
@@ -30,6 +30,7 @@ use dragonfly_client::resource::{
     persistent_cache_task::PersistentCacheTask, persistent_task::PersistentTask, task::Task,
 };
 use dragonfly_client::stats::Stats;
+use dragonfly_client::terminal;
 use dragonfly_client::tracing::init_tracing;
 use dragonfly_client_backend::BackendFactory;
 use dragonfly_client_config::{dfdaemon, VersionValueParser};
@@ -44,7 +45,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use termion::{color, style};
 use tokio::sync::mpsc;
 use tokio::sync::Barrier;
 use tracing::{error, info, Level};
@@ -156,25 +156,14 @@ async fn main() -> Result<(), anyhow::Error> {
     let config = match dfdaemon::Config::load(&args.config).await {
         Ok(config) => config,
         Err(err) => {
-            println!(
-                "{}{}Load config {} error: {}{}\n",
-                color::Fg(color::Red),
-                style::Bold,
+            terminal::error(format!(
+                "Load config {} error: {}",
                 args.config.display(),
-                err,
-                style::Reset
-            );
+                err
+            ));
+            println!();
 
-            println!(
-                "{}{}If the file does not exist, you need to new a default config file refer to: {}{}{}{}https://d7y.io/docs/next/reference/configuration/client/dfdaemon/{}",
-                color::Fg(color::Yellow),
-                style::Bold,
-                style::Reset,
-                color::Fg(color::Cyan),
-                style::Underline,
-                style::Italic,
-                style::Reset,
-            );
+            terminal::warn("If the file does not exist, you need to new a default config file refer to: https://d7y.io/docs/next/reference/configuration/client/dfdaemon/");
             std::process::exit(1);
         }
     };

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -23,6 +23,7 @@ use dragonfly_api::dfdaemon::v2::{
 use dragonfly_api::errordetails::v2::Backend;
 use dragonfly_client::grpc::dfdaemon_download::DfdaemonDownloadClient;
 use dragonfly_client::resource::piece::MIN_PIECE_LENGTH;
+use dragonfly_client::terminal;
 use dragonfly_client::tracing::init_command_tracing;
 use dragonfly_client_backend::{
     hdfs, hugging_face, model_scope, object_storage, BackendFactory, DirEntry,
@@ -45,7 +46,6 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{cmp::min, fmt::Write};
-use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tokio::sync::Semaphore;
@@ -442,38 +442,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Validate command line arguments.
     if let Err(err) = validate_args(&args) {
-        println!(
-            "{}{}{}Validating Failed!{}",
-            color::Fg(color::Red),
-            style::Italic,
-            style::Bold,
-            style::Reset
-        );
-
-        println!(
-            "{}{}{}****************************************{}",
-            color::Fg(color::Black),
-            style::Italic,
-            style::Bold,
-            style::Reset
-        );
-
-        println!(
-            "{}{}{}Message:{} {}",
-            color::Fg(color::Cyan),
-            style::Italic,
-            style::Bold,
-            style::Reset,
-            err,
-        );
-
-        println!(
-            "{}{}{}****************************************{}",
-            color::Fg(color::Black),
-            style::Italic,
-            style::Bold,
-            style::Reset
-        );
+        terminal::error("Validating Failed!");
+        terminal::separator();
+        terminal::field("Message:", err);
+        terminal::separator();
 
         std::process::exit(1);
     }
@@ -483,39 +455,17 @@ async fn main() -> anyhow::Result<()> {
         match get_dfdaemon_download_client(args.endpoint.to_path_buf()).await {
             Ok(client) => client,
             Err(err) => {
-                println!(
-                    "{}{}{}Connect Dfdaemon Failed!{}",
-                    color::Fg(color::Red),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
+                terminal::error("Connect Dfdaemon Failed!");
+                terminal::separator();
+                terminal::field(
+                    "Message:",
+                    format!(
+                        "can not connect {}, please check the unix socket {}",
+                        err,
+                        args.endpoint.to_string_lossy()
+                    ),
                 );
-
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
-
-                println!(
-                    "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                    color::Fg(color::Cyan),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset,
-                    err,
-                    args.endpoint.to_string_lossy(),
-                );
-
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
+                terminal::separator();
 
                 std::process::exit(1);
             }
@@ -527,197 +477,59 @@ async fn main() -> anyhow::Result<()> {
             Error::TonicStatus(status) => {
                 let details = status.details();
                 if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                    println!(
-                        "{}{}{}Downloading Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Downloading Failed!");
+                    terminal::separator();
 
                     if let Some(status_code) = backend_err.status_code {
-                        println!(
-                            "{}{}{}Bad Status Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status_code
-                        );
+                        terminal::error_field("Bad Status Code:", status_code);
                     }
 
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        backend_err.message
-                    );
+                    terminal::field("Message:", backend_err.message);
 
                     if !backend_err.header.is_empty() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            backend_err
+                                .header
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.as_str())),
                         );
-                        for (key, value) in backend_err.header.iter() {
-                            println!("  [{}]: {}", key.as_str(), value.as_str());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 } else {
-                    println!(
-                        "{}{}{}Downloading Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Bad Code:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.code()
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.message()
-                    );
+                    terminal::error("Downloading Failed!");
+                    terminal::separator();
+                    terminal::error_field("Bad Code:", status.code());
+                    terminal::field("Message:", status.message());
 
                     if !status.details().is_empty() {
-                        println!(
-                            "{}{}{}Details:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            std::str::from_utf8(status.details()).unwrap()
-                        );
+                        terminal::field("Details:", std::str::from_utf8(status.details()).unwrap());
                     }
 
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
             }
             Error::BackendError(err) => {
-                println!(
-                    "{}{}{}Downloading Failed!{}",
-                    color::Fg(color::Red),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
-
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
-
-                println!(
-                    "{}{}{}Message:{} {}",
-                    color::Fg(color::Red),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset,
-                    err.message
-                );
+                terminal::error("Downloading Failed!");
+                terminal::separator();
+                terminal::error_field("Message:", err.message);
 
                 if err.header.is_some() {
-                    println!(
-                        "{}{}{}Header:{}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::headers(
+                        err.header
+                            .unwrap_or_default()
+                            .iter()
+                            .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                     );
-                    for (key, value) in err.header.unwrap_or_default().iter() {
-                        println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                    }
                 }
 
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
+                terminal::separator();
             }
             err => {
-                println!(
-                    "{}{}{}Downloading Failed!{}",
-                    color::Fg(color::Red),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
-
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
-
-                println!(
-                    "{}{}{}Message:{} {}",
-                    color::Fg(color::Red),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset,
-                    err
-                );
-
-                println!(
-                    "{}{}{}****************************************{}",
-                    color::Fg(color::Black),
-                    style::Italic,
-                    style::Bold,
-                    style::Reset
-                );
+                terminal::error("Downloading Failed!");
+                terminal::separator();
+                terminal::error_field("Message:", err);
+                terminal::separator();
             }
         }
 

--- a/dragonfly-client/src/bin/dfstore/export.rs
+++ b/dragonfly-client/src/bin/dfstore/export.rs
@@ -20,6 +20,7 @@ use dragonfly_api::dfdaemon::v2::{
     download_persistent_task_response, DownloadPersistentTaskRequest,
 };
 use dragonfly_api::errordetails::v2::Backend;
+use dragonfly_client::terminal;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
     Error, Result,
@@ -31,7 +32,6 @@ use path_absolutize::*;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{cmp::min, fmt::Write};
-use termion::{color, style};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter, SeekFrom};
 use tracing::{debug, error, info};
@@ -214,38 +214,10 @@ impl ExportCommand {
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {
-            println!(
-                "{}{}{}Validating Failed!{}",
-                color::Fg(color::Red),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}Message:{} {}",
-                color::Fg(color::Cyan),
-                style::Italic,
-                style::Bold,
-                style::Reset,
-                err,
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
+            terminal::error("Validating Failed!");
+            terminal::separator();
+            terminal::field("Message:", err);
+            terminal::separator();
 
             std::process::exit(1);
         }
@@ -255,39 +227,17 @@ impl ExportCommand {
             match get_dfdaemon_download_client(self.endpoint.to_path_buf()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -299,197 +249,62 @@ impl ExportCommand {
                 Error::TonicStatus(status) => {
                     let details = status.details();
                     if let Ok(backend_err) = serde_json::from_slice::<Backend>(details) {
-                        println!(
-                            "{}{}{}Exporting Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::error("Exporting Failed!");
+                        terminal::separator();
 
                         if let Some(status_code) = backend_err.status_code {
-                            println!(
-                                "{}{}{}Bad Status Code:{} {}",
-                                color::Fg(color::Red),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                status_code
-                            );
+                            terminal::error_field("Bad Status Code:", status_code);
                         }
 
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            backend_err.message
-                        );
+                        terminal::field("Message:", backend_err.message);
 
                         if !backend_err.header.is_empty() {
-                            println!(
-                                "{}{}{}Header:{}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset
+                            terminal::headers(
+                                backend_err
+                                    .header
+                                    .iter()
+                                    .map(|(key, value)| (key.as_str(), value.as_str())),
                             );
-                            for (key, value) in backend_err.header.iter() {
-                                println!("  [{}]: {}", key.as_str(), value.as_str());
-                            }
                         }
 
-                        println!(
-                            "{}{}{}****************************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     } else {
-                        println!(
-                            "{}{}{}Exporting Failed!{}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
-
-                        println!(
-                            "{}{}{}Bad Code:{} {}",
-                            color::Fg(color::Red),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.code()
-                        );
-
-                        println!(
-                            "{}{}{}Message:{} {}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset,
-                            status.message()
-                        );
+                        terminal::error("Exporting Failed!");
+                        terminal::separator();
+                        terminal::error_field("Bad Code:", status.code());
+                        terminal::field("Message:", status.message());
 
                         if !status.details().is_empty() {
-                            println!(
-                                "{}{}{}Details:{} {}",
-                                color::Fg(color::Cyan),
-                                style::Italic,
-                                style::Bold,
-                                style::Reset,
-                                std::str::from_utf8(status.details()).unwrap()
+                            terminal::field(
+                                "Details:",
+                                std::str::from_utf8(status.details()).unwrap(),
                             );
                         }
 
-                        println!(
-                            "{}{}{}*********************************{}",
-                            color::Fg(color::Black),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
-                        );
+                        terminal::separator();
                     }
                 }
                 Error::BackendError(err) => {
-                    println!(
-                        "{}{}{}Exporting Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err.message
-                    );
+                    terminal::error("Exporting Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err.message);
 
                     if err.header.is_some() {
-                        println!(
-                            "{}{}{}Header:{}",
-                            color::Fg(color::Cyan),
-                            style::Italic,
-                            style::Bold,
-                            style::Reset
+                        terminal::headers(
+                            err.header
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|(key, value)| (key.as_str(), value.to_str().unwrap())),
                         );
-                        for (key, value) in err.header.unwrap_or_default().iter() {
-                            println!("  [{}]: {}", key.as_str(), value.to_str().unwrap());
-                        }
                     }
 
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Exporting Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Exporting Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/bin/dfstore/import.rs
+++ b/dragonfly-client/src/bin/dfstore/import.rs
@@ -17,6 +17,7 @@
 use clap::Parser;
 use dragonfly_api::common::v2::ObjectStorage;
 use dragonfly_api::dfdaemon::v2::UploadPersistentTaskRequest;
+use dragonfly_client::terminal;
 use dragonfly_client_config::dfstore::default_dfstore_persistent_replica_count;
 use dragonfly_client_core::{
     error::{ErrorType, OrErr},
@@ -27,7 +28,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use path_absolutize::*;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use termion::{color, style};
 use tracing::info;
 use url::Url;
 
@@ -190,38 +190,10 @@ impl ImportCommand {
 
         // Validate the command line arguments.
         if let Err(err) = self.validate_args() {
-            println!(
-                "{}{}{}Validating Failed!{}",
-                color::Fg(color::Red),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
-
-            println!(
-                "{}{}{}Message:{} {}",
-                color::Fg(color::Cyan),
-                style::Italic,
-                style::Bold,
-                style::Reset,
-                err,
-            );
-
-            println!(
-                "{}{}{}****************************************{}",
-                color::Fg(color::Black),
-                style::Italic,
-                style::Bold,
-                style::Reset
-            );
+            terminal::error("Validating Failed!");
+            terminal::separator();
+            terminal::field("Message:", err);
+            terminal::separator();
 
             std::process::exit(1);
         }
@@ -231,39 +203,17 @@ impl ImportCommand {
             match get_dfdaemon_download_client(self.endpoint.to_path_buf()).await {
                 Ok(client) => client,
                 Err(err) => {
-                    println!(
-                        "{}{}{}Connect Dfdaemon Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
+                    terminal::error("Connect Dfdaemon Failed!");
+                    terminal::separator();
+                    terminal::field(
+                        "Message:",
+                        format!(
+                            "can not connect {}, please check the unix socket {}",
+                            err,
+                            self.endpoint.to_string_lossy()
+                        ),
                     );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{}, can not connect {}, please check the unix socket {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err,
-                        self.endpoint.to_string_lossy(),
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::separator();
 
                     std::process::exit(1);
                 }
@@ -273,90 +223,18 @@ impl ImportCommand {
         if let Err(err) = self.run(dfdaemon_download_client).await {
             match err {
                 Error::TonicStatus(status) => {
-                    println!(
-                        "{}{}{}Importing Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Bad Code:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.code()
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        status.message()
-                    );
-
-                    println!(
-                        "{}{}{}Details:{} {}",
-                        color::Fg(color::Cyan),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        std::str::from_utf8(status.details()).unwrap()
-                    );
-
-                    println!(
-                        "{}{}{}*********************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Importing Failed!");
+                    terminal::separator();
+                    terminal::error_field("Bad Code:", status.code());
+                    terminal::field("Message:", status.message());
+                    terminal::field("Details:", std::str::from_utf8(status.details()).unwrap());
+                    terminal::separator();
                 }
                 err => {
-                    println!(
-                        "{}{}{}Importing Failed!{}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
-
-                    println!(
-                        "{}{}{}Message:{} {}",
-                        color::Fg(color::Red),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset,
-                        err
-                    );
-
-                    println!(
-                        "{}{}{}****************************************{}",
-                        color::Fg(color::Black),
-                        style::Italic,
-                        style::Bold,
-                        style::Reset
-                    );
+                    terminal::error("Importing Failed!");
+                    terminal::separator();
+                    terminal::error_field("Message:", err);
+                    terminal::separator();
                 }
             }
 

--- a/dragonfly-client/src/lib.rs
+++ b/dragonfly-client/src/lib.rs
@@ -22,4 +22,5 @@ pub mod health;
 pub mod proxy;
 pub mod resource;
 pub mod stats;
+pub mod terminal;
 pub mod tracing;

--- a/dragonfly-client/src/terminal/mod.rs
+++ b/dragonfly-client/src/terminal/mod.rs
@@ -1,0 +1,71 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt::Display;
+use termion::{color, style};
+
+/// The separator line between sections of command line output.
+const SEPARATOR: &str = "****************************************";
+
+/// Returns the text in bold italic with the given color.
+fn styled(fg: impl color::Color, text: impl Display) -> String {
+    format!(
+        "{}{}{}{}{}",
+        color::Fg(fg),
+        style::Italic,
+        style::Bold,
+        text,
+        style::Reset
+    )
+}
+
+/// Prints a red headline, e.g. `Downloading Failed!`.
+pub fn error(text: impl Display) {
+    println!("{}", styled(color::Red, text));
+}
+
+/// Prints a green headline, e.g. `Task Removed!`.
+pub fn success(text: impl Display) {
+    println!("{}", styled(color::Green, text));
+}
+
+/// Prints a yellow warning message.
+pub fn warn(text: impl Display) {
+    println!("{}", styled(color::Yellow, text));
+}
+
+/// Prints the separator line between sections.
+pub fn separator() {
+    println!("{}", styled(color::Black, SEPARATOR));
+}
+
+/// Prints a cyan key followed by a plain value, e.g. `Message: ...`.
+pub fn field(key: &str, value: impl Display) {
+    println!("{} {}", styled(color::Cyan, key), value);
+}
+
+/// Prints a red key followed by a plain value, e.g. `Bad Code: ...`.
+pub fn error_field(key: &str, value: impl Display) {
+    println!("{} {}", styled(color::Red, key), value);
+}
+
+/// Prints a cyan `Header:` key followed by indented `[key]: value` lines.
+pub fn headers<'a>(entries: impl IntoIterator<Item = (&'a str, &'a str)>) {
+    println!("{}", styled(color::Cyan, "Header:"));
+    for (key, value) in entries {
+        println!("  [{key}]: {value}");
+    }
+}


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

Centralize terminal styling across dfcache, dfctl, dfstore, dfdaemon, dfget, and dfstore binaries by using shared terminal helper functions instead of inline termion calls.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
