### PR TITLE
chore: bump workspace version from 1.5.0 to 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1301,11 +1301,11 @@ dependencies = [
  "dragonfly-api",
  "dragonfly-client-backend",
  "dragonfly-client-config",
- "dragonfly-client-core 1.5.0",
+ "dragonfly-client-core 1.5.1",
  "dragonfly-client-metric",
  "dragonfly-client-request",
  "dragonfly-client-storage",
- "dragonfly-client-util 1.5.0",
+ "dragonfly-client-util 1.5.1",
  "fastrand",
  "futures",
  "glob",
@@ -1365,15 +1365,15 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "bytes",
  "dashmap",
  "dragonfly-api",
  "dragonfly-client-config",
- "dragonfly-client-core 1.5.0",
- "dragonfly-client-util 1.5.0",
+ "dragonfly-client-core 1.5.1",
+ "dragonfly-client-util 1.5.1",
  "fastrand",
  "futures",
  "http",
@@ -1403,13 +1403,13 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bytesize",
  "bytesize-serde",
  "clap",
- "dragonfly-client-core 1.5.0",
- "dragonfly-client-util 1.5.0",
+ "dragonfly-client-core 1.5.1",
+ "dragonfly-client-util 1.5.1",
  "home",
  "hostname",
  "http-serde",
@@ -1428,26 +1428,6 @@ dependencies = [
  "tonic",
  "tracing",
  "validator",
-]
-
-[[package]]
-name = "dragonfly-client-core"
-version = "1.5.0"
-dependencies = [
- "cgroups-rs",
- "http",
- "hyper",
- "hyper-util",
- "opendal",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-reflection",
- "url",
- "vortex-protocol",
 ]
 
 [[package]]
@@ -1473,14 +1453,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dragonfly-client-core"
+version = "1.5.1"
+dependencies = [
+ "cgroups-rs",
+ "http",
+ "hyper",
+ "hyper-util",
+ "opendal",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-reflection",
+ "url",
+ "vortex-protocol",
+]
+
+[[package]]
 name = "dragonfly-client-init"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "clap",
  "dragonfly-client",
  "dragonfly-client-config",
- "dragonfly-client-core 1.5.0",
+ "dragonfly-client-core 1.5.1",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1491,12 +1491,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bytes",
  "dragonfly-api",
  "dragonfly-client-config",
- "dragonfly-client-util 1.5.0",
+ "dragonfly-client-util 1.5.1",
  "fs2",
  "http-body-util",
  "hyper",
@@ -1515,8 +1515,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "dragonfly-api",
- "dragonfly-client-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dragonfly-client-util 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dragonfly-client-core 1.5.0",
+ "dragonfly-client-util 1.5.0",
  "futures",
  "hostname",
  "oci-client",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -1548,9 +1548,9 @@ dependencies = [
  "dashmap",
  "dragonfly-api",
  "dragonfly-client-config",
- "dragonfly-client-core 1.5.0",
+ "dragonfly-client-core 1.5.1",
  "dragonfly-client-metric",
- "dragonfly-client-util 1.5.0",
+ "dragonfly-client-util 1.5.1",
  "fs2",
  "futures",
  "leaky-bucket",
@@ -1573,6 +1573,8 @@ dependencies = [
 [[package]]
 name = "dragonfly-client-util"
 version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0be81e728ecb42f619740de7e29cd86aba836297ee45b897749ac2d9a3a8f9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1583,6 +1585,47 @@ dependencies = [
  "dashmap",
  "dragonfly-api",
  "dragonfly-client-core 1.5.0",
+ "fs2",
+ "hashring",
+ "hex",
+ "http",
+ "http-range-header",
+ "humantime-serde",
+ "libc",
+ "local-ip-address",
+ "lru",
+ "parking_lot",
+ "pnet",
+ "rcgen",
+ "regex",
+ "reqwest 0.12.28",
+ "ringbuf",
+ "rustix 1.1.3",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "sha2 0.10.8",
+ "sysinfo",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "dragonfly-client-util"
+version = "1.5.1"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "bytesize",
+ "cgroups-rs",
+ "crc32fast",
+ "dashmap",
+ "dragonfly-api",
+ "dragonfly-client-core 1.5.1",
  "fs2",
  "hashring",
  "hex",
@@ -1607,49 +1650,6 @@ dependencies = [
  "sha2 0.10.8",
  "sysinfo",
  "tempfile",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "dragonfly-client-util"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0be81e728ecb42f619740de7e29cd86aba836297ee45b897749ac2d9a3a8f9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "bytesize",
- "cgroups-rs",
- "crc32fast",
- "dashmap",
- "dragonfly-api",
- "dragonfly-client-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs2",
- "hashring",
- "hex",
- "http",
- "http-range-header",
- "humantime-serde",
- "libc",
- "local-ip-address",
- "lru",
- "parking_lot",
- "pnet",
- "rcgen",
- "regex",
- "reqwest 0.12.28",
- "ringbuf",
- "rustix 1.1.3",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "sha2 0.10.8",
- "sysinfo",
  "tokio",
  "tracing",
  "url",
@@ -2149,11 +2149,11 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",
- "dragonfly-client-core 1.5.0",
+ "dragonfly-client-core 1.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.0"
+version = "1.5.1"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -34,14 +34,14 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.2.32"
-dragonfly-client = { path = "dragonfly-client", version = "1.5.0" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.0" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.0" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.0" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.0" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.0" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.0" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.0" }
+dragonfly-client = { path = "dragonfly-client", version = "1.5.1" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.1" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.1" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.1" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.1" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.1" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.1" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.1" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client-util/src/lib.rs
+++ b/dragonfly-client-util/src/lib.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+pub use dragonfly_api;
 pub mod buffer_pool;
 pub mod container;
 pub mod digest;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Increment all workspace crate versions to 1.5.1 and re-export dragonfly_api from dragonfly-client-util.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
