### PR TITLE
feat(storage): make per-piece writeback configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "cgroups-rs",
  "http",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bytes",
  "dragonfly-api",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -34,14 +34,14 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.3.1"
-dragonfly-client = { path = "dragonfly-client", version = "1.5.1" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.1" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.1" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.1" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.1" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.1" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.1" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.1" }
+dragonfly-client = { path = "dragonfly-client", version = "1.5.2" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.2" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.2" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.2" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.2" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.2" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.2" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.2" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -967,12 +967,37 @@ impl Default for StorageServer {
     }
 }
 
+/// WritebackMode controls how the storage initiates writeback of written
+/// piece ranges to disk.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WritebackMode {
+    /// Sync awaits sync_file_range on the write path after each piece write.
+    /// It keeps dirty pages bounded, but paces the write path at disk speed
+    /// when the device writeback queue is congested.
+    Sync,
+
+    /// Async enqueues written ranges to a dedicated background task, so the
+    /// write path is never paced by the disk. A full queue drops ranges and
+    /// the kernel writeback thresholds cover them.
+    #[default]
+    Async,
+
+    /// Off skips per-piece writeback and leaves it entirely to the kernel
+    /// writeback thresholds.
+    Off,
+}
+
 /// The storage configuration for dfdaemon.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Storage {
     /// The storage server configuration for dfdaemon.
     pub server: StorageServer,
+
+    /// The writeback mode for written piece ranges, default is async.
+    #[serde(default)]
+    pub writeback_mode: WritebackMode,
 
     /// The directory to store task's metadata and content.
     #[serde(default = "crate::default_storage_dir")]
@@ -1045,6 +1070,7 @@ impl Default for Storage {
     fn default() -> Self {
         Storage {
             server: StorageServer::default(),
+            writeback_mode: WritebackMode::default(),
             dir: crate::default_storage_dir(),
             keep: default_storage_keep(),
             write_piece_timeout: default_storage_write_piece_timeout(),
@@ -2097,6 +2123,27 @@ key: /etc/ssl/private/client.pem
         let super_json = serde_json::to_string(&HostType::Super).unwrap();
         assert_eq!(normal_json, "\"normal\"");
         assert_eq!(super_json, "\"super\"");
+    }
+
+    #[test]
+    fn default_writeback_mode_correctly() {
+        // Test if the default value is WritebackMode::Async.
+        let default_writeback_mode: WritebackMode = Default::default();
+        assert_eq!(default_writeback_mode, WritebackMode::Async);
+
+        // Test if the missing field falls back to the default.
+        let storage: Storage = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(storage.writeback_mode, WritebackMode::Async);
+    }
+
+    #[test]
+    fn serialize_writeback_mode_correctly() {
+        let sync: WritebackMode = serde_json::from_str("\"sync\"").unwrap();
+        let asynchronous: WritebackMode = serde_json::from_str("\"async\"").unwrap();
+        let off: WritebackMode = serde_json::from_str("\"off\"").unwrap();
+        assert_eq!(sync, WritebackMode::Sync);
+        assert_eq!(asynchronous, WritebackMode::Async);
+        assert_eq!(off, WritebackMode::Off);
     }
 
     #[test]

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -2128,11 +2128,9 @@ key: /etc/ssl/private/client.pem
 
     #[test]
     fn default_writeback_mode_correctly() {
-        // Test if the default value is WritebackMode::Async.
         let default_writeback_mode: WritebackMode = Default::default();
         assert_eq!(default_writeback_mode, WritebackMode::Async);
 
-        // Test if the missing field falls back to the default.
         let storage: Storage = serde_yaml::from_str("{}").unwrap();
         assert_eq!(storage.writeback_mode, WritebackMode::Async);
     }

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -977,14 +977,15 @@ pub enum WritebackMode {
     /// when the device writeback queue is congested.
     Sync,
 
-    /// Async enqueues written ranges to a dedicated background task, so the
-    /// write path is never paced by the disk. A full queue drops ranges and
-    /// the kernel writeback thresholds cover them.
+    /// Async enqueues written ranges to a dedicated background task, so writes
+    /// are not paced by a congested disk until the kernel dirty thresholds
+    /// throttle them. A full queue drops ranges and the kernel writeback
+    /// covers them.
     #[default]
     Async,
 
     /// Off skips per-piece writeback and leaves it entirely to the kernel
-    /// writeback thresholds.
+    /// writeback.
     Off,
 }
 

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -47,7 +47,7 @@ pub const DEFAULT_PERSISTENT_CACHE_TASK_DIR: &str = "persistent-cache-tasks";
 /// content, multiplied by the largest configured buffer size to size the pool.
 pub const MAX_BUFFER_POOL_IDLE_BUFFERS: usize = 128;
 
-/// The capacity of the background writeback queue, matching the ranges a
+/// The capacity of the background writeback queue, roughly the ranges a
 /// congested disk drains within the kernel dirty expire window. A full
 /// queue drops further ranges and the kernel writeback covers them.
 const WRITEBACK_QUEUE_CAPACITY: usize = 1024;
@@ -61,14 +61,14 @@ pub enum Writeback {
     /// Sends written ranges to the background writeback task.
     Async(mpsc::Sender<(Arc<File>, u64, u64)>),
 
-    /// Leaves writeback to the kernel writeback thresholds.
+    /// Leaves it to the kernel writeback.
     Off,
 }
 
 /// Implements the writeback.
 impl Writeback {
     /// Creates a new writeback. In async mode it spawns the background task,
-    /// which exits when the last sender drops.
+    /// which drains the queue and exits when the last sender drops.
     pub fn new(mode: WritebackMode) -> Self {
         match mode {
             WritebackMode::Sync => Writeback::Sync,
@@ -88,8 +88,7 @@ impl Writeback {
         }
     }
 
-    /// Triggers writeback of the written range, awaited on the write path
-    /// or enqueued to the background task.
+    /// Triggers writeback of the written range per the configured mode.
     pub async fn trigger(&self, fd: &Arc<File>, offset: u64, length: u64) {
         match self {
             Writeback::Sync => {

--- a/dragonfly-client-storage/src/content.rs
+++ b/dragonfly-client-storage/src/content.rs
@@ -15,11 +15,15 @@
  */
 
 use dragonfly_api::common::v2::Range;
-use dragonfly_client_config::dfdaemon::Config;
+use dragonfly_client_config::dfdaemon::{Config, WritebackMode};
 use dragonfly_client_core::Result;
+use dragonfly_client_util::fs::sync_file_range;
 use std::cmp::{max, min};
+use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{trace, warn};
 
 #[cfg(target_os = "linux")]
 pub type Content = super::content_linux::Content;
@@ -42,6 +46,66 @@ pub const DEFAULT_PERSISTENT_CACHE_TASK_DIR: &str = "persistent-cache-tasks";
 /// The maximum number of idle buffers retained by the buffer pool of the
 /// content, multiplied by the largest configured buffer size to size the pool.
 pub const MAX_BUFFER_POOL_IDLE_BUFFERS: usize = 128;
+
+/// The capacity of the background writeback queue, matching the ranges a
+/// congested disk drains within the kernel dirty expire window. A full
+/// queue drops further ranges and the kernel writeback covers them.
+const WRITEBACK_QUEUE_CAPACITY: usize = 1024;
+
+/// Writeback initiates writeback of written piece ranges according to the
+/// storage.writebackMode configuration.
+pub enum Writeback {
+    /// Awaits sync_file_range on the write path.
+    Sync,
+
+    /// Sends written ranges to the background writeback task.
+    Async(mpsc::Sender<(Arc<File>, u64, u64)>),
+
+    /// Leaves writeback to the kernel writeback thresholds.
+    Off,
+}
+
+/// Implements the writeback.
+impl Writeback {
+    /// Creates a new writeback. In async mode it spawns the background task,
+    /// which exits when the last sender drops.
+    pub fn new(mode: WritebackMode) -> Self {
+        match mode {
+            WritebackMode::Sync => Writeback::Sync,
+            WritebackMode::Async => {
+                let (tx, mut rx) = mpsc::channel::<(Arc<File>, u64, u64)>(WRITEBACK_QUEUE_CAPACITY);
+                tokio::spawn(async move {
+                    while let Some((fd, offset, length)) = rx.recv().await {
+                        sync_file_range(&fd, offset, length)
+                            .await
+                            .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+                    }
+                });
+
+                Writeback::Async(tx)
+            }
+            WritebackMode::Off => Writeback::Off,
+        }
+    }
+
+    /// Triggers writeback of the written range, awaited on the write path
+    /// or enqueued to the background task.
+    pub async fn trigger(&self, fd: &Arc<File>, offset: u64, length: u64) {
+        match self {
+            Writeback::Sync => {
+                sync_file_range(fd, offset, length)
+                    .await
+                    .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            }
+            Writeback::Async(tx) => {
+                if let Err(err) = tx.try_send((fd.clone(), offset, length)) {
+                    trace!("dropped writeback range: {}", err);
+                }
+            }
+            Writeback::Off => {}
+        }
+    }
+}
 
 /// Creates a new Content instance to support linux and macos.
 pub async fn new_content(config: Arc<Config>, dir: &Path) -> Result<Content> {

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -1024,8 +1024,6 @@ mod tests {
                 .unwrap();
             assert_eq!(response.length, 13);
 
-            // Give the background writeback task a chance to process the
-            // enqueued range, so the async path itself is exercised.
             if mode == WritebackMode::Async {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -46,6 +46,9 @@ pub struct Content {
 
     /// The pool of the staging buffers for reading and writing pieces.
     buffer_pool: BufferPool,
+
+    /// Initiates writeback of written piece ranges per storage.writebackMode.
+    writeback: super::content::Writeback,
 }
 
 /// Implements the content storage.
@@ -65,6 +68,7 @@ impl Content {
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_TASK_DIR)).await?;
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_CACHE_TASK_DIR)).await?;
         info!("content initialized directory: {:?}", dir);
+
         Ok(Content {
             buffer_pool: BufferPool::new(
                 super::content::MAX_BUFFER_POOL_IDLE_BUFFERS
@@ -73,6 +77,7 @@ impl Content {
                         config.storage.read_buffer_size,
                     ),
             ),
+            writeback: super::content::Writeback::new(config.storage.writeback_mode),
             config,
             dir,
             fd_cache: FDCache::new(DEFAULT_FD_CACHE_CAPACITY),
@@ -313,8 +318,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -323,7 +328,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Returns the task path by task id.
@@ -529,8 +537,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range(
-            fd,
+        let response = super::io::write_range(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -540,7 +548,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Writes the persistent piece from the stream of bytes chunks to the
@@ -565,8 +576,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -575,7 +586,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Deletes the persistent task content.
@@ -817,8 +831,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range(
-            fd,
+        let response = super::io::write_range(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -828,7 +842,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Writes the persistent cache piece from the stream of bytes chunks to
@@ -854,8 +871,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -864,7 +881,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Deletes the persistent cache task content.
@@ -911,6 +931,7 @@ impl Content {
 mod tests {
     use super::*;
     use crate::content;
+    use dragonfly_client_config::dfdaemon::WritebackMode;
     use std::io::Cursor;
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -976,6 +997,44 @@ mod tests {
 
         content.delete_task(task_id).await.unwrap();
         assert!(!task_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_write_piece_writeback_modes() {
+        for mode in [
+            WritebackMode::Sync,
+            WritebackMode::Async,
+            WritebackMode::Off,
+        ] {
+            let temp_dir = tempdir().unwrap();
+            let mut config = Config::default();
+            config.storage.writeback_mode = mode;
+            let content = Content::new(Arc::new(config), temp_dir.path())
+                .await
+                .unwrap();
+
+            let task_id = "60409bd0ec44160f44c53c39b3fe1c5fdfb23faded0228c68bee83bc15a200e3";
+            content.create_task(task_id, 13).await.unwrap();
+
+            let data = b"hello, world!";
+            let mut stream = futures::stream::iter([Ok(Bytes::from_static(data))]);
+            let response = content
+                .write_piece_from_stream(task_id, 0, 13, &mut stream)
+                .await
+                .unwrap();
+            assert_eq!(response.length, 13);
+
+            // Give the background writeback task a chance to process the
+            // enqueued range, so the async path itself is exercised.
+            if mode == WritebackMode::Async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+
+            let mut reader = content.read_piece(task_id, 0, 13, None).await.unwrap();
+            let mut buffer = Vec::new();
+            reader.read_to_end(&mut buffer).await.unwrap();
+            assert_eq!(buffer, data);
+        }
     }
 
     #[tokio::test]

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -46,6 +46,9 @@ pub struct Content {
 
     /// The pool of the staging buffers for reading and writing pieces.
     buffer_pool: BufferPool,
+
+    /// Initiates writeback of written piece ranges per storage.writebackMode.
+    writeback: super::content::Writeback,
 }
 
 /// Implements the content storage.
@@ -65,6 +68,7 @@ impl Content {
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_TASK_DIR)).await?;
         fs::create_dir_all(&dir.join(super::content::DEFAULT_PERSISTENT_CACHE_TASK_DIR)).await?;
         info!("content initialized directory: {:?}", dir);
+
         Ok(Content {
             buffer_pool: BufferPool::new(
                 super::content::MAX_BUFFER_POOL_IDLE_BUFFERS
@@ -73,6 +77,7 @@ impl Content {
                         config.storage.read_buffer_size,
                     ),
             ),
+            writeback: super::content::Writeback::new(config.storage.writeback_mode),
             config,
             dir,
             fd_cache: FDCache::new(DEFAULT_FD_CACHE_CAPACITY),
@@ -341,8 +346,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -351,7 +356,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Returns the task path by task id.
@@ -557,8 +565,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range(
-            fd,
+        let response = super::io::write_range(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -568,7 +576,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Writes the persistent piece from the stream of bytes chunks to the
@@ -593,8 +604,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -603,7 +614,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Deletes the persistent task content.
@@ -845,8 +859,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range(
-            fd,
+        let response = super::io::write_range(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -856,7 +870,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Writes the persistent cache piece from the stream of bytes chunks to
@@ -882,8 +899,8 @@ impl Content {
                 error!("open {:?} failed: {}", task_path, err);
             })?;
 
-        super::io::write_range_from_stream(
-            fd,
+        let response = super::io::write_range_from_stream(
+            fd.clone(),
             offset,
             expected_length,
             self.config.storage.write_buffer_size,
@@ -892,7 +909,10 @@ impl Content {
         .await
         .inspect_err(|err| {
             error!("write {:?} failed: {}", task_path, err);
-        })
+        })?;
+
+        self.writeback.trigger(&fd, offset, response.length).await;
+        Ok(response)
     }
 
     /// Deletes the persistent cache task content.
@@ -939,6 +959,7 @@ impl Content {
 mod tests {
     use super::*;
     use crate::content;
+    use dragonfly_client_config::dfdaemon::WritebackMode;
     use std::io::Cursor;
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1004,6 +1025,44 @@ mod tests {
 
         content.delete_task(task_id).await.unwrap();
         assert!(!task_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_write_piece_writeback_modes() {
+        for mode in [
+            WritebackMode::Sync,
+            WritebackMode::Async,
+            WritebackMode::Off,
+        ] {
+            let temp_dir = tempdir().unwrap();
+            let mut config = Config::default();
+            config.storage.writeback_mode = mode;
+            let content = Content::new(Arc::new(config), temp_dir.path())
+                .await
+                .unwrap();
+
+            let task_id = "60409bd0ec44160f44c53c39b3fe1c5fdfb23faded0228c68bee83bc15a200e3";
+            content.create_task(task_id, 13).await.unwrap();
+
+            let data = b"hello, world!";
+            let mut stream = futures::stream::iter([Ok(Bytes::from_static(data))]);
+            let response = content
+                .write_piece_from_stream(task_id, 0, 13, &mut stream)
+                .await
+                .unwrap();
+            assert_eq!(response.length, 13);
+
+            // Give the background writeback task a chance to process the
+            // enqueued range, so the async path itself is exercised.
+            if mode == WritebackMode::Async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+
+            let mut reader = content.read_piece(task_id, 0, 13, None).await.unwrap();
+            let mut buffer = Vec::new();
+            reader.read_to_end(&mut buffer).await.unwrap();
+            assert_eq!(buffer, data);
+        }
     }
 
     #[tokio::test]

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -1052,8 +1052,6 @@ mod tests {
                 .unwrap();
             assert_eq!(response.length, 13);
 
-            // Give the background writeback task a chance to process the
-            // enqueued range, so the async path itself is exercised.
             if mode == WritebackMode::Async {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }

--- a/dragonfly-client-storage/src/io.rs
+++ b/dragonfly-client-storage/src/io.rs
@@ -17,7 +17,6 @@
 use bytes::{Bytes, BytesMut};
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
-use dragonfly_client_util::fs::sync_file_range;
 use futures::{Stream, TryStreamExt};
 use std::cmp::{max, min};
 use std::fs::File;
@@ -29,7 +28,6 @@ use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt, ReadBuf};
 use tokio::task::JoinHandle;
-use tracing::warn;
 
 /// The response of writing a range.
 pub struct WriteRangeResponse {
@@ -320,12 +318,6 @@ pub async fn write_range<R: AsyncRead + Unpin + ?Sized>(
         )));
     }
 
-    // Kick off writeback of the written range, so dirty pages do not
-    // accumulate across pieces until the kernel writeback thresholds kick in.
-    sync_file_range(&fd, offset - length, length)
-        .await
-        .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
-
     Ok(WriteRangeResponse {
         length,
         hash: hasher.finalize().to_string(),
@@ -481,12 +473,6 @@ where
             "expected length {expected_length} but got {length}"
         )));
     }
-
-    // Kick off writeback of the written range, so dirty pages do not
-    // accumulate across pieces until the kernel writeback thresholds kick in.
-    sync_file_range(&fd, offset - length, length)
-        .await
-        .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
 
     Ok(WriteRangeResponse {
         length,


### PR DESCRIPTION
## Description

Adds a `storage.writeback` config option that controls how the storage triggers writeback of written piece ranges:

```yaml
storage:
  writeback: inline   # default — current behavior, await sync_file_range per piece write
  #           background — enqueue ranges to a dedicated flusher task (fire-and-forget)
  #           off        — rely on the kernel vm.dirty_* thresholds only
```

The default is `inline`, so existing deployments see zero behavior change. Hosts whose download bandwidth exceeds the disk's sustained write bandwidth can opt into `background` and recover the full download rate (measurements in the linked issue: 0.25 → 1.07 GiB/s on a host with ~1.19 GiB/s network ingress and ~266 MiB/s NVMe).

Implementation notes:

- The per-piece writeback moves from `io.rs` (which returns to pure I/O, no signature changes, no test churn) to the content layer, which owns both the configuration and the flusher lifecycle.
- In `background` mode, `Content::new` spawns a single flusher task fed by a small bounded channel; the write path does a `try_send` and moves on. A full channel drops the hint — safe, because `sync_file_range` is purely advisory and kernel writeback covers dropped ranges. The single consumer also means at most one blocked syscall at a time, instead of piling blocked threads onto the blocking pool at high piece rates.
- Lifecycle is owned, not global: when `Content` drops, the last `Sender` drops, the flusher's `recv()` returns `None`, and the task exits.
- The GC-time and copy-time writeback from #1981 is unchanged — only the two per-piece write-path calls are affected.
- On non-Linux targets all modes are no-ops (the existing `sync_file_range` wrapper is already cfg-gated to Linux).

## Related Issue

Fixes #2005

## Motivation and Context

`SYNC_FILE_RANGE_WRITE` only initiates writeback, but the syscall blocks while the device writeback queue is congested. Awaiting it inline after every piece write therefore paces the whole cold download at disk write speed on hosts where the network outruns the disk, and it flushes each range immediately, so dirty pages never accumulate and the kernel `vm.dirty_*` thresholds never get a chance to absorb download bursts in RAM. Full analysis, measurements, and reproduction steps are in #2005.

The `background` mode preserves what the inline call was added for — a steady drain and bounded dirty pages while the disk keeps up — and degrades gracefully to kernel-threshold writeback when it can't, instead of pacing the download.

## Screenshots (if appropriate)

N/A