### PR TITLE
Refactor URL query parameter filtering for task ID consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "lru",
  "mocktail",
  "parking_lot",
+ "percent-encoding",
  "pnet",
  "rcgen",
  "regex",

--- a/dragonfly-client-storage/src/content_linux.rs
+++ b/dragonfly-client-storage/src/content_linux.rs
@@ -22,7 +22,7 @@ use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
+use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -223,12 +223,11 @@ impl Content {
     pub async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);
@@ -469,12 +468,11 @@ impl Content {
     pub async fn copy_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_persistent_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);
@@ -763,12 +761,11 @@ impl Content {
     pub async fn copy_persistent_cache_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);

--- a/dragonfly-client-storage/src/content_macos.rs
+++ b/dragonfly-client-storage/src/content_macos.rs
@@ -22,7 +22,7 @@ use dragonfly_client_config::MIN_PIECE_LENGTH;
 use dragonfly_client_core::{Error, Result};
 use dragonfly_client_util::buffer_pool::BufferPool;
 use dragonfly_client_util::fs::fd::{FDCache, DEFAULT_FD_CACHE_CAPACITY};
-use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate, sync_file_range};
+use dragonfly_client_util::fs::{fadvise_dontneed, fadvise_willneed, fallocate};
 use futures::Stream;
 use std::cmp::max;
 use std::os::unix::fs::MetadataExt;
@@ -251,12 +251,11 @@ impl Content {
     pub async fn copy_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);
@@ -497,12 +496,11 @@ impl Content {
     pub async fn copy_persistent_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_persistent_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);
@@ -791,12 +789,11 @@ impl Content {
     pub async fn copy_persistent_cache_task(&self, task_id: &str, to: &Path) -> Result<()> {
         let length = fs::copy(self.get_persistent_cache_task_path(task_id), to).await?;
 
-        // Kick off writeback of the copied content, so dirty pages do not
-        // accumulate until the kernel writeback thresholds kick in.
+        // Triggers writeback of the copied content per storage.writebackMode.
         if let Ok(f) = fs::File::open(to).await {
-            sync_file_range(&f.into_std().await, 0, length)
-                .await
-                .unwrap_or_else(|err| warn!("sync_file_range failed: {}", err));
+            self.writeback
+                .trigger(&Arc::new(f.into_std().await), 0, length)
+                .await;
         }
 
         info!("copy to {:?} success", to);

--- a/dragonfly-client-util/Cargo.toml
+++ b/dragonfly-client-util/Cargo.toml
@@ -18,6 +18,7 @@ http.workspace = true
 tracing.workspace = true
 serde.workspace = true
 url.workspace = true
+percent-encoding.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rcgen.workspace = true

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -15,15 +15,12 @@
  */
 
 use crate::digest;
+use crate::url::filter_query_params;
 use dragonfly_api::common::v2::{Download, TaskType};
-use dragonfly_client_core::{
-    error::{ErrorType, OrErr},
-    Error, Result,
-};
+use dragonfly_client_core::{Error, Result};
 use sha2::{Digest, Sha256};
 use std::io::{self, Read};
 use std::path::PathBuf;
-use url::Url;
 use uuid::Uuid;
 
 /// The suffix of the seed peer.
@@ -141,30 +138,8 @@ impl IDGenerator {
                 filtered_query_params,
                 revision,
             } => {
-                // Filter the query parameters.
-                let url = Url::parse(url.as_str()).or_err(ErrorType::ParseError)?;
-                let mut query = url
-                    .query_pairs()
-                    .filter(|(k, _)| {
-                        !filtered_query_params
-                            .iter()
-                            .any(|param| param.as_str() == k.as_ref())
-                    })
-                    .peekable();
-
-                let mut artifact_url = url.clone();
-                if query.peek().is_none() {
-                    artifact_url.set_query(None);
-                } else {
-                    artifact_url.query_pairs_mut().clear().extend_pairs(query);
-                }
-
-                let artifact_url_str = artifact_url.to_string();
-                let final_url = if artifact_url_str.ends_with('/') && artifact_url.path() == "/" {
-                    artifact_url_str.trim_end_matches('/').to_string()
-                } else {
-                    artifact_url_str
-                };
+                // Canonicalize the url, identical to the scheduler's task id generation.
+                let final_url = filter_query_params(&url, &filtered_query_params)?;
 
                 // Initialize the hasher.
                 let mut hasher = Sha256::new();
@@ -436,6 +411,66 @@ mod tests {
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 TaskIDParameter::URLBased {
+                    url: "https://example.com/file.txt?z=9&b=2&a=1".to_string(),
+                    piece_length: None,
+                    tag: Some("foo".to_string()),
+                    application: Some("bar".to_string()),
+                    filtered_query_params: vec!["z".to_string()],
+                    revision: None,
+                },
+                "8b3f6e9b9b8fe20903bced565cfd1d0aaef354a4c17573f0c2c1979210443f9d",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::URLBased {
+                    url: "https://example.com/file.txt?b=2&a=1&b=1".to_string(),
+                    piece_length: None,
+                    tag: None,
+                    application: None,
+                    filtered_query_params: vec!["c".to_string()],
+                    revision: None,
+                },
+                "7c8801d0596be5e8f9449d5c4af23866c72fe5205119c0e5912981f3b16a37aa",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::URLBased {
+                    url: "https://example.com/file.txt?k=a b&m=x*y&n=c~d".to_string(),
+                    piece_length: Some(1024_u64),
+                    tag: None,
+                    application: None,
+                    filtered_query_params: vec!["none".to_string()],
+                    revision: None,
+                },
+                "6196a6846023f6d3c1e4d30f6c86f3d4186e4c664a33e5692b0e04e49b26a9af",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::URLBased {
+                    url: "https://example.com/file.txt?a=1&b=2".to_string(),
+                    piece_length: None,
+                    tag: Some("foo".to_string()),
+                    application: None,
+                    filtered_query_params: vec!["a".to_string(), "b".to_string()],
+                    revision: None,
+                },
+                "c8f4b41117329d54af920010394f6f607bac707e933ab2f18d372e3dd4c7fcb3",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::URLBased {
+                    url: "https://example.com/file.txt?b=2&a=1".to_string(),
+                    piece_length: None,
+                    tag: None,
+                    application: None,
+                    filtered_query_params: vec![],
+                    revision: None,
+                },
+                "980ee327518ccc5a7c30703e1a2232e8ba9047b39431f940636c85b6146f8b9a",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::URLBased {
                     url: "https://example.com".to_string(),
                     piece_length: None,
                     tag: None,
@@ -453,16 +488,43 @@ mod tests {
             (
                 IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
                 TaskIDParameter::BlobDigestBased(
-                    "https://registry.example.com/v2/myorg/myrepo/blobs/sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                    "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"
                         .to_string(),
                 ),
-                "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::BlobDigestBased(
+                    "https://registry.example.com/v2/myorg/myrepo/blobs/sha512:94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8"
+                        .to_string(),
+                ),
+                "94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8",
+            ),
+            (
+                IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false),
+                TaskIDParameter::BlobDigestBased(
+                    "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io"
+                        .to_string(),
+                ),
+                "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
             ),
         ];
 
         for (generator, parameter, expected_id) in test_cases {
             let task_id = generator.task_id(parameter).unwrap();
             assert_eq!(task_id, expected_id);
+        }
+
+        let generator = IDGenerator::new("127.0.0.1".to_string(), "localhost".to_string(), false);
+        for url in [
+            "https://example.com/file.txt",
+            "http://registry.example.com/v2/library/ubuntu/blobs/sha256:abc",
+            "http://registry.example.com/v2/library/ubuntu/blobs/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+        ] {
+            assert!(generator
+                .task_id(TaskIDParameter::BlobDigestBased(url.to_string()))
+                .is_err());
         }
     }
 

--- a/dragonfly-client-util/src/lib.rs
+++ b/dragonfly-client-util/src/lib.rs
@@ -28,6 +28,7 @@ pub mod shutdown;
 pub mod sysinfo;
 pub mod tls;
 pub mod types;
+pub mod url;
 
 #[cfg(target_os = "linux")]
 pub mod cgroups;

--- a/dragonfly-client-util/src/url/mod.rs
+++ b/dragonfly-client-util/src/url/mod.rs
@@ -1,0 +1,146 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dragonfly_client_core::{
+    error::{ErrorType, OrErr},
+    Result,
+};
+use percent_encoding::percent_encode_byte;
+use url::{form_urlencoded, Url};
+
+/// Escapes the string so it can be safely placed inside a url query, identical
+/// to the scheduler's query escaping (Go's url.QueryEscape). Mirrors the byte
+/// serializer of form_urlencoded with the unreserved characters of Go.
+fn query_escape(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for &byte in s.as_bytes() {
+        match byte {
+            b'-' | b'.' | b'0'..=b'9' | b'A'..=b'Z' | b'_' | b'a'..=b'z' | b'~' => {
+                escaped.push(byte as char)
+            }
+            b' ' => escaped.push('+'),
+            _ => escaped.push_str(percent_encode_byte(byte)),
+        }
+    }
+
+    escaped
+}
+
+/// Filters and sorts the query parameters by key to canonicalize the url,
+/// identical to the scheduler. The values of the same key keep the original order.
+pub fn filter_query_params(url: &str, filtered_query_params: &[String]) -> Result<String> {
+    if filtered_query_params.is_empty() {
+        return Ok(url.to_string());
+    }
+
+    let mut url = Url::parse(url).or_err(ErrorType::ParseError)?;
+    let mut query_pairs: Vec<(String, String)> = url
+        .query()
+        .unwrap_or_default()
+        .split('&')
+        .filter(|segment| !segment.contains(';'))
+        .flat_map(|segment| form_urlencoded::parse(segment.as_bytes()))
+        .filter(|(k, _)| {
+            !filtered_query_params
+                .iter()
+                .any(|param| param.as_str() == k.as_ref())
+        })
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+    query_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    if query_pairs.is_empty() {
+        url.set_query(None);
+    } else {
+        let query = query_pairs
+            .iter()
+            .map(|(k, v)| format!("{}={}", query_escape(k), query_escape(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+        url.set_query(Some(&query));
+    }
+
+    let filtered = url.to_string();
+    if url.path() == "/" && filtered.ends_with('/') {
+        return Ok(filtered.trim_end_matches('/').to_string());
+    }
+
+    Ok(filtered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_escape_query() {
+        assert_eq!(query_escape("a b"), "a+b");
+        assert_eq!(query_escape("x*y"), "x%2Ay");
+        assert_eq!(query_escape("c~d"), "c~d");
+        assert_eq!(query_escape("1+1"), "1%2B1");
+        assert_eq!(query_escape("中"), "%E4%B8%AD");
+    }
+
+    #[test]
+    fn should_filter_query_params() {
+        let test_cases = vec![
+            (
+                "https://example.com/file.txt?z=9&b=2&a=1",
+                vec!["z".to_string()],
+                "https://example.com/file.txt?a=1&b=2",
+            ),
+            (
+                "https://example.com/file.txt?b=2&a=1&b=1",
+                vec!["c".to_string()],
+                "https://example.com/file.txt?a=1&b=2&b=1",
+            ),
+            (
+                "https://example.com?foo=foo",
+                vec!["foo".to_string()],
+                "https://example.com",
+            ),
+            (
+                "https://example.com/file.txt?k=a b&m=x*y&n=c~d",
+                vec!["none".to_string()],
+                "https://example.com/file.txt?k=a+b&m=x%2Ay&n=c~d",
+            ),
+            (
+                "http://www.xx.yy/path?u=f&x=y&m=z&x=s#size",
+                vec!["x".to_string(), "m".to_string()],
+                "http://www.xx.yy/path?u=f#size",
+            ),
+            (
+                "http://www.xx.yy/path?u=f&x=y&m=z&x=s#size",
+                vec![],
+                "http://www.xx.yy/path?u=f&x=y&m=z&x=s#size",
+            ),
+            (
+                "https://example.com/file.txt?a=1;x&b=2",
+                vec!["none".to_string()],
+                "https://example.com/file.txt?b=2",
+            ),
+        ];
+
+        for (url, filtered_query_params, expected) in test_cases {
+            assert_eq!(
+                filter_query_params(url, &filtered_query_params).unwrap(),
+                expected
+            );
+        }
+
+        assert!(filter_query_params(":error_url", &["x".to_string()]).is_err());
+    }
+}


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

Extract query parameter filtering into a shared `url::filter_query_params` utility that sorts remaining params by key and escapes values using Go-compatible `url.QueryEscape` semantics, ensuring task IDs generated by the client match those produced by the scheduler.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
