### PR TITLE
chore: release v1.5.3 with scheduling policy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.3.1"
+version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547ab7dcb66a4ea98cd267fbe9e19f3cb52991580bf3bcd766a889a317001902"
+checksum = "26b44fcddaa294d75750a706dfe2f5b817c1a2d263e87434c8631d8bed806ec2"
 dependencies = [
  "prost 0.14.4",
  "prost-types",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1403,11 +1403,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bytesize",
  "bytesize-serde",
  "clap",
+ "dragonfly-api",
  "dragonfly-client-core",
  "dragonfly-client-util",
  "home",
@@ -1432,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "cgroups-rs",
  "http",
@@ -1452,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1469,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bytes",
  "dragonfly-api",
@@ -1520,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -1555,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2090,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.2"
+version = "1.5.3"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -33,15 +33,15 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
-dragonfly-api = "=2.3.1"
-dragonfly-client = { path = "dragonfly-client", version = "1.5.2" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.2" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.2" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.2" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.2" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.2" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.2" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.2" }
+dragonfly-api = "=2.3.5"
+dragonfly-client = { path = "dragonfly-client", version = "1.5.3" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.3" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.3" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.3" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.3" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.3" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.3" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.3" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client-config/Cargo.toml
+++ b/dragonfly-client-config/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 build = "build.rs"
 
 [dependencies]
+dragonfly-api.workspace = true
 dragonfly-client-core.workspace = true
 dragonfly-client-util.workspace = true
 local-ip-address.workspace = true

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -1300,6 +1300,33 @@ impl ProxyServer {
     }
 }
 
+/// SchedulingPolicy represents how the download interacts with the scheduler.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SchedulingPolicy {
+    /// Auto downloads through the scheduler unless the content length is smaller
+    /// than the minimum piece length, in which case it downloads from the source
+    /// directly, skipping the scheduler.
+    #[default]
+    Auto,
+
+    /// Always downloads through the scheduler even if the content length is smaller
+    /// than the minimum piece length, so that the peer announces the task to the
+    /// scheduler and other peers can discover it as a parent. It is useful for
+    /// sharing small artifacts, such as OCI image manifests.
+    Always,
+}
+
+/// Implement From<SchedulingPolicy> for the scheduling policy of the download.
+impl From<SchedulingPolicy> for dragonfly_api::common::v2::SchedulingPolicy {
+    fn from(policy: SchedulingPolicy) -> Self {
+        match policy {
+            SchedulingPolicy::Auto => dragonfly_api::common::v2::SchedulingPolicy::Auto,
+            SchedulingPolicy::Always => dragonfly_api::common::v2::SchedulingPolicy::Always,
+        }
+    }
+}
+
 /// The proxy rule configuration.
 #[derive(Debug, Clone, Validate, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1322,6 +1349,12 @@ pub struct Rule {
     /// Default value includes the filtered query params of s3, gcs, oss, obs, cos.
     #[serde(default = "default_proxy_rule_filtered_query_params")]
     pub filtered_query_params: Vec<String>,
+
+    /// Represents how the download interacts with the scheduler, default is auto.
+    /// Auto downloads small files from the source directly, skipping the scheduler.
+    /// Always downloads through the scheduler even for small files, so that the peer
+    /// announces the task to the scheduler and other peers can discover it as a parent.
+    pub scheduling_policy: SchedulingPolicy,
 }
 
 /// Implement Default for Rule.
@@ -1332,6 +1365,7 @@ impl Default for Rule {
             use_tls: false,
             redirect: None,
             filtered_query_params: default_proxy_rule_filtered_query_params(),
+            scheduling_policy: SchedulingPolicy::default(),
         }
     }
 }
@@ -2053,6 +2087,26 @@ mod tests {
         assert!(result.is_ok());
         let config = result.unwrap();
         assert!(config.is_some());
+    }
+
+    #[test]
+    fn deserialize_proxy_rule_correctly() {
+        let yaml = r#"
+regex: 'manifests/sha256:.*'
+schedulingPolicy: always
+"#;
+
+        let rule: Rule = serde_yaml::from_str(yaml).expect("Failed to deserialize");
+        assert!(rule.regex.is_match("https://example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"));
+        assert_eq!(rule.scheduling_policy, SchedulingPolicy::Always);
+
+        let yaml = r#"
+regex: 'blobs/sha256.*'
+"#;
+
+        let rule: Rule = serde_yaml::from_str(yaml).expect("Failed to deserialize");
+        assert_eq!(rule.scheduling_policy, SchedulingPolicy::Auto);
+        assert_eq!(Rule::default().scheduling_policy, SchedulingPolicy::Auto);
     }
 
     #[test]

--- a/dragonfly-client-util/src/types/redacted.rs
+++ b/dragonfly-client-util/src/types/redacted.rs
@@ -83,6 +83,7 @@ impl fmt::Debug for RedactedDownload<'_> {
             timeout: _,
             disable_back_to_source: _,
             need_back_to_source: _,
+            scheduling_policy: _,
             certificate_chain: _,
             need_piece_content: _,
             force_hard_link: _,

--- a/dragonfly-client/src/bin/dfget/main.rs
+++ b/dragonfly-client/src/bin/dfget/main.rs
@@ -17,7 +17,7 @@
 use bytesize::ByteSize;
 use clap::Parser;
 use dragonfly_api::common::v2::{
-    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, TaskType,
+    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, SchedulingPolicy, TaskType,
 };
 use dragonfly_api::dfdaemon::v2::{
     download_task_response, DownloadTaskRequest, ListTaskEntriesRequest,
@@ -263,6 +263,15 @@ struct Args {
         help = "Disable back-to-source download when dfget download failed"
     )]
     disable_back_to_source: bool,
+
+    #[arg(
+        long = "scheduling-policy",
+        default_value = "auto",
+        value_parser = ["auto", "always"],
+        env = "DFGET_SCHEDULING_POLICY",
+        help = "Specify how the download interacts with the scheduler, 'auto' downloads small files from the source directly, 'always' downloads through the scheduler even for small files, so the peer announces the task and other peers can discover it as a parent"
+    )]
+    scheduling_policy: String,
 
     #[arg(
         long,
@@ -964,6 +973,11 @@ async fn download(
                         .or_err(ErrorType::ParseError)?,
                 ),
                 need_back_to_source: false,
+                scheduling_policy: if args.scheduling_policy.eq_ignore_ascii_case("always") {
+                    SchedulingPolicy::Always as i32
+                } else {
+                    SchedulingPolicy::Auto as i32
+                },
                 disable_back_to_source: args.disable_back_to_source,
                 certificate_chain: Vec::new(),
                 prefetch: false,

--- a/dragonfly-client/src/proxy/header.rs
+++ b/dragonfly-client/src/proxy/header.rs
@@ -15,7 +15,7 @@
  */
 
 use bytesize::ByteSize;
-use dragonfly_api::common::v2::Priority;
+use dragonfly_api::common::v2::{Priority, SchedulingPolicy};
 use reqwest::header::HeaderMap;
 use std::{fmt, str::FromStr};
 use tracing::error;
@@ -87,6 +87,14 @@ pub const DRAGONFLY_CONTENT_FOR_CALCULATING_TASK_ID_HEADER: &str =
 /// registries shares one task ID, eliminating redundant downloads and storage.
 pub const DRAGONFLY_ENABLE_TASK_ID_BASED_BLOB_DIGEST: &str =
     "X-Dragonfly-Enable-Task-ID-Based-Blob-Digest";
+
+/// The header key of scheduling policy. It represents how the download interacts
+/// with the scheduler. The value is case-insensitive, e.g. "auto" or "always".
+/// "auto" downloads small files from the source directly, skipping the scheduler.
+/// "always" downloads through the scheduler even if the content length is smaller
+/// than the minimum piece length, so that the peer announces the task to the
+/// scheduler and other peers can discover it as a parent.
+pub const DRAGONFLY_SCHEDULING_POLICY_HEADER: &str = "X-Dragonfly-Scheduling-Policy";
 
 /// The response header key to indicate whether the task download finished.
 /// When the task download is finished, the response will include this header with the value `"true"`,
@@ -322,6 +330,26 @@ pub fn get_enable_task_id_based_blob_digest(header: &HeaderMap, default: bool) -
     }
 }
 
+/// Get X-Dragonfly-Scheduling-Policy header value to determine how the download
+/// interacts with the scheduler.
+pub fn get_scheduling_policy(header: &HeaderMap, default: SchedulingPolicy) -> SchedulingPolicy {
+    match header.get(DRAGONFLY_SCHEDULING_POLICY_HEADER) {
+        Some(value) => match value.to_str() {
+            Ok(value) if value.eq_ignore_ascii_case("auto") => SchedulingPolicy::Auto,
+            Ok(value) if value.eq_ignore_ascii_case("always") => SchedulingPolicy::Always,
+            Ok(value) => {
+                error!("invalid scheduling policy from header: {}", value);
+                default
+            }
+            Err(err) => {
+                error!("get scheduling policy from header failed: {}", err);
+                default
+            }
+        },
+        None => default,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -516,5 +544,48 @@ mod tests {
         let empty_headers = HeaderMap::new();
         assert!(get_enable_task_id_based_blob_digest(&empty_headers, true));
         assert!(!get_enable_task_id_based_blob_digest(&empty_headers, false));
+    }
+
+    #[test]
+    fn test_get_scheduling_policy() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DRAGONFLY_SCHEDULING_POLICY_HEADER,
+            HeaderValue::from_static("always"),
+        );
+        assert_eq!(
+            get_scheduling_policy(&headers, SchedulingPolicy::Auto),
+            SchedulingPolicy::Always
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DRAGONFLY_SCHEDULING_POLICY_HEADER,
+            HeaderValue::from_static("AUTO"),
+        );
+        assert_eq!(
+            get_scheduling_policy(&headers, SchedulingPolicy::Always),
+            SchedulingPolicy::Auto
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DRAGONFLY_SCHEDULING_POLICY_HEADER,
+            HeaderValue::from_static("invalid"),
+        );
+        assert_eq!(
+            get_scheduling_policy(&headers, SchedulingPolicy::Always),
+            SchedulingPolicy::Always
+        );
+
+        let empty_headers = HeaderMap::new();
+        assert_eq!(
+            get_scheduling_policy(&empty_headers, SchedulingPolicy::Always),
+            SchedulingPolicy::Always
+        );
+        assert_eq!(
+            get_scheduling_policy(&empty_headers, SchedulingPolicy::Auto),
+            SchedulingPolicy::Auto
+        );
     }
 }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -1304,6 +1304,8 @@ fn make_download_task_request(
             output_path: header::get_output_path(header),
             timeout: None,
             need_back_to_source: false,
+            scheduling_policy: header::get_scheduling_policy(header, rule.scheduling_policy.into())
+                as i32,
             disable_back_to_source: config.proxy.disable_back_to_source,
             certificate_chain: Vec::new(),
             prefetch: need_prefetch(&config, header),

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -17,7 +17,7 @@
 use crate::grpc::{scheduler::SchedulerClient, REQUEST_TIMEOUT};
 use crate::resource::parent_selector::ParentSelector;
 use dragonfly_api::common::v2::{
-    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, Peer, Piece,
+    Download, Hdfs, HuggingFace, ModelScope, ObjectStorage, OpenCsg, Peer, Piece, SchedulingPolicy,
     Task as CommonTask, TrafficType,
 };
 use dragonfly_api::dfdaemon::{
@@ -336,6 +336,28 @@ impl Task {
         self.storage.copy_task(id, to).await
     }
 
+    /// Returns whether the download should bypass the scheduler and download the
+    /// pieces from the source directly. It returns true only if all of the
+    /// following conditions are met:
+    ///
+    /// 1. The scheduling policy is AUTO, which decides by the size heuristic below.
+    ///    If the policy is ALWAYS, the download always goes through the scheduler,
+    ///    so that the peer announces the task to the scheduler and other peers can
+    ///    discover it as a parent.
+    /// 2. The back-to-source download is allowed, since bypassing the scheduler
+    ///    downloads from the source directly.
+    /// 3. The task is small enough that the scheduling overhead outweighs the
+    ///    transfer: the requested range length or the content length is less than
+    ///    or equal to the min piece length, i.e. a single-piece task.
+    fn should_bypass_scheduler(&self, request: &Download, content_length: u64) -> bool {
+        request.scheduling_policy() == SchedulingPolicy::Auto
+            && !request.disable_back_to_source
+            && (request
+                .range
+                .is_some_and(|range| range.length <= piece::MIN_PIECE_LENGTH)
+                || content_length <= piece::MIN_PIECE_LENGTH)
+    }
+
     /// Downloads a task.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
@@ -510,14 +532,9 @@ impl Task {
             interested_pieces
         };
 
-        // If the range length is less than or equal to the min piece
-        // length, download the pieces from the source directly.
-        if !request.disable_back_to_source
-            && (request
-                .range
-                .is_some_and(|range| range.length <= super::piece::MIN_PIECE_LENGTH)
-                || content_length <= super::piece::MIN_PIECE_LENGTH)
-        {
+        // Download the pieces from the source directly, skipping the scheduler,
+        // if the task is small enough and the scheduling policy allows it.
+        if self.should_bypass_scheduler(&request, content_length) {
             debug!("peer downloads the range task from source directly, skipping the scheduler");
 
             if let Err(err) = self


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump workspace version to 1.5.3 and dragonfly-api to 2.3.5. Introduce a `SchedulingPolicy` enum (`auto`/`always`) that controls whether small downloads bypass the scheduler. `auto` preserves existing behaviour; `always` forces scheduler registration so other peers can discover the task as a parent. The policy is configurable per proxy rule, via the `X-Dragonfly-Scheduling-Policy` request header, and via the `--scheduling-policy` dfget flag.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
