### PR TITLE
feat: add per-piece download duration metric split by traffic type

### DIFF
--- a/dragonfly-client-metric/src/lib.rs
+++ b/dragonfly-client-metric/src/lib.rs
@@ -215,6 +215,21 @@ pub static DOWNLOAD_TRAFFIC: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("metric can be created")
 });
 
+/// Used to record the download piece duration.
+pub static DOWNLOAD_PIECE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "download_piece_duration_milliseconds",
+            "Histogram of the download piece duration.",
+        )
+        .namespace(dragonfly_client_config::SERVICE_NAME)
+        .subsystem(dragonfly_client_config::NAME)
+        .buckets(exponential_buckets(1.0, 2.0, 24).unwrap()),
+        &["type"],
+    )
+    .expect("metric can be created")
+});
+
 /// Used to count the upload traffic.
 pub static UPLOAD_TRAFFIC: LazyLock<IntCounterVec> = LazyLock::new(|| {
     IntCounterVec::new(
@@ -638,6 +653,10 @@ fn register_custom_metrics() {
         .expect("metric can be registered");
 
     REGISTRY
+        .register(Box::new(DOWNLOAD_PIECE_DURATION.clone()))
+        .expect("metric can be registered");
+
+    REGISTRY
         .register(Box::new(UPLOAD_TRAFFIC.clone()))
         .expect("metric can be registered");
 
@@ -752,6 +771,7 @@ fn reset_custom_metrics() {
     CONCURRENT_DOWNLOAD_TASK_GAUGE.reset();
     CONCURRENT_UPLOAD_PIECE_GAUGE.reset();
     DOWNLOAD_TRAFFIC.reset();
+    DOWNLOAD_PIECE_DURATION.reset();
     UPLOAD_TRAFFIC.reset();
     DOWNLOAD_TASK_DURATION.reset();
     BACKEND_REQUEST_COUNT.reset();
@@ -1049,6 +1069,13 @@ pub fn collect_download_piece_traffic_metrics(typ: &TrafficType, length: u64) {
     DOWNLOAD_TRAFFIC
         .with_label_values(&[typ.as_str_name()])
         .inc_by(length);
+}
+
+/// Collects the download piece duration metrics.
+pub fn collect_download_piece_duration_metrics(typ: &TrafficType, cost: Duration) {
+    DOWNLOAD_PIECE_DURATION
+        .with_label_values(&[typ.as_str_name()])
+        .observe(cost.as_millis() as f64);
 }
 
 /// Collects the upload piece started metrics.
@@ -1688,6 +1715,17 @@ mod tests {
             .with_label_values(&[traffic_type.as_str_name()])
             .get();
         assert!(traffic >= 2048);
+    }
+
+    #[test]
+    fn test_collect_download_piece_duration_metrics() {
+        let traffic_type = TrafficType::RemotePeer;
+        collect_download_piece_duration_metrics(&traffic_type, Duration::from_millis(42));
+
+        let count = DOWNLOAD_PIECE_DURATION
+            .with_label_values(&[traffic_type.as_str_name()])
+            .get_sample_count();
+        assert!(count >= 1);
     }
 
     #[test]

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -338,9 +338,9 @@ impl Piece {
 
         // Record the start time.
         let start_time = Instant::now();
+
         // Upload the piece content.
         let (_, reader) = self.storage.upload_piece(piece_id, task_id, range).await?;
-
         collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
 
         Ok(reader)
@@ -404,7 +404,6 @@ impl Piece {
 
         // Record the start time.
         let start_time = Instant::now();
-
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -452,9 +451,6 @@ impl Piece {
             }
         };
 
-        // Collect the download piece duration metrics.
-        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
-
         // Record the finish of downloading piece.
         match self
             .storage
@@ -472,6 +468,10 @@ impl Piece {
         {
             Ok(piece) => {
                 collect_download_piece_traffic_metrics(&TrafficType::RemotePeer, length);
+                collect_download_piece_duration_metrics(
+                    &TrafficType::RemotePeer,
+                    start_time.elapsed(),
+                );
 
                 scopeguard::ScopeGuard::into_inner(guard);
                 Ok(piece)
@@ -618,9 +618,6 @@ impl Piece {
             start_time.elapsed(),
         );
 
-        // Collect the download piece duration metrics.
-        collect_download_piece_duration_metrics(&TrafficType::BackToSource, start_time.elapsed());
-
         let mut stream = response.reader.into_inner();
         match self
             .storage
@@ -636,6 +633,10 @@ impl Piece {
         {
             Ok(piece) => {
                 collect_download_piece_traffic_metrics(&TrafficType::BackToSource, length);
+                collect_download_piece_duration_metrics(
+                    &TrafficType::BackToSource,
+                    start_time.elapsed(),
+                );
 
                 scopeguard::ScopeGuard::into_inner(guard);
                 Ok(piece)
@@ -701,6 +702,7 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
+        // Record the start time.
         let start_time = Instant::now();
 
         // Upload the piece content.
@@ -708,8 +710,6 @@ impl Piece {
             .storage
             .upload_persistent_piece(piece_id, task_id, range)
             .await?;
-
-        // Collect the download piece duration metrics.
         collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
 
         Ok(reader)
@@ -767,8 +767,8 @@ impl Piece {
             };
         });
 
+        // Record the start time.
         let start_time = Instant::now();
-
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -816,8 +816,6 @@ impl Piece {
             }
         };
 
-        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
-
         // Record the finish of downloading piece.
         match self
             .storage
@@ -834,6 +832,10 @@ impl Piece {
         {
             Ok(piece) => {
                 collect_download_piece_traffic_metrics(&TrafficType::RemotePeer, length);
+                collect_download_piece_duration_metrics(
+                    &TrafficType::RemotePeer,
+                    start_time.elapsed(),
+                );
 
                 scopeguard::ScopeGuard::into_inner(guard);
                 Ok(piece)
@@ -975,9 +977,6 @@ impl Piece {
             start_time.elapsed(),
         );
 
-        // Collect the download piece duration metrics.
-        collect_download_piece_duration_metrics(&TrafficType::BackToSource, start_time.elapsed());
-
         // Record the finish of downloading piece. Consumes the stream of
         // bytes chunks underlying the reader, so the chunks are written to
         // the storage without copying.
@@ -996,6 +995,10 @@ impl Piece {
         {
             Ok(piece) => {
                 collect_download_piece_traffic_metrics(&TrafficType::BackToSource, length);
+                collect_download_piece_duration_metrics(
+                    &TrafficType::BackToSource,
+                    start_time.elapsed(),
+                );
 
                 scopeguard::ScopeGuard::into_inner(guard);
                 Ok(piece)
@@ -1061,6 +1064,7 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
+        // Record the start time.
         let start_time = Instant::now();
 
         // Upload the piece content.
@@ -1068,8 +1072,6 @@ impl Piece {
             .storage
             .upload_persistent_cache_piece(piece_id, task_id, range)
             .await?;
-
-        // Collect the download piece duration metrics.
         collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
 
         Ok(reader)
@@ -1127,8 +1129,8 @@ impl Piece {
             };
         });
 
+        // Record the start time.
         let start_time = Instant::now();
-
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -1176,8 +1178,6 @@ impl Piece {
             }
         };
 
-        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
-
         // Record the finish of downloading piece.
         match self
             .storage
@@ -1194,6 +1194,10 @@ impl Piece {
         {
             Ok(piece) => {
                 collect_download_piece_traffic_metrics(&TrafficType::RemotePeer, length);
+                collect_download_piece_duration_metrics(
+                    &TrafficType::RemotePeer,
+                    start_time.elapsed(),
+                );
 
                 scopeguard::ScopeGuard::into_inner(guard);
                 Ok(piece)

--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -24,7 +24,8 @@ use dragonfly_client_config::dfdaemon::Config;
 use dragonfly_client_core::{error::BackendError, Error, Result};
 use dragonfly_client_metric::{
     collect_backend_request_failure_metrics, collect_backend_request_finished_metrics,
-    collect_backend_request_started_metrics, collect_download_piece_traffic_metrics,
+    collect_backend_request_started_metrics, collect_download_piece_duration_metrics,
+    collect_download_piece_traffic_metrics,
 };
 use dragonfly_client_storage::{io::RangeReader, metadata, Storage};
 use dragonfly_client_util::net::format_socket_addr;
@@ -335,8 +336,13 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
+        // Record the start time.
+        let start_time = Instant::now();
         // Upload the piece content.
         let (_, reader) = self.storage.upload_piece(piece_id, task_id, range).await?;
+
+        collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
+
         Ok(reader)
     }
 
@@ -396,6 +402,9 @@ impl Piece {
             .acquire(length as usize)
             .await;
 
+        // Record the start time.
+        let start_time = Instant::now();
+
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -442,6 +451,9 @@ impl Piece {
                     })?
             }
         };
+
+        // Collect the download piece duration metrics.
+        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
 
         // Record the finish of downloading piece.
         match self
@@ -606,6 +618,9 @@ impl Piece {
             start_time.elapsed(),
         );
 
+        // Collect the download piece duration metrics.
+        collect_download_piece_duration_metrics(&TrafficType::BackToSource, start_time.elapsed());
+
         let mut stream = response.reader.into_inner();
         match self
             .storage
@@ -686,11 +701,17 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
+        let start_time = Instant::now();
+
         // Upload the piece content.
         let (_, reader) = self
             .storage
             .upload_persistent_piece(piece_id, task_id, range)
             .await?;
+
+        // Collect the download piece duration metrics.
+        collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
+
         Ok(reader)
     }
 
@@ -746,6 +767,8 @@ impl Piece {
             };
         });
 
+        let start_time = Instant::now();
+
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -792,6 +815,8 @@ impl Piece {
                     })?
             }
         };
+
+        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
 
         // Record the finish of downloading piece.
         match self
@@ -950,6 +975,9 @@ impl Piece {
             start_time.elapsed(),
         );
 
+        // Collect the download piece duration metrics.
+        collect_download_piece_duration_metrics(&TrafficType::BackToSource, start_time.elapsed());
+
         // Record the finish of downloading piece. Consumes the stream of
         // bytes chunks underlying the reader, so the chunks are written to
         // the storage without copying.
@@ -1033,11 +1061,17 @@ impl Piece {
         Span::current().record("piece_id", piece_id);
         Span::current().record("piece_length", length);
 
+        let start_time = Instant::now();
+
         // Upload the piece content.
         let (_, reader) = self
             .storage
             .upload_persistent_cache_piece(piece_id, task_id, range)
             .await?;
+
+        // Collect the download piece duration metrics.
+        collect_download_piece_duration_metrics(&TrafficType::LocalPeer, start_time.elapsed());
+
         Ok(reader)
     }
 
@@ -1093,6 +1127,8 @@ impl Piece {
             };
         });
 
+        let start_time = Instant::now();
+
         let (mut stream, offset, digest) = match (
             self.config.download.protocol.as_str(),
             parent.download_ip,
@@ -1139,6 +1175,8 @@ impl Piece {
                     })?
             }
         };
+
+        collect_download_piece_duration_metrics(&TrafficType::RemotePeer, start_time.elapsed());
 
         // Record the finish of downloading piece.
         match self


### PR DESCRIPTION
## Description

Adds a new download_piece_duration_milliseconds histogram, labeled by type (LOCAL_PEER, REMOTE_PEER, BACK_TO_SOURCE), that records how long each piece download takes broken out by traffic source.

Currently, download_task_duration_milliseconds only reports latency at the whole-task level, and its task_type label reflects the TaskType enum (STANDARD/PERSISTENT/PERSISTENT_CACHE/CACHE) rather than where the data came from. There is no existing metric that lets you compare p2p latency against back-to-source latency against local-cache latency — this PR adds one.

Changes:

- dragonfly-client-metric/src/lib.rs: adds the DOWNLOAD_PIECE_DURATION histogram (registered and reset alongside the other custom metrics), a collect_download_piece_duration_metrics helper, and a unit test.
- dragonfly-client/src/resource/piece.rs: records the new metric in every piece-download code path that does real I/O:
  - download_from_local_into_range_reader / download_persistent_from_local_into_async_read / download_persistent_cache_from_local_into_async_read → LOCAL_PEER
  - download_from_parent / download_persistent_from_parent / download_persistent_cache_from_parent → REMOTE_PEER
  - download_from_source / download_persistent_from_source → BACK_TO_SOURCE (reuses the start_time already captured for backend_request_duration_milliseconds, so both metrics measure the identical window)

The stub functions that only tally traffic bytes for an already-completed local-cache hit (download_from_local, download_persistent_from_local, download_persistent_cache_from_local) are intentionally left untouched — they do no real I/O, so there's nothing meaningful to time there.

In every case, the timer starts immediately before the network/storage call being measured and stops immediately after, excluding rate-limiter waits and unrelated bookkeeping (piece-started/failed storage calls), so all three traffic types are measured over a comparable window.

## Related Issue

https://github.com/dragonflyoss/client/issues/2016

## Motivation and Context

We wanted a Grafana panel showing download latency split by p2p vs. back-to-source vs. local-cache for our Dragonfly client fleet. The existing task_type label on download_task_duration_milliseconds looked like it should provide this, but it's actually the TaskType enum (standard/persistent/cache) and is constant across normal workloads, so it can't answer that question. The traffic-source distinction (TrafficType) already exists on the byte-counter metric (download_traffic) but had no corresponding duration metric. This PR closes that gap without touching any existing metric's behavior.

## Screenshots (if appropriate)
