### PR TITLE
feat(digest): support manifest digest-based task IDs for OCI manifest URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,9 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfad171928d9de122a2ddb484ed474d7e5ecceb94898a6c897cf44cb256346be"
+version = "1.6.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1502,6 +1500,7 @@ dependencies = [
  "local-ip-address",
  "oci-client",
  "oci-spec",
+ "percent-encoding",
  "prost-wkt-types",
  "rand 0.9.4",
  "regex",
@@ -5808,9 +5807,9 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,8 @@ dependencies = [
 [[package]]
 name = "dragonfly-client-request"
 version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1379d1f7ea6a83a7525cef4f4c82ec9a423f13ba220b9d97a531cfcece0d29"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ tokio-stream = "0.1.18"
 tokio-util = { version = "0.7.18", features = ["full"] }
 toml = "0.8.23"
 toml_edit = "0.25.12"
-tonic = { version = "=0.14.2", features = ["tls-aws-lc"] }
+tonic = { version = "=0.14.6", features = ["tls-aws-lc"] }
 tonic-health = "=0.14.5"
 tonic-reflection = "=0.14.5"
 tracing = "0.1"

--- a/dragonfly-client-util/src/digest/mod.rs
+++ b/dragonfly-client-util/src/digest/mod.rs
@@ -36,6 +36,17 @@ pub fn is_blob_url(url: &str) -> bool {
     BLOB_URL_REGEX.is_match(url)
 }
 
+/// Regex pattern for OCI manifest URLs, e.g. http(s)://<registry>/v2/<repository>/manifests/<reference>.
+static MANIFEST_URL_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(.*)://(.*)/v2/(.*)/manifests/([^?]+)(?:\?.*)?$").unwrap());
+
+/// Checks if the URL is an OCI manifest URL whose reference is a digest with a
+/// supported algorithm. A manifest URL referenced by a tag returns false, so it
+/// falls back to the url based task id.
+pub fn is_manifest_digest_url(url: &str) -> bool {
+    Digest::extract_from_manifest_url(url).is_some()
+}
+
 /// Algorithm for generating digests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Algorithm {
@@ -102,6 +113,16 @@ impl Digest {
             .ok()
     }
 
+    /// Extracts the digest from an OCI manifest URL, e.g. http(s)://<registry>/v2/<repository>/manifests/<digest>.
+    pub fn extract_from_manifest_url(url: &str) -> Option<Self> {
+        MANIFEST_URL_REGEX
+            .captures(url)
+            .and_then(|caps| caps.get(4))
+            .map(|m| m.as_str())?
+            .parse()
+            .ok()
+    }
+
     /// Returns the algorithm of the digest.
     pub fn algorithm(&self) -> Algorithm {
         self.algorithm
@@ -134,11 +155,8 @@ impl FromStr for Digest {
 
         let algorithm = match parts[0] {
             "crc32" => {
-                if parts[1].len() != 10 {
-                    return Err(format!(
-                        "invalid crc32 digest length: {}, expected 10",
-                        parts[1].len()
-                    ));
+                if parts[1].is_empty() {
+                    return Err(format!("invalid crc32 digest: {s}"));
                 }
 
                 Algorithm::Crc32
@@ -230,91 +248,170 @@ mod tests {
 
     #[test]
     fn test_extract_from_blob_url() {
-        let url = "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-        let digest = digest.unwrap();
-        assert_eq!(digest.algorithm(), Algorithm::Sha256);
-        assert_eq!(
-            digest.encoded(),
-            "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"
-        );
-
-        let url = "https://registry.example.com/v2/myorg/myrepo/blobs/sha512:94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-        let digest = digest.unwrap();
-        assert_eq!(digest.algorithm(), Algorithm::Sha512);
-        assert_eq!(digest.encoded(), "94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8");
-
-        let url = "https://registry.io/v2/org/team/project/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-
-        let url = "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-        let digest = digest.unwrap();
-        assert_eq!(digest.algorithm(), Algorithm::Sha256);
-        assert_eq!(
-            digest.encoded(),
-            "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"
-        );
-
-        let url = "https://index.docker.io/v2/library/alpine/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-        let digest = digest.unwrap();
-        assert_eq!(digest.algorithm(), Algorithm::Sha256);
-        assert_eq!(
-            digest.encoded(),
-            "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"
-        );
-
-        let url = "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?id=12345";
-        let digest = Digest::extract_from_blob_url(url);
-        assert!(digest.is_some());
-        let digest = digest.unwrap();
-        assert_eq!(digest.algorithm(), Algorithm::Sha256);
-        assert_eq!(
-            digest.encoded(),
-            "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e"
-        );
-
-        let invalid_urls = vec![
-            "http://registry.example.com/blobs/sha256:abc",
-            "http://registry.example.com/v2/repo/manifests/sha256:abc",
-            "registry.example.com/v2/repo/blobs/sha256:abc",
-            "http://registry.example.com/v2/blobs/sha256:abc",
-            "",
-            "not-a-url",
-            "http://registry.example.com/v2/repo/blobs/invalid-digest",
+        let test_cases = vec![
+            (
+                "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "https://registry.example.com/v2/myorg/myrepo/blobs/sha512:94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8",
+                Some((Algorithm::Sha512, "94381a28e8c039fedfa78de025158a068226c3ccd041b22c2c8e73fc993584e9b167d9ae32bc8b372c66701c808ab134e0768c8f16b9a3e61eec1ccf8faa9db8")),
+            ),
+            (
+                "https://registry.io/v2/org/team/project/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "https://index.docker.io/v2/library/alpine/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "http://localhost:5000/v2/myrepo/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?id=12345",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            ("http://registry.example.com/blobs/sha256:abc", None),
+            ("http://registry.example.com/v2/repo/manifests/sha256:abc", None),
+            ("registry.example.com/v2/repo/blobs/sha256:abc", None),
+            ("http://registry.example.com/v2/blobs/sha256:abc", None),
+            ("", None),
+            ("not-a-url", None),
+            ("http://registry.example.com/v2/repo/blobs/invalid-digest", None),
         ];
 
-        for url in invalid_urls {
-            assert!(Digest::extract_from_blob_url(url).is_none());
+        for (url, expected) in test_cases {
+            match expected {
+                Some((algorithm, encoded)) => {
+                    let digest = Digest::extract_from_blob_url(url).unwrap();
+                    assert_eq!(digest.algorithm(), algorithm);
+                    assert_eq!(digest.encoded(), encoded);
+                }
+                None => assert!(Digest::extract_from_blob_url(url).is_none()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_manifest_digest_url() {
+        let test_cases = vec![
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                true,
+            ),
+            (
+                "http://localhost:5000/v2/myrepo/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+                true,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/latest",
+                false,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+                false,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/sha256:abc",
+                false,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                false,
+            ),
+            ("https://example.com/file.txt", false),
+        ];
+
+        for (url, expected) in test_cases {
+            assert_eq!(is_manifest_digest_url(url), expected);
+        }
+    }
+
+    #[test]
+    fn test_extract_from_manifest_url() {
+        let test_cases = vec![
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "http://localhost:5000/v2/myrepo/manifests/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e?ns=docker.io",
+                Some((Algorithm::Sha256, "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e")),
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/latest",
+                None,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/sha256:abc",
+                None,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/manifests/md5:8a04994a666b4e4b20a2fd9e5a44f44c",
+                None,
+            ),
+            (
+                "http://registry.example.com/v2/library/ubuntu/blobs/sha256:b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                None,
+            ),
+            ("https://example.com/file.txt", None),
+        ];
+
+        for (url, expected) in test_cases {
+            match expected {
+                Some((algorithm, encoded)) => {
+                    let digest = Digest::extract_from_manifest_url(url).unwrap();
+                    assert_eq!(digest.algorithm(), algorithm);
+                    assert_eq!(digest.encoded(), encoded);
+                }
+                None => assert!(Digest::extract_from_manifest_url(url).is_none()),
+            }
         }
     }
 
     #[test]
     fn test_algorithm_display() {
-        assert_eq!(Algorithm::Crc32.to_string(), "crc32");
-        assert_eq!(Algorithm::Sha256.to_string(), "sha256");
-        assert_eq!(Algorithm::Sha512.to_string(), "sha512");
+        let test_cases = vec![
+            (Algorithm::Crc32, "crc32"),
+            (Algorithm::Sha256, "sha256"),
+            (Algorithm::Sha512, "sha512"),
+        ];
+
+        for (algorithm, expected) in test_cases {
+            assert_eq!(algorithm.to_string(), expected);
+        }
     }
 
     #[test]
     fn test_algorithm_from_str() {
-        assert_eq!("crc32".parse::<Algorithm>(), Ok(Algorithm::Crc32));
-        assert_eq!("sha256".parse::<Algorithm>(), Ok(Algorithm::Sha256));
-        assert_eq!("sha512".parse::<Algorithm>(), Ok(Algorithm::Sha512));
-        assert!("invalid".parse::<Algorithm>().is_err());
+        let test_cases = vec![
+            ("crc32", Some(Algorithm::Crc32)),
+            ("sha256", Some(Algorithm::Sha256)),
+            ("sha512", Some(Algorithm::Sha512)),
+            ("invalid", None),
+        ];
+
+        for (s, expected) in test_cases {
+            assert_eq!(s.parse::<Algorithm>().ok(), expected);
+        }
     }
 
     #[test]
     fn test_digest_display() {
-        let digest = Digest::new(Algorithm::Sha256, "encoded_hash".to_string());
-        assert_eq!(digest.to_string(), "sha256:encoded_hash");
+        let test_cases = vec![
+            (Algorithm::Crc32, "1475635037", "crc32:1475635037"),
+            (Algorithm::Sha256, "encoded_hash", "sha256:encoded_hash"),
+            (Algorithm::Sha512, "encoded_hash", "sha512:encoded_hash"),
+        ];
+
+        for (algorithm, encoded, expected) in test_cases {
+            assert_eq!(
+                Digest::new(algorithm, encoded.to_string()).to_string(),
+                expected
+            );
+        }
     }
 
     #[test]
@@ -325,20 +422,23 @@ mod tests {
         let mut file = File::create(path).expect("failed to create file");
         file.write_all(content).expect("failed to write to file");
 
-        let expected_sha256 = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72";
-        let digest = calculate_file_digest(Algorithm::Sha256, path)
-            .expect("failed to calculate Sha256 hash");
-        assert_eq!(digest.encoded(), expected_sha256);
+        let test_cases = vec![
+            (Algorithm::Crc32, "1475635037"),
+            (
+                Algorithm::Sha256,
+                "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72",
+            ),
+            (
+                Algorithm::Sha512,
+                "0cbf4caef38047bba9a24e621a961484e5d2a92176a859e7eb27df343dd34eb98d538a6c5f4da1ce302ec250b821cc001e46cc97a704988297185a4df7e99602",
+            ),
+        ];
 
-        let expected_sha512 = "0cbf4caef38047bba9a24e621a961484e5d2a92176a859e7eb27df343dd34eb98d538a6c5f4da1ce302ec250b821cc001e46cc97a704988297185a4df7e99602";
-        let digest = calculate_file_digest(Algorithm::Sha512, path)
-            .expect("failed to calculate Sha512 hash");
-        assert_eq!(digest.encoded(), expected_sha512);
-
-        let expected_crc32 = "1475635037";
-        let digest =
-            calculate_file_digest(Algorithm::Crc32, path).expect("failed to calculate Crc32 hash");
-        assert_eq!(digest.encoded(), expected_crc32);
+        for (algorithm, expected) in test_cases {
+            let digest =
+                calculate_file_digest(algorithm, path).expect("failed to calculate digest");
+            assert_eq!(digest.encoded(), expected);
+        }
     }
 
     #[test]
@@ -349,19 +449,30 @@ mod tests {
         let mut file = File::create(path).expect("failed to create file");
         file.write_all(content).expect("failed to write to file");
 
-        let expected_sha256_digest = Digest::new(
-            Algorithm::Sha256,
-            "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72".to_string(),
-        );
-        assert!(verify_file_digest(expected_sha256_digest, path).is_ok());
+        let test_cases = vec![
+            (Algorithm::Crc32, "1475635037", true),
+            (
+                Algorithm::Sha256,
+                "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72",
+                true,
+            ),
+            (
+                Algorithm::Sha512,
+                "0cbf4caef38047bba9a24e621a961484e5d2a92176a859e7eb27df343dd34eb98d538a6c5f4da1ce302ec250b821cc001e46cc97a704988297185a4df7e99602",
+                true,
+            ),
+            (
+                Algorithm::Sha256,
+                "b2c366cce7e68013d5441c6326d5a3e1b12aeb5ed58564d0fd3fa089bc29cb6e",
+                false,
+            ),
+        ];
 
-        let expected_sha512_digest = Digest::new(
-            Algorithm::Sha512,
-            "0cbf4caef38047bba9a24e621a961484e5d2a92176a859e7eb27df343dd34eb98d538a6c5f4da1ce302ec250b821cc001e46cc97a704988297185a4df7e99602".to_string(),
-        );
-        assert!(verify_file_digest(expected_sha512_digest, path).is_ok());
-
-        let expected_crc32_digest = Digest::new(Algorithm::Crc32, "1475635037".to_string());
-        assert!(verify_file_digest(expected_crc32_digest, path).is_ok());
+        for (algorithm, encoded, expected) in test_cases {
+            assert_eq!(
+                verify_file_digest(Digest::new(algorithm, encoded.to_string()), path).is_ok(),
+                expected
+            );
+        }
     }
 }

--- a/dragonfly-client-util/src/id_generator/mod.rs
+++ b/dragonfly-client-util/src/id_generator/mod.rs
@@ -45,6 +45,9 @@ pub enum TaskIDParameter {
     /// BlobDigestBased will extract the digest in the oci blob url and use the digest's encoded as
     /// the task id.
     BlobDigestBased(String),
+    /// ManifestDigestBased will extract the digest in the oci manifest url and use the digest's
+    /// encoded as the task id.
+    ManifestDigestBased(String),
 }
 
 /// The parameter of the persistent task id.
@@ -175,6 +178,12 @@ impl IDGenerator {
             }
             TaskIDParameter::BlobDigestBased(url) => {
                 Ok(digest::Digest::extract_from_blob_url(&url)
+                    .ok_or_else(|| Error::InvalidURI(url))?
+                    .encoded()
+                    .to_string())
+            }
+            TaskIDParameter::ManifestDigestBased(url) => {
+                Ok(digest::Digest::extract_from_manifest_url(&url)
                     .ok_or_else(|| Error::InvalidURI(url))?
                     .encoded()
                     .to_string())

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -77,7 +77,8 @@ fastrand.workspace = true
 opendal.workspace = true
 regex.workspace = true
 serde_regex.workspace = true
-dragonfly-client-request = { version = "=1.6.0", features = ["preheat"] }
+# TODO(Gaius): Remove the path dependency after the next release of dragonfly-client-request.
+dragonfly-client-request = { path = "../../dragonfly-sdk/client-request/rust", version = "1.6.2", features = ["preheat"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "chrono"] }
 tracing-panic = "0.1.2"

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -77,8 +77,7 @@ fastrand.workspace = true
 opendal.workspace = true
 regex.workspace = true
 serde_regex.workspace = true
-# TODO(Gaius): Remove the path dependency after the next release of dragonfly-client-request.
-dragonfly-client-request = { path = "../../dragonfly-sdk/client-request/rust", version = "1.6.2", features = ["preheat"] }
+dragonfly-client-request = { version = "1.6.2", features = ["preheat"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "chrono"] }
 tracing-panic = "0.1.2"

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -61,7 +61,7 @@ use dragonfly_client_metric::{
     collect_upload_task_finished_metrics, collect_upload_task_started_metrics,
 };
 use dragonfly_client_util::{
-    digest::{is_blob_url, verify_file_digest, Digest},
+    digest::{is_blob_url, is_manifest_digest_url, verify_file_digest, Digest},
     http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
     id_generator::{
         repository_revision, PersistentCacheTaskIDParameter, PersistentTaskIDParameter,
@@ -354,6 +354,10 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                     TaskIDParameter::Content(content)
                 } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                     TaskIDParameter::BlobDigestBased(download.url.clone())
+                } else if download.enable_task_id_based_blob_digest
+                    && is_manifest_digest_url(&download.url)
+                {
+                    TaskIDParameter::ManifestDigestBased(download.url.clone())
                 } else {
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -52,7 +52,7 @@ use dragonfly_client_metric::{
     collect_update_task_started_metrics,
 };
 use dragonfly_client_util::{
-    digest::{is_blob_url, verify_file_digest, Digest},
+    digest::{is_blob_url, is_manifest_digest_url, verify_file_digest, Digest},
     http::{hashmap_to_headermap, headermap_to_hashmap, parse_range_header},
     id_generator::{repository_revision, PersistentTaskIDParameter, TaskIDParameter},
     ratelimiter::bbr::BBR,
@@ -313,6 +313,10 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     TaskIDParameter::Content(content)
                 } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                     TaskIDParameter::BlobDigestBased(download.url.clone())
+                } else if download.enable_task_id_based_blob_digest
+                    && is_manifest_digest_url(&download.url)
+                {
+                    TaskIDParameter::ManifestDigestBased(download.url.clone())
                 } else {
                     TaskIDParameter::URLBased {
                         url: download.url.clone(),

--- a/dragonfly-client/src/proxy/task.rs
+++ b/dragonfly-client/src/proxy/task.rs
@@ -29,7 +29,7 @@ use dragonfly_client_metric::{
     collect_prefetch_task_failure_metrics, collect_prefetch_task_started_metrics,
 };
 use dragonfly_client_util::{
-    digest::is_blob_url,
+    digest::{is_blob_url, is_manifest_digest_url},
     http::{headermap_to_hashmap, parse_range_header},
     id_generator::{repository_revision, TaskIDParameter},
     types::redacted::RedactedDownload,
@@ -91,6 +91,10 @@ pub async fn download(
                 TaskIDParameter::Content(content)
             } else if download.enable_task_id_based_blob_digest && is_blob_url(&download.url) {
                 TaskIDParameter::BlobDigestBased(download.url.clone())
+            } else if download.enable_task_id_based_blob_digest
+                && is_manifest_digest_url(&download.url)
+            {
+                TaskIDParameter::ManifestDigestBased(download.url.clone())
             } else {
                 TaskIDParameter::URLBased {
                     url: download.url.clone(),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

When `enable_task_id_based_blob_digest` is enabled, OCI manifest URLs referenced by a digest (e.g. `.../manifests/sha256:<hash>`) now generate a task ID from the digest itself, matching the existing behavior for blob URLs. Tag-referenced manifest URLs fall back to URL-based task IDs.

Also bumps tonic from 0.14.2 to 0.14.6 and relaxes the crc32 digest validation to reject only empty encoded values instead of enforcing a fixed length.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
