### PR TITLE
fix(dfctl): pass enable_task_id_based_blob_digest flag in preheat gRPC request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-api"
-version = "2.3.5"
+version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b44fcddaa294d75750a706dfe2f5b817c1a2d263e87434c8631d8bed806ec2"
+checksum = "857f8df2f06356c2486a67d9179e603d570aa2ce757c9b82cc9f028f73670a1d"
 dependencies = [
  "prost 0.14.4",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
-dragonfly-api = "=2.3.5"
+dragonfly-api = "=2.3.6"
 dragonfly-client = { path = "dragonfly-client", version = "1.5.3" }
 dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.3" }
 dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.3" }

--- a/dragonfly-client/src/bin/dfctl/task.rs
+++ b/dragonfly-client/src/bin/dfctl/task.rs
@@ -512,11 +512,11 @@ pub struct PreheatCommand {
         long,
         default_value_t = true,
         env = "DFCTL_TASK_PREHEAT_ENABLE_TASK_ID_BASED_BLOB_DIGEST",
-        help = "Specify whether to generate task id based blob digest. It indicates whether to use the blob digest for task ID calculation \
+        help = "Specify whether to generate task id based blob digest, used in both scheduler gRPC mode and request SDK mode \
+         (scheduler gRPC mode applies it to image preheat only). It indicates whether to use the blob digest for task ID calculation \
          when downloading from OCI registries. When enabled for OCI blob URLs (e.g., /v2/<name>/blobs/sha256:<digest>), \
-         the task ID is derived from the blob digest rather than the full URL. This enables deduplication across \
-         registries - the same blob from different registries shares one task ID, eliminating redundant downloads \
-         and storage"
+         the task ID is derived from the blob digest rather than the full URL, so the same blob from different registries \
+         shares one task ID. This enables deduplication across registries and eliminates redundant downloads and storage"
     )]
     enable_task_id_based_blob_digest: bool,
 
@@ -893,6 +893,7 @@ impl PreheatCommand {
             timeout: Some(
                 prost_wkt_types::Duration::try_from(self.timeout).or_err(ErrorType::ParseError)?,
             ),
+            enable_task_id_based_blob_digest: self.enable_task_id_based_blob_digest,
 
             // TODO: Support certificate chain.
             certificate_chain: Vec::new(),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The flag was never sent to the scheduler, making the CLI option a no-op. Also update the help text to clarify the flag applies to both scheduler gRPC mode and request SDK mode, and bump dragonfly-api to 2.3.6.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
