### PR TITLE
fix(piece): collect local peer traffic metrics for cached pieces

### DIFF
--- a/dragonfly-client/src/resource/piece.rs
+++ b/dragonfly-client/src/resource/piece.rs
@@ -381,6 +381,7 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
+            collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
             return Ok(piece);
         }
 
@@ -516,6 +517,7 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
+            collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
             return Ok(piece);
         }
 
@@ -754,6 +756,7 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished persistent piece {} from local", piece_id);
+            collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
             return Ok(piece);
         }
 
@@ -879,6 +882,7 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished piece {} from local", piece_id);
+            collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
             return Ok(piece);
         }
 
@@ -1116,6 +1120,7 @@ impl Piece {
         // return the piece directly.
         if piece.is_finished() {
             debug!("finished persistent cache piece {} from local", piece_id);
+            collect_download_piece_traffic_metrics(&TrafficType::LocalPeer, length);
             return Ok(piece);
         }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, when a piece was already finished and returned early from local storage, no traffic metrics were recorded. This caused local peer traffic to be under-reported in all download paths.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
