### PR TITLE
Implement backtosource concurency control

### DIFF
--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -1901,7 +1901,7 @@ mod tests {
             "bandwidthLimit": "50GB",
             "pieceTimeout": "30s",
             "concurrentPieceCount": 10,
-            "backToSourceConcurrentPieceCount": 10
+            "backToSourceConcurrentPieceCount": 4
         }"#;
 
         let download: Download = serde_json::from_str(json_data).unwrap();
@@ -1914,7 +1914,7 @@ mod tests {
         assert_eq!(download.bandwidth_limit, ByteSize::gb(50));
         assert_eq!(download.piece_timeout, Duration::from_secs(30));
         assert_eq!(download.concurrent_piece_count, 10);
-        assert_eq!(download.back_to_source_concurrent_piece_count, 10);
+        assert_eq!(download.back_to_source_concurrent_piece_count, 4);
     }
 
     #[test]

--- a/dragonfly-client-config/src/dfdaemon.rs
+++ b/dragonfly-client-config/src/dfdaemon.rs
@@ -177,6 +177,12 @@ fn default_download_concurrent_piece_count() -> u32 {
     8
 }
 
+/// Returns the default number of concurrent pieces to download from source.
+#[inline]
+fn default_back_to_source_concurrent_piece_count() -> u32 {
+    8
+}
+
 /// Returns the default max retries for backend request, default is 1.
 #[inline]
 fn default_backend_max_retries() -> u32 {
@@ -531,6 +537,11 @@ pub struct Download {
     #[serde(default = "default_download_concurrent_piece_count")]
     #[validate(range(min = 1))]
     pub concurrent_piece_count: u32,
+
+    /// The number of concurrent pieces to download from source.
+    #[serde(default = "default_back_to_source_concurrent_piece_count")]
+    #[validate(range(min = 1))]
+    pub back_to_source_concurrent_piece_count: u32,
 }
 
 /// Implement Default for Download.
@@ -544,6 +555,7 @@ impl Default for Download {
             piece_timeout: default_download_piece_timeout(),
             collected_piece_timeout: default_collected_download_piece_timeout(),
             concurrent_piece_count: default_download_concurrent_piece_count(),
+            back_to_source_concurrent_piece_count: default_back_to_source_concurrent_piece_count(),
         }
     }
 }
@@ -1888,7 +1900,8 @@ mod tests {
             "protocol": "quic",
             "bandwidthLimit": "50GB",
             "pieceTimeout": "30s",
-            "concurrentPieceCount": 10
+            "concurrentPieceCount": 10,
+            "backToSourceConcurrentPieceCount": 10
         }"#;
 
         let download: Download = serde_json::from_str(json_data).unwrap();
@@ -1901,6 +1914,7 @@ mod tests {
         assert_eq!(download.bandwidth_limit, ByteSize::gb(50));
         assert_eq!(download.piece_timeout, Duration::from_secs(30));
         assert_eq!(download.concurrent_piece_count, 10);
+        assert_eq!(download.back_to_source_concurrent_piece_count, 10);
     }
 
     #[test]

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1169,7 +1169,7 @@ impl PersistentCacheTask {
         // Initialize the join set.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.back_to_source_concurrent_piece_count as usize,
+            self.config.download.concurrent_piece_count as usize,
         ));
         while let Some(collect_piece) = piece_collector_rx.recv().await {
             if interrupt.load(Ordering::SeqCst) {

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1169,7 +1169,7 @@ impl PersistentCacheTask {
         // Initialize the join set.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
+            self.config.download.back_to_source_concurrent_piece_count as usize,
         ));
         while let Some(collect_piece) = piece_collector_rx.recv().await {
             if interrupt.load(Ordering::SeqCst) {

--- a/dragonfly-client/src/resource/persistent_task.rs
+++ b/dragonfly-client/src/resource/persistent_task.rs
@@ -2343,7 +2343,7 @@ impl PersistentTask {
         // Download the piece from the local.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
+            self.config.download.back_to_source_concurrent_piece_count as usize,
         ));
         for interested_piece in interested_pieces {
             async fn download_from_source(
@@ -2791,7 +2791,7 @@ impl PersistentTask {
         // Download the pieces.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
+            self.config.download.back_to_source_concurrent_piece_count as usize,
         ));
         for interested_piece in interested_pieces.clone() {
             async fn download_from_source(

--- a/dragonfly-client/src/resource/task.rs
+++ b/dragonfly-client/src/resource/task.rs
@@ -1632,7 +1632,7 @@ impl Task {
         // Download the piece from the local.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
+            self.config.download.back_to_source_concurrent_piece_count as usize,
         ));
         for interested_piece in interested_pieces {
             async fn download_from_source(
@@ -2205,7 +2205,7 @@ impl Task {
         // Download the pieces.
         let mut join_set = JoinSet::new();
         let semaphore = Arc::new(Semaphore::new(
-            self.config.download.concurrent_piece_count as usize,
+            self.config.download.back_to_source_concurrent_piece_count as usize,
         ));
         for interested_piece in interested_pieces.clone() {
             async fn download_from_source(


### PR DESCRIPTION
## Description

This PR separates peer download concurrency from back-to-source concurrency.

Currently concurrentPieceCount is used for both peer-to-peer downloads and back-to-source downloads. In environments where many Dragonfly clients hit a slow origin storage, this can create too much parallel load on the source and cause it to degrade or fail.

To mitigate this, a new config field backToSourceConcurrentPieceCount is introduced. It allows tuning back-to-source concurrency independently from peer concurrency, so source traffic can be kept under control without affecting normal peer download parallelism.
Changes

    Add download.backToSourceConcurrentPieceCount to dfdaemon config.
    Keep download.concurrentPieceCount for peer/p2p downloads.
    Use the new dedicated limit in back-to-source download paths.
    Add default value and config deserialization test coverage.

## Motivation

Decoupling these limits helps prevent a slow origin storage from being overwhelmed by too many concurrent back-to-source requests when many clients are downloading through Dragonfly.