### PR TITLE
fix(proxy): map dfdaemon download errors to specific HTTP status codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-backend"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-config"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "bytesize",
  "bytesize-serde",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-core"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "cgroups-rs",
  "http",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-init"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-metric"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "bytes",
  "dragonfly-api",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-storage"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-util"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "hdfs"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "async-trait",
  "dragonfly-client-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.4"
+version = "1.5.5"
 authors = ["The Dragonfly Developers"]
 edition = "2021"
 readme = "README.md"
@@ -34,14 +34,14 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 crc32fast = "1.5.0"
 dashmap = "6.1.0"
 dragonfly-api = "=2.3.6"
-dragonfly-client = { path = "dragonfly-client", version = "1.5.4" }
-dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.4" }
-dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.4" }
-dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.4" }
-dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.4" }
-dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.4" }
-dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.4" }
-dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.4" }
+dragonfly-client = { path = "dragonfly-client", version = "1.5.5" }
+dragonfly-client-backend = { path = "dragonfly-client-backend", version = "1.5.5" }
+dragonfly-client-config = { path = "dragonfly-client-config", version = "1.5.5" }
+dragonfly-client-core = { path = "dragonfly-client-core", version = "1.5.5" }
+dragonfly-client-init = { path = "dragonfly-client-init", version = "1.5.5" }
+dragonfly-client-metric = { path = "dragonfly-client-metric", version = "1.5.5" }
+dragonfly-client-storage = { path = "dragonfly-client-storage", version = "1.5.5" }
+dragonfly-client-util = { path = "dragonfly-client-util", version = "1.5.5" }
 fastrand = "2.4.1"
 fs2 = "0.4.3"
 futures = "0.3.32"

--- a/dragonfly-client/src/grpc/dfdaemon_download.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_download.rs
@@ -747,7 +747,9 @@ impl DfdaemonDownload for DfdaemonDownloadServerHandler {
                     );
                 }
                 // If the task is already prefetched, ignore the error.
-                Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
+                Err(err @ ClientError::InvalidState(_)) => {
+                    debug!("task is already prefetched: {}", err)
+                }
                 Err(err) => {
                     error!("prefetch task started: {}", err);
                 }

--- a/dragonfly-client/src/grpc/dfdaemon_upload.rs
+++ b/dragonfly-client/src/grpc/dfdaemon_upload.rs
@@ -683,7 +683,9 @@ impl DfdaemonUpload for DfdaemonUploadServerHandler {
                     );
                 }
                 // If the task is already prefetched, ignore the error.
-                Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
+                Err(err @ ClientError::InvalidState(_)) => {
+                    debug!("task is already prefetched: {}", err)
+                }
                 Err(err) => {
                     error!("prefetch task started: {}", err);
                 }

--- a/dragonfly-client/src/proxy/mod.rs
+++ b/dragonfly-client/src/proxy/mod.rs
@@ -436,8 +436,8 @@ pub async fn http_handler(
     if let Some(basic_auth) = config.proxy.server.basic_auth.as_ref() {
         match basic_auth.credentials().verify(request.headers()) {
             Ok(_) => {}
-            Err(ClientError::Unauthorized) => {
-                error!("basic auth failed");
+            Err(err @ ClientError::Unauthorized) => {
+                error!("basic auth failed: {}", err);
                 return Ok(make_error_response(
                     header::ErrorType::Proxy,
                     http::StatusCode::UNAUTHORIZED,
@@ -693,7 +693,8 @@ pub async fn upgraded_handler(
     if let Some(basic_auth) = config.proxy.server.basic_auth.as_ref() {
         match basic_auth.credentials().verify(request.headers()) {
             Ok(_) => {}
-            Err(ClientError::Unauthorized) => {
+            Err(err @ ClientError::Unauthorized) => {
+                error!("basic auth failed: {}", err);
                 return Ok(make_error_response(
                     header::ErrorType::Proxy,
                     http::StatusCode::UNAUTHORIZED,
@@ -817,7 +818,7 @@ async fn proxy_via_dfdaemon(
                 error!("make download task request failed: {}", err);
                 return Ok(make_error_response(
                     header::ErrorType::Proxy,
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    http::StatusCode::BAD_REQUEST,
                     None,
                 ));
             }
@@ -833,8 +834,8 @@ async fn proxy_via_dfdaemon(
     .await
     {
         Ok(out_stream) => out_stream,
-        Err(ClientError::PermissionDenied) => {
-            error!("download task rejected by blocklist policy");
+        Err(err @ ClientError::PermissionDenied) => {
+            error!("download task rejected by blocklist policy: {}", err);
             return Ok(make_error_response(
                 header::ErrorType::Proxy,
                 http::StatusCode::FORBIDDEN,
@@ -848,6 +849,30 @@ async fn proxy_via_dfdaemon(
                 err.status_code
                     .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
                 err.header.clone(),
+            ));
+        }
+        Err(err @ ClientError::NoSpace(_)) => {
+            error!("download task failed: {}", err);
+            return Ok(make_error_response(
+                header::ErrorType::Dfdaemon,
+                http::StatusCode::INSUFFICIENT_STORAGE,
+                None,
+            ));
+        }
+        Err(err @ (ClientError::InvalidContentLength | ClientError::InvalidPieceLength)) => {
+            error!("download task failed: {}", err);
+            return Ok(make_error_response(
+                header::ErrorType::Dfdaemon,
+                http::StatusCode::UNPROCESSABLE_ENTITY,
+                None,
+            ));
+        }
+        Err(err @ (ClientError::InvalidParameter | ClientError::InvalidURI(_))) => {
+            error!("download task failed: {}", err);
+            return Ok(make_error_response(
+                header::ErrorType::Dfdaemon,
+                http::StatusCode::BAD_REQUEST,
+                None,
             ));
         }
         Err(err) => {
@@ -924,7 +949,9 @@ async fn proxy_via_dfdaemon(
                 );
             }
             // If the task is already prefetched, ignore the error.
-            Err(ClientError::InvalidState(_)) => debug!("task is already prefetched"),
+            Err(err @ ClientError::InvalidState(_)) => {
+                debug!("task is already prefetched: {}", err)
+            }
             Err(err) => {
                 error!("prefetch task started: {}", err);
             }

--- a/dragonfly-client/src/resource/persistent_cache_task.rs
+++ b/dragonfly-client/src/resource/persistent_cache_task.rs
@@ -1449,12 +1449,12 @@ impl PersistentCacheTask {
 
                     return Err(Error::DownloadFromParentFailed(err));
                 }
-                Err(Error::SendTimeout) => {
+                Err(err @ Error::SendTimeout) => {
                     join_set.shutdown().await;
 
                     // If the send timeout with scheduler or download progress, return the error
                     // and interrupt the collector.
-                    return Err(Error::SendTimeout);
+                    return Err(err);
                 }
                 Err(err) => {
                     join_set.shutdown().await;


### PR DESCRIPTION


Bump workspace version to 1.5.5.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Return 507 for no space, 422 for invalid content/piece length, and 400 for invalid parameters or URIs instead of a generic 500 when a proxied download fails; also return 400 rather than 500 when building the download request fails. Log the error details when basic auth is rejected on upgraded connections and include the underlying error in existing debug/error logs.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
