### PR TITLE
chore(deps): bump tonic-health to 0.14.6 and dragonfly-client-request to 1.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,11 +1493,12 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-client-request"
-version = "1.6.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1379d1f7ea6a83a7525cef4f4c82ec9a423f13ba220b9d97a531cfcece0d29"
+checksum = "8ad5b4c0719c695a360fa1f43d9c4fb996ed17abd161ef71e0a48732ff141ad1"
 dependencies = [
  "async-trait",
+ "backon",
  "bytes",
  "dashmap",
  "dragonfly-api",
@@ -1516,7 +1517,8 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-tracing",
  "rustls-pki-types",
- "sha2 0.10.8",
+ "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
@@ -5857,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost 0.14.4",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ tokio-util = { version = "0.7.18", features = ["full"] }
 toml = "0.8.23"
 toml_edit = "0.25.12"
 tonic = { version = "=0.14.6", features = ["tls-aws-lc"] }
-tonic-health = "=0.14.5"
+tonic-health = "=0.14.6"
 tonic-reflection = "=0.14.6"
 tracing = "0.1"
 url = "2.5.4"

--- a/dragonfly-client/Cargo.toml
+++ b/dragonfly-client/Cargo.toml
@@ -77,7 +77,7 @@ fastrand.workspace = true
 opendal.workspace = true
 regex.workspace = true
 serde_regex.workspace = true
-dragonfly-client-request = { version = "1.6.2", features = ["preheat"] }
+dragonfly-client-request = { version = "1.7.2", features = ["preheat"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time", "chrono"] }
 tracing-panic = "0.1.2"


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

Align the pinned tonic-health version with tonic and tonic-reflection (0.14.6) and update the dragonfly-client-request dependency from 1.6.2 to 1.7.2 for the dragonfly-client crate.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
