### PR TITLE
docs: add Python example for native S3 range reads

### DIFF
--- a/.github/workflows/python-examples.yml
+++ b/.github/workflows/python-examples.yml
@@ -1,0 +1,40 @@
+name: Python examples
+
+on:
+  pull_request:
+    branches: [main, release-*]
+    paths:
+      - 'examples/python-s3-range/**'
+      - '.github/workflows/python-examples.yml'
+  push:
+    branches: [main, release-*]
+    paths:
+      - 'examples/python-s3-range/**'
+      - '.github/workflows/python-examples.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+    defaults:
+      run:
+        working-directory: examples/python-s3-range
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install core dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Test without video dependencies
+        run: python -m unittest discover -s tests -v
+      - name: Install video dependencies
+        run: python -m pip install -r requirements-video.txt
+      - name: Test including video decoding
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Dragonfly client written in Rust. It can serve as both a peer and a seed peer.
 
 You can find the full documentation on the [d7y.io](https://d7y.io).
 
+For a Python gRPC integration, see the [S3 range reader example](examples/python-s3-range).
+
 ## Community
 
 Join the conversation and help the community grow. Here are the ways to get involved:

--- a/examples/python-s3-range/.gitignore
+++ b/examples/python-s3-range/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/examples/python-s3-range/README.md
+++ b/examples/python-s3-range/README.md
@@ -1,0 +1,133 @@
+# Python S3 range reader
+
+Read byte ranges from S3 through dfdaemon's v2 gRPC API, using the generated
+[dragonfly-api](https://pypi.org/project/dragonfly-api/) Python bindings. The
+reader implements `read`, `readinto`, `seek`, and `tell`, so a library that
+accepts a seekable binary file can use Dragonfly's piece cache and P2P downloads.
+The optional video example decodes selected time windows without first
+materializing the entire object.
+
+## Requirements
+
+- Python 3.11+ and a configured dfdaemon with access to S3 and its scheduler.
+- A trusted local dfdaemon Unix socket, normally
+  `/var/run/dragonfly/dfdaemon.sock`.
+- AWS credentials available through boto3's normal credential provider chain.
+- Immutable S3 object keys. This example does not pin a version on source GETs.
+
+Tested with official dfdaemon v1.5.5 and dragonfly-api 2.3.7. Older daemon
+versions may not implement the scheduling policy used for small-range peer
+lookup. This example does not change or deploy the daemon.
+
+## Read bytes
+
+From this directory:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+```python
+from reader import open_s3_reader
+
+with open_s3_reader("s3://my-bucket/immutable/data.bin", region="us-west-2") as source:
+    # Exact bytes [5 MiB, 6 MiB), clipped at EOF; does not move tell().
+    data = source.read_range(start=5 * 1024 * 1024, length=1024 * 1024)
+
+    source.seek(100)
+    next_bytes = source.read(4096)
+```
+
+Use `socket="/mounted/dfdaemon.sock"`, `profile="my-profile"`, or
+`endpoint="https://my-s3-compatible-host"` as needed. The endpoint must be
+reachable and its TLS certificate trusted by both Python and dfdaemon.
+The boto3 metadata HEAD goes directly to S3; object data goes through gRPC.
+If your environment uses a dfdaemon HTTP proxy, configure `NO_PROXY` or use a
+separate environment so the metadata HEAD can reach S3 directly.
+
+Use URL-encoded object keys (for example, `%20` for a space and `%25` for a
+literal percent sign). This example accepts ordinary bucket names and file
+keys, and rejects query strings, fragments, empty or dot path segments, and
+backslashes to avoid path normalization changing which object is downloaded.
+
+Create one reader per worker after forking; a reader is not thread-safe.
+Keep it open across related reads to reuse its small application cache.
+Intervals larger than the default 64 MiB allocation limit must be consumed in
+smaller windows. An unbounded `read()` is rejected if it exceeds that limit.
+
+## Optional video windows
+
+Only this example and its test require PyAV:
+
+```bash
+python -m pip install -r requirements-video.txt
+python video_chunks.py s3://my-bucket/immutable/video.mp4 \
+  --region us-west-2 --start 7200 --chunk-seconds 60 --chunks 2
+```
+
+This decodes windows 02:00:00–02:01:00 and 02:01:00–02:02:00, printing frame
+counts, timestamps, and gRPC transfer counters. `frames_in_window` yields
+`(timestamp, frame)` pairs for use in a training loader. It selects the first
+video stream and does not return audio or write standalone video clips.
+
+S3 Range addresses **bytes, not seconds**. PyAV uses the video container index
+to map timestamps to byte reads and seeks to an earlier keyframe for decoding.
+Use a seekable, indexed container such as MP4. Metadata, keyframes, read-ahead,
+and full Dragonfly pieces can require more bytes than the selected frames.
+If you already have a byte-offset index, use the reader without PyAV.
+
+## Download behavior
+
+- Each RPC sends the same object URL/tag with a different `Download.range`,
+  `need_piece_content=true`, `prefetch=false`, and a fixed 4 MiB piece length.
+  Ranges do not create separate object tasks. No output file is requested,
+  though dfdaemon still caches pieces on disk.
+- The daemon returns complete pieces with absolute offsets, possibly out of
+  order. The reader validates metadata and coverage, reorders and trims pieces,
+  and waits for a successful final RPC status before returning or caching bytes.
+- `scheduling_policy="always"` enables peer lookup for small reads. On v1.5.5,
+  `auto` bypasses the scheduler for uncached ranges <= 4 MiB. `always` can add
+  scheduling latency; it neither guarantees a peer hit nor disables source
+  fallback. The video CLI also exposes `--scheduling-policy auto`.
+- The Unix channel sets `grpc.default_authority=localhost` for compatibility
+  with the Rust HTTP/2 server and raises the receive limit above a 4 MiB piece
+  plus protobuf metadata. This authority is unrelated to S3's Host header.
+- Up to four full pieces (16 MiB) are cached in Python. Peak memory also includes
+  the requested result, assembly copies, protobuf messages, and decoder buffers.
+- Boto3 resolves a fresh frozen credential snapshot for each uncached RPC,
+  including the STS session token. Refreshable providers can renew between
+  RPCs; static credentials cannot refresh themselves. Credentials already sent
+  on an in-flight RPC are not refreshed. Errors propagate without hidden retries.
+- dfdaemon signs its actual S3 piece requests using those credentials. This
+  does not forward a caller's pre-signed HTTP request or implement a proxy.
+
+The cache tag includes endpoint, region, HEAD ETag, and HEAD version ID. It stays
+stable across ranges and credential rotations. Other clients need the same tag
+and piece length to share task identity. HEAD and source reads are separate
+operations: this tag does not pin a version or detect a same-size overwrite
+while a reader is open. Use immutable keys.
+
+The daemon receives AWS credentials. Protect its socket and use your deployment's
+isolation model. The tag namespaces cached data; it is not an authorization
+boundary or a guarantee of authorization checks on every cached read.
+
+## Tests
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+The core tests use real protobuf/gRPC streams with a local test server. They
+exercise unaligned and out-of-order pieces, EOF and seek behavior, bounded
+caching, credential rotation, URL handling, malformed responses, and errors
+reported after the last piece. The optional video test compares two windows
+from an indexed three-hour synthetic MP4 against a sequential local decode;
+it is skipped when PyAV is absent. No AWS credentials or running daemon are
+needed for these tests.
+
+Additional manual validation used two real v1.5.5 daemons with separate caches,
+a scheduler, and MinIO: signed ranged GETs, STS, source/remote/local traffic,
+and partial video reads. This is S3-compatible functional validation, not an
+AWS service test or a video throughput benchmark.

--- a/examples/python-s3-range/reader.py
+++ b/examples/python-s3-range/reader.py
@@ -1,0 +1,345 @@
+# Copyright 2026 The Dragonfly Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Seekable, bounded-memory native-S3 reader for Dragonfly's v2 gRPC API.
+
+Use one reader per worker and immutable S3 object keys. This is a client example,
+not an S3 proxy or a tenant authorization boundary.
+"""
+
+import io
+import re
+from collections import OrderedDict
+from collections.abc import Callable
+from contextlib import closing, contextmanager
+from operator import index
+from urllib.parse import quote, unquote, urlsplit
+
+import boto3
+import grpc
+from dragonfly_api import common_pb2, dfdaemon_pb2, dfdaemon_pb2_grpc
+
+MIB = 1024 * 1024
+PIECE_LENGTH = 4 * MIB
+
+
+class DragonflyReader(io.RawIOBase):
+    """Return exact byte ranges, preserving whole-object Dragonfly task identity.
+
+    The daemon returns FULL pieces with absolute offsets. They can arrive out of
+    order. Only successful, complete RPCs populate the small client-side cache.
+    Dfdaemon still uses its own on-disk piece cache.
+    """
+
+    def __init__(
+        self,
+        stub,
+        url: str,
+        size: int,
+        credentials: Callable[[], common_pb2.ObjectStorage],
+        *,
+        cache_tag: str,
+        cache_pieces: int = 4,
+        timeout: float = 60,
+        max_range_bytes: int = 64 * MIB,
+        scheduling_policy: str = "always",
+    ):
+        super().__init__()
+        self.cache = OrderedDict()
+        size, cache_pieces, max_range_bytes = map(
+            index, (size, cache_pieces, max_range_bytes)
+        )
+        if size < 0 or cache_pieces < 0 or max_range_bytes <= 0 or timeout <= 0:
+            raise ValueError("Invalid size, cache capacity, range limit, or timeout")
+        if scheduling_policy not in ("auto", "always"):
+            raise ValueError("Scheduling policy must be auto or always")
+        self.stub = stub
+        self.url = url
+        self.size = size
+        self.credentials = credentials
+        self.cache_tag = cache_tag
+        self.cache_pieces = cache_pieces
+        self.timeout = timeout
+        self.max_range_bytes = max_range_bytes
+        self.scheduling_policy = scheduling_policy
+        self.position = 0
+        self.task_id = None
+        self.rpc_count = 0
+        self.piece_bytes_received = 0
+        self.range_bytes_requested = 0
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def tell(self):
+        self._checkClosed()
+        return self.position
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        self._checkClosed()
+        offset, whence = index(offset), index(whence)
+        bases = {io.SEEK_SET: 0, io.SEEK_CUR: self.position, io.SEEK_END: self.size}
+        if whence not in bases:
+            raise ValueError("Invalid whence")
+        position = bases[whence] + offset
+        if position < 0:
+            raise ValueError("Negative seek position")
+        self.position = position
+        return position
+
+    def read(self, size=-1):
+        self._checkClosed()
+        size = -1 if size is None else index(size)
+        remaining = max(0, self.size - self.position)
+        if size is None or size < 0:
+            # Protect a training process from accidentally materializing hours
+            # of video via read() or readall(). PyAV uses bounded reads.
+            if remaining > self.max_range_bytes:
+                raise io.UnsupportedOperation(
+                    "Use bounded read(size) for large objects"
+                )
+            size = remaining
+        data = self.read_range(self.position, min(size, remaining))
+        self.position += len(data)
+        return data
+
+    def readall(self):
+        return self.read()
+
+    def readinto(self, buffer):
+        self._checkClosed()
+        with memoryview(buffer).cast("B") as view:
+            if view.readonly:
+                raise TypeError("readinto requires a writable buffer")
+            data = self.read(view.nbytes)
+            view[: len(data)] = data
+            return len(data)
+
+    def read_range(self, start: int, length: int) -> bytes:
+        """Read [start, start+length), clipped at EOF, without moving tell()."""
+        self._checkClosed()
+        start, length = index(start), index(length)
+        if start < 0 or length < 0:
+            raise ValueError("Negative range")
+        length = min(length, max(0, self.size - start))
+        if length > self.max_range_bytes:
+            raise ValueError("Range exceeds memory limit; read in smaller windows")
+        if length == 0:
+            return b""
+        end = start + length
+        numbers = range(start // PIECE_LENGTH, (end - 1) // PIECE_LENGTH + 1)
+        if all(number in self.cache for number in numbers):
+            pieces = {number: self.cache[number] for number in numbers}
+            for number in numbers:
+                self.cache.move_to_end(number)
+        else:
+            pieces = self._download(start, length, numbers)
+
+        # Keep source coordinates in the daemon; compact only the returned bytes.
+        output = bytearray(length)
+        for number in numbers:
+            piece_start = number * PIECE_LENGTH
+            content = pieces[number]
+            lo = max(start, piece_start)
+            hi = min(end, piece_start + len(content))
+            output[lo - start : hi - start] = content[
+                lo - piece_start : hi - piece_start
+            ]
+        return bytes(output)
+
+    def _download(self, start, length, numbers):
+        request = dfdaemon_pb2.DownloadTaskRequest(
+            download=common_pb2.Download(
+                url=self.url,
+                type=common_pb2.STANDARD,
+                range=common_pb2.Range(start=start, length=length),
+                piece_length=PIECE_LENGTH,
+                tag=self.cache_tag,
+                need_piece_content=True,
+                prefetch=False,
+                # AUTO bypasses the scheduler for ranges <= 4 MiB. Video
+                # demuxers often request only a few KiB, so opt into peer lookup.
+                scheduling_policy=(
+                    common_pb2.ALWAYS
+                    if self.scheduling_policy == "always"
+                    else common_pb2.AUTO
+                ),
+                object_storage=self.credentials(),
+                # No output_path, HTTP Authorization/Range, or range-derived ID.
+            )
+        )
+        self.rpc_count += 1
+        self.range_bytes_requested += length
+        call = self.stub.DownloadTask(request, timeout=self.timeout)
+        expected = set(numbers)
+        pieces = {}
+        started = False
+        task_id = None
+        try:
+            for response in call:
+                kind = response.WhichOneof("response")
+                if kind == "download_task_started_response":
+                    metadata = response.download_task_started_response
+                    if started or metadata.content_length != self.size:
+                        raise OSError("Unexpected metadata or object size changed")
+                    if (
+                        not metadata.HasField("range")
+                        or metadata.range.start != start
+                        or metadata.range.length != length
+                    ):
+                        raise OSError("Daemon did not honor the requested range")
+                    task_id = response.task_id
+                    if not task_id or (
+                        self.task_id is not None and task_id != self.task_id
+                    ):
+                        raise OSError(
+                            "Object task identity changed across range requests"
+                        )
+                    started = True
+                elif kind == "download_piece_finished_response":
+                    piece = response.download_piece_finished_response.piece
+                    if not started or response.task_id != task_id:
+                        raise OSError("Piece arrived without matching task metadata")
+                    expected_offset = piece.number * PIECE_LENGTH
+                    expected_length = min(PIECE_LENGTH, self.size - expected_offset)
+                    if (
+                        piece.number not in expected
+                        or piece.number in pieces
+                        or piece.offset != expected_offset
+                        or piece.length != expected_length
+                        or not piece.HasField("content")
+                        or len(piece.content) != piece.length
+                    ):
+                        raise OSError(
+                            "Missing, duplicate, unexpected, or malformed piece"
+                        )
+                    self.piece_bytes_received += len(piece.content)
+                    pieces[piece.number] = piece.content
+                else:
+                    raise OSError("Unexpected download response")
+            # Exhaust the stream even after all bytes arrive: its final status
+            # may be an error. Never silently return zero-filled missing bytes.
+            if not started or set(pieces) != expected:
+                raise OSError("Incomplete range response")
+        finally:
+            call.cancel()
+
+        self.task_id = task_id
+        for number, content in pieces.items():
+            self.cache[number] = content
+            self.cache.move_to_end(number)
+            while len(self.cache) > self.cache_pieces:
+                self.cache.popitem(last=False)
+        return pieces
+
+    def close(self):
+        self.cache.clear()
+        super().close()
+
+
+@contextmanager
+def open_s3_reader(
+    url,
+    *,
+    socket="/var/run/dragonfly/dfdaemon.sock",
+    region=None,
+    endpoint=None,
+    profile=None,
+    timeout=60,
+    scheduling_policy="always",
+):
+    """HEAD metadata with boto3; transfer object bytes through dfdaemon.
+
+    The socket must belong to a trusted daemon: each RPC includes credentials.
+    Boto3 resolves credentials normally (including role/web-identity providers).
+    Obtain a fresh frozen snapshot before each RPC; this does not refresh a
+    credential already sent on an in-flight RPC.
+    """
+    import hashlib
+    import json
+
+    if any(ord(char) < 32 or ord(char) == 127 for char in url):
+        raise ValueError("Control characters are not supported in S3 URLs")
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme != "s3"
+        or not re.fullmatch(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", parsed.netloc)
+        or not parsed.path.startswith("/")
+    ):
+        raise ValueError("Expected s3://bucket/key")
+    if parsed.query or parsed.fragment:
+        raise ValueError("Use an immutable object key, without query or fragment")
+    key = unquote(parsed.path[1:], errors="strict")
+    # Rust's URL parser and the storage backend normalize path segments. Avoid
+    # HEAD and GET referring to different keys; this example supports file keys.
+    if any(part in ("", ".", "..") for part in key.split("/")) or "\\" in key:
+        raise ValueError("Empty, dot, and backslash key segments are not supported")
+    url = f"s3://{parsed.netloc}/{quote(key, safe='/')}"
+    session = boto3.Session(profile_name=profile, region_name=region)
+    region = region or session.region_name or "us-east-1"
+    with closing(session.client("s3", region_name=region, endpoint_url=endpoint)) as s3:
+        metadata = s3.head_object(Bucket=parsed.netloc, Key=key)
+        # Include endpoints supplied through boto3's environment/config as well
+        # as the explicit --endpoint argument in the daemon's S3 configuration.
+        endpoint = s3.meta.endpoint_url
+
+    # Stable across ranges/credential rotation, distinct across endpoints and
+    # object revisions observed at open. A tag is a cache namespace, not auth.
+    cache_tag = hashlib.sha256(
+        json.dumps(
+            [endpoint or "aws", region, metadata.get("VersionId"), metadata.get("ETag")]
+        ).encode()
+    ).hexdigest()
+
+    def credentials():
+        provider = session.get_credentials()
+        if provider is None:
+            raise RuntimeError("No AWS credentials found")
+        frozen = provider.get_frozen_credentials()
+        options = dict(
+            region=region,
+            access_key_id=frozen.access_key,
+            access_key_secret=frozen.secret_key,
+        )
+        if frozen.token:
+            options["session_token"] = frozen.token
+        if endpoint:
+            options["endpoint"] = endpoint
+        return common_pb2.ObjectStorage(**options)
+
+    # The Python gRPC default receive limit is too small for a 4 MiB piece plus
+    # protobuf metadata. Request a fixed legal piece length and allow headroom.
+    with grpc.insecure_channel(
+        "unix:" + socket,
+        # Python gRPC otherwise derives :authority from the Unix socket path.
+        # The Rust HTTP/2 server rejects that authority before dispatching the
+        # RPC. This is routing metadata for the local socket, not an S3 Host.
+        options=[
+            ("grpc.default_authority", "localhost"),
+            ("grpc.max_receive_message_length", PIECE_LENGTH + MIB),
+        ],
+    ) as channel:
+        with DragonflyReader(
+            dfdaemon_pb2_grpc.DfdaemonDownloadStub(channel),
+            url,
+            metadata["ContentLength"],
+            credentials,
+            cache_tag=cache_tag,
+            timeout=timeout,
+            scheduling_policy=scheduling_policy,
+        ) as reader:
+            yield reader

--- a/examples/python-s3-range/requirements-video.txt
+++ b/examples/python-s3-range/requirements-video.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+av==18.1.0

--- a/examples/python-s3-range/requirements.txt
+++ b/examples/python-s3-range/requirements.txt
@@ -1,0 +1,3 @@
+dragonfly-api==2.3.7
+grpcio==1.83.1
+boto3==1.43.90

--- a/examples/python-s3-range/tests/test_reader.py
+++ b/examples/python-s3-range/tests/test_reader.py
@@ -1,0 +1,365 @@
+# Copyright 2026 The Dragonfly Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise real protobuf serialization and gRPC streaming over a local socket.
+
+The server models dfdaemon's wire contract; it is NOT a real Dragonfly cluster.
+"""
+
+import hashlib
+import io
+import tempfile
+import unittest
+from array import array
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import boto3
+import grpc
+from botocore.stub import Stubber
+from dragonfly_api import common_pb2, dfdaemon_pb2, dfdaemon_pb2_grpc
+
+from reader import MIB, PIECE_LENGTH, DragonflyReader, open_s3_reader
+
+
+class PieceServer(dfdaemon_pb2_grpc.DfdaemonDownloadServicer):
+    def __init__(self, content):
+        self.content = content
+        self.requests = []
+        self.mode = "normal"
+
+    def DownloadTask(self, request, context):
+        download = request.download
+        self.requests.append(download)
+        # The range and credentials deliberately do not participate in identity.
+        task_id = hashlib.sha256(
+            f"{download.url}|{download.tag}|{download.piece_length}".encode()
+        ).hexdigest()
+        start = download.range.start
+        end = min(start + download.range.length, len(self.content))
+        numbers = range(start // PIECE_LENGTH, (end - 1) // PIECE_LENGTH + 1)
+        pieces = [
+            common_pb2.Piece(
+                number=number,
+                offset=number * PIECE_LENGTH,
+                length=min(PIECE_LENGTH, len(self.content) - number * PIECE_LENGTH),
+            )
+            for number in numbers
+        ]
+        yield dfdaemon_pb2.DownloadTaskResponse(
+            task_id="" if self.mode == "missing_task" else task_id,
+            download_task_started_response=dfdaemon_pb2.DownloadTaskStartedResponse(
+                content_length=len(self.content),
+                range=(
+                    common_pb2.Range(start=start + 1, length=end - start)
+                    if self.mode == "wrong_range"
+                    else download.range
+                ),
+                pieces=pieces,
+            ),
+        )
+        for index, piece in enumerate(reversed(pieces)):
+            if self.mode == "missing" and index == 0:
+                continue
+            piece.content = self.content[piece.offset : piece.offset + piece.length]
+            if self.mode == "truncated":
+                piece.content = piece.content[:-1]
+            if self.mode == "wrong_offset":
+                piece.offset += 1
+            response = dfdaemon_pb2.DownloadTaskResponse(
+                task_id="different-task" if self.mode == "wrong_task" else task_id,
+                download_piece_finished_response=dfdaemon_pb2.DownloadPieceFinishedResponse(
+                    piece=piece,
+                ),
+            )
+            yield response
+            if self.mode == "duplicate":
+                yield response
+        if self.mode == "terminal_error":
+            context.abort(grpc.StatusCode.INTERNAL, "Simulated final stream failure")
+
+
+@contextmanager
+def serve(content):
+    # Short pathname: Unix sockets have a much smaller path limit than files.
+    with tempfile.TemporaryDirectory(prefix="df-video-", dir="/tmp") as directory:
+        address = "unix:" + str(Path(directory) / "rpc.sock")
+        service = PieceServer(content)
+        service.address = address
+        server = grpc.server(ThreadPoolExecutor(max_workers=2))
+        dfdaemon_pb2_grpc.add_DfdaemonDownloadServicer_to_server(service, server)
+        if not server.add_insecure_port(address):
+            raise RuntimeError("Could not bind test socket")
+        server.start()
+        try:
+            with grpc.insecure_channel(
+                address,
+                options=[("grpc.max_receive_message_length", PIECE_LENGTH + MIB)],
+            ) as channel:
+                grpc.channel_ready_future(channel).result(timeout=5)
+                yield service, dfdaemon_pb2_grpc.DfdaemonDownloadStub(channel)
+        finally:
+            server.stop(0).wait()
+
+
+def example_credentials():
+    return common_pb2.ObjectStorage(
+        region="us-east-1",
+        access_key_id="test-only",
+        access_key_secret="test-only",
+        session_token="test-only-token",
+    )
+
+
+class ReaderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Different, nonzero patterns in each piece expose offset mistakes.
+        cls.content = (
+            b"".join(
+                bytes((byte + number * 31) % 256 for byte in range(256))
+                * (PIECE_LENGTH // 256)
+                for number in range(3)
+            )
+            + b"short final piece"
+        )
+
+    def setUp(self):
+        self.context = serve(self.content)
+        self.service, stub = self.context.__enter__()
+        self.addCleanup(self.context.__exit__, None, None, None)
+        self.reader = DragonflyReader(
+            stub,
+            "s3://test/video.mp4",
+            len(self.content),
+            example_credentials,
+            cache_tag="immutable-test-object",
+            cache_pieces=2,
+        )
+        self.addCleanup(self.reader.close)
+
+    def test_unaligned_out_of_order_pieces_and_cache(self):
+        start, length = PIECE_LENGTH - 17, 63
+        self.assertEqual(
+            self.reader.read_range(start, length), self.content[start : start + length]
+        )
+        self.assertEqual(
+            self.reader.read_range(PIECE_LENGTH + 10, 20),
+            self.content[PIECE_LENGTH + 10 : PIECE_LENGTH + 30],
+        )
+        self.assertEqual(len(self.service.requests), 1)
+        self.assertEqual(self.reader.piece_bytes_received, 2 * PIECE_LENGTH)
+        request = self.service.requests[0]
+        self.assertTrue(request.need_piece_content)
+        self.assertFalse(request.prefetch)
+        self.assertEqual(request.scheduling_policy, common_pb2.ALWAYS)
+        self.assertFalse(request.HasField("output_path"))
+        self.assertFalse(request.request_header)
+
+    def test_seek_readinto_eof_and_cache_bound(self):
+        self.reader.seek(PIECE_LENGTH + 11)
+        buffer = bytearray(100)
+        self.assertEqual(self.reader.readinto(buffer), 100)
+        self.assertEqual(buffer, self.content[PIECE_LENGTH + 11 : PIECE_LENGTH + 111])
+        self.reader.seek(-6, io.SEEK_END)
+        self.assertEqual(self.reader.read(100), self.content[-6:])
+        self.assertEqual(self.reader.read(1), b"")
+        self.reader.read_range(0, 1)
+        self.assertEqual(len(self.reader.cache), 2)
+        self.reader.seek(len(self.content) + 100)
+        self.assertEqual(self.reader.read(1), b"")
+        with self.assertRaises(ValueError):
+            self.reader.seek(-1)
+
+    def test_rotating_credentials_keep_object_task_identity(self):
+        tokens = iter(["first-session", "second-session"])
+
+        def credentials():
+            value = example_credentials()
+            value.session_token = next(tokens)
+            return value
+
+        self.reader.credentials = credentials
+        self.reader.read_range(0, 1)
+        task_id = self.reader.task_id
+        self.reader.read_range(2 * PIECE_LENGTH, 1)
+        self.assertEqual(self.reader.task_id, task_id)
+        self.assertEqual(
+            [r.object_storage.session_token for r in self.service.requests],
+            ["first-session", "second-session"],
+        )
+
+    def test_reject_missing_duplicate_truncated_and_final_error(self):
+        for mode, exception in [
+            ("missing", OSError),
+            ("duplicate", OSError),
+            ("truncated", OSError),
+            ("wrong_offset", OSError),
+            ("wrong_task", OSError),
+            ("wrong_range", OSError),
+            ("missing_task", OSError),
+            ("terminal_error", grpc.RpcError),
+        ]:
+            with self.subTest(mode=mode):
+                self.service.mode = mode
+                with self.assertRaises(exception):
+                    self.reader.read_range(PIECE_LENGTH - 10, 20)
+                self.assertEqual(len(self.reader.cache), 0)
+                self.assertIsNone(self.reader.task_id)
+
+    def test_failed_read_does_not_advance_or_cache_and_can_retry(self):
+        self.reader.seek(PIECE_LENGTH - 10)
+        self.service.mode = "terminal_error"
+        with self.assertRaises(grpc.RpcError):
+            self.reader.read(20)
+        self.assertEqual(self.reader.tell(), PIECE_LENGTH - 10)
+        self.assertFalse(self.reader.cache)
+        self.service.mode = "normal"
+        self.assertEqual(
+            self.reader.read(20), self.content[PIECE_LENGTH - 10 : PIECE_LENGTH + 10]
+        )
+
+    def test_empty_ranges_and_closed_reader_do_not_make_requests(self):
+        self.assertEqual(self.reader.read_range(0, 0), b"")
+        self.assertEqual(self.reader.read_range(len(self.content), 1), b"")
+        self.reader.close()
+        for action in (
+            self.reader.tell,
+            self.reader.read,
+            lambda: self.reader.seek(0),
+            lambda: self.reader.read_range(0, 1),
+        ):
+            with self.assertRaises(ValueError):
+                action()
+        self.assertFalse(self.service.requests)
+
+    def test_binary_io_argument_validation(self):
+        for action in (
+            lambda: self.reader.seek(0.5),
+            lambda: self.reader.seek(0, 0.5),
+            lambda: self.reader.read(1.5),
+            lambda: self.reader.read_range(0.5, 1),
+            lambda: self.reader.read_range(0, 1.5),
+            lambda: self.reader.readinto(b"readonly"),
+        ):
+            with self.assertRaises(TypeError):
+                action()
+        self.assertEqual(self.reader.tell(), 0)
+        self.assertFalse(self.service.requests)
+        buffer = array("I", [0, 0])
+        self.assertEqual(self.reader.readinto(buffer), buffer.itemsize * len(buffer))
+        self.assertEqual(buffer.tobytes(), self.content[: len(buffer.tobytes())])
+
+    def test_auto_policy_and_disabled_application_cache(self):
+        self.reader.scheduling_policy = "auto"
+        self.reader.cache_pieces = 0
+        for _ in range(2):
+            self.assertEqual(self.reader.read_range(0, 1), self.content[:1])
+        self.assertEqual(len(self.service.requests), 2)
+        self.assertFalse(self.reader.cache)
+        self.assertEqual(self.service.requests[0].scheduling_policy, common_pb2.AUTO)
+
+    def test_changed_size_and_allocation_limit(self):
+        self.reader.size += 1
+        with self.assertRaisesRegex(OSError, "object size changed"):
+            self.reader.read_range(0, 10)
+        self.reader.max_range_bytes = 8
+        self.reader.seek(0)
+        with self.assertRaises(io.UnsupportedOperation):
+            self.reader.read()
+        with self.assertRaises(ValueError):
+            self.reader.read_range(0, 9)
+
+    def test_boto3_metadata_and_sts_wiring(self):
+        session = boto3.Session(
+            aws_access_key_id="test-only",
+            aws_secret_access_key="test-only",
+            aws_session_token="session-from-boto3",
+            region_name="us-east-1",
+        )
+        s3 = session.client("s3", endpoint_url="http://s3.test")
+        with (
+            Stubber(s3) as metadata,
+            patch("reader.boto3.Session", return_value=session),
+            patch.object(session, "client", return_value=s3),
+        ):
+            metadata.add_response(
+                "head_object",
+                {"ContentLength": len(self.content), "ETag": '"fixture"'},
+                {"Bucket": "test", "Key": "video.mp4"},
+            )
+            with open_s3_reader(
+                "s3://test/video.mp4",
+                socket=self.service.address.removeprefix("unix:"),
+                endpoint="http://s3.test",
+            ) as reader:
+                self.assertEqual(reader.read_range(100, 10), self.content[100:110])
+            metadata.assert_no_pending_responses()
+        options = self.service.requests[0].object_storage
+        self.assertEqual(options.session_token, "session-from-boto3")
+        self.assertEqual(options.endpoint, "http://s3.test")
+
+    def test_encoded_key_uses_the_same_object_for_head_and_download(self):
+        session = boto3.Session(
+            aws_access_key_id="test-only", aws_secret_access_key="test-only"
+        )
+        s3 = session.client("s3", endpoint_url="http://s3.test")
+        with (
+            Stubber(s3) as metadata,
+            patch("reader.boto3.Session", return_value=session),
+            patch.object(session, "client", return_value=s3),
+        ):
+            metadata.add_response(
+                "head_object",
+                {"ContentLength": len(self.content), "ETag": '"fixture"'},
+                {"Bucket": "test", "Key": "folder/a b+100%.bin"},
+            )
+            with open_s3_reader(
+                "s3://test/folder/a%20b%2B100%25.bin",
+                socket=self.service.address.removeprefix("unix:"),
+            ) as reader:
+                self.assertEqual(reader.read(10), self.content[:10])
+            metadata.assert_no_pending_responses()
+        self.assertEqual(
+            self.service.requests[0].url, "s3://test/folder/a%20b%2B100%25.bin"
+        )
+        self.assertEqual(
+            self.service.requests[0].object_storage.endpoint, "http://s3.test"
+        )
+
+    def test_reject_ambiguous_urls_before_metadata_requests(self):
+        for url in (
+            "https://test/key",
+            "s3://test/",
+            "s3://user@test/key",
+            "s3://test:9000/key",
+            "s3://test/a/../b",
+            "s3://test/a/%2E/b",
+            "s3://test//key",
+            "s3://test/key?versionId=123",
+            "s3://test/key#part",
+            "s3://test/a%2F%2Fb",
+            "s3://test/a\\b",
+            "s3://test/a\nb",
+        ):
+            with self.subTest(url=url), patch("reader.boto3.Session") as session:
+                with self.assertRaises(ValueError), open_s3_reader(url):
+                    self.fail("URL should have been rejected")
+                session.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/python-s3-range/tests/test_video.py
+++ b/examples/python-s3-range/tests/test_video.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Dragonfly Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A real indexed three-hour MP4, served by the local gRPC test double."""
+
+import io
+import random
+import unittest
+from fractions import Fraction
+
+try:
+    import av
+except ImportError:
+    av = None
+
+from reader import PIECE_LENGTH, DragonflyReader
+
+if av is not None:
+    from video_chunks import frames_in_window
+from test_reader import example_credentials, serve
+
+
+def three_hour_video():
+    output = io.BytesIO()
+    rng = random.Random(42)
+    with av.open(output, mode="w", format="mp4") as container:
+        # One frame every 10 seconds keeps this test small. Random texture makes
+        # the file span several real 4 MiB pieces; it is not padded with zeros.
+        stream = container.add_stream("mpeg4", rate=Fraction(1, 10))
+        stream.width, stream.height = 160, 128
+        stream.pix_fmt = "yuv420p"
+        stream.bit_rate = 100_000
+        stream.codec_context.gop_size = 6
+        for index in range(1080):
+            frame = av.VideoFrame(160, 128, "yuv420p")
+            for plane in frame.planes:
+                plane.update(rng.randbytes(plane.buffer_size))
+            frame.pts = index
+            frame.time_base = Fraction(10, 1)
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+    return output.getvalue()
+
+
+@unittest.skipIf(av is None, "Install requirements-video.txt to test video decoding")
+class VideoTests(unittest.TestCase):
+    def test_two_minutes_at_two_hours_without_full_download(self):
+        video = three_hour_video()
+        self.assertGreater(len(video), 4 * PIECE_LENGTH)
+        expected = []
+        # Sequential local decode is the reference; don't use the same seek
+        # helper to produce both the expected and actual frames.
+        with av.open(io.BytesIO(video)) as local:
+            for frame in local.decode(video=0):
+                timestamp = float(frame.pts * frame.time_base)
+                if 7200 <= timestamp < 7320:
+                    expected.append((timestamp, bytes(frame.planes[0])))
+        with serve(video) as (service, stub):
+            with DragonflyReader(
+                stub,
+                "s3://test/three-hours.mp4",
+                len(video),
+                example_credentials,
+                cache_tag="three-hour-fixture",
+            ) as reader:
+                with av.open(reader, mode="r") as remote:
+                    actual = []
+                    for start in (7200, 7260):
+                        actual.extend(
+                            (timestamp, bytes(frame.planes[0]))
+                            for timestamp, frame in frames_in_window(remote, start, 60)
+                        )
+                self.assertEqual([x[0] for x in actual], list(range(7200, 7320, 10)))
+                self.assertEqual(actual, expected)
+                self.assertLess(reader.piece_bytes_received, len(video))
+                self.assertTrue(
+                    all(not request.prefetch for request in service.requests)
+                )
+                print(
+                    f"\nThree-hour video: {len(video):,} bytes; two one-minute windows: "
+                    f"{len(actual)} verified frames; {reader.rpc_count} RPCs; "
+                    f"{reader.piece_bytes_received:,} piece bytes transferred"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/python-s3-range/video_chunks.py
+++ b/examples/python-s3-range/video_chunks.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The Dragonfly Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decode minute-long windows without first downloading the whole video."""
+
+import argparse
+from fractions import Fraction
+
+import av
+
+from reader import open_s3_reader
+
+
+def frames_in_window(container, start_seconds, duration_seconds=60):
+    """Yield (relative timestamp, VideoFrame) in [start, start+duration).
+
+    Keep the container open across windows. The demuxer obtains metadata/index
+    bytes and performs byte seeks through DragonflyReader. It may decode from
+    an earlier keyframe and read ahead beyond the requested window.
+    """
+    start = Fraction(str(start_seconds))
+    duration = Fraction(str(duration_seconds))
+    if start < 0 or duration <= 0:
+        raise ValueError("Start must be nonnegative and duration positive")
+    if not container.streams.video:
+        raise ValueError("No video stream")
+    stream = container.streams.video[0]
+    origin = stream.start_time or 0
+    target = origin + int(start / stream.time_base)
+    container.seek(target, stream=stream, backward=True, any_frame=False)
+    origin_seconds = origin * stream.time_base
+    for frame in container.decode(stream):
+        if frame.pts is None or frame.time_base is None:
+            raise ValueError("Video requires timestamps for time-window selection")
+        timestamp = frame.pts * frame.time_base - origin_seconds
+        if timestamp < start:
+            continue
+        if timestamp >= start + duration:
+            break
+        yield float(timestamp), frame
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="Immutable s3://bucket/key video object")
+    parser.add_argument(
+        "--start", type=float, default=7200, help="Seconds from video start"
+    )
+    parser.add_argument("--chunk-seconds", type=float, default=60)
+    parser.add_argument("--chunks", type=int, default=1)
+    parser.add_argument("--socket", default="/var/run/dragonfly/dfdaemon.sock")
+    parser.add_argument("--region")
+    parser.add_argument("--endpoint", help="Custom S3 endpoint, e.g. MinIO")
+    parser.add_argument("--profile")
+    parser.add_argument(
+        "--timeout", type=float, default=60, help="Deadline per gRPC call"
+    )
+    parser.add_argument(
+        "--scheduling-policy",
+        choices=("auto", "always"),
+        default="always",
+        help="always enables peer lookup for small byte ranges (v1.5.5+)",
+    )
+    args = parser.parse_args()
+    if args.chunks < 1 or args.start < 0 or args.chunk_seconds <= 0:
+        parser.error("Invalid start, chunk duration, or chunk count")
+    with open_s3_reader(
+        args.url,
+        socket=args.socket,
+        region=args.region,
+        endpoint=args.endpoint,
+        profile=args.profile,
+        timeout=args.timeout,
+        scheduling_policy=args.scheduling_policy,
+    ) as reader:
+        with av.open(reader, mode="r") as container:
+            for index in range(args.chunks):
+                start = args.start + index * args.chunk_seconds
+                count, first, last = 0, None, None
+                for timestamp, frame in frames_in_window(
+                    container, start, args.chunk_seconds
+                ):
+                    # Feed frame.to_ndarray(format="rgb24") into your training
+                    # pipeline here. Process incrementally; don't retain hours.
+                    count += 1
+                    if first is None:
+                        first = timestamp
+                    last = timestamp
+                print(
+                    f"[{start:g}, {start + args.chunk_seconds:g}) seconds: "
+                    f"{count} frames; first={first}, last={last}"
+                )
+        print(
+            f"Object bytes: {reader.size:,}; gRPC calls: {reader.rpc_count}; "
+            f"piece bytes received: {reader.piece_bytes_received:,}; "
+            f"requested range bytes: {reader.range_bytes_requested:,}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Add a seekable Python S3 reader using the existing v2 gRPC API and generated `dragonfly-api` bindings. It preserves whole-object task identity, validates and trims complete pieces, and obtains AWS credentials (including STS tokens) through boto3.

The example includes an optional PyAV video-window consumer, focused tests, and a path-scoped Python 3.11/3.12 CI workflow. PyAV is not required for byte-range reads. The README documents the trusted-socket and immutable-object assumptions, memory limits, and small-range scheduling behavior.

## Related Issue

Related to #1821. This demonstrates native gRPC integration for callers that can be adapted; it does not resolve signed HTTP proxy compatibility or close that issue.

## Motivation and Context

Python data loaders need selected object bytes in process, including seekable reads for large videos. The existing daemon API can serve this use case while keeping normal task/piece caching and P2P behavior. No daemon or protocol changes are needed.

## Validation

Validated the example files in `517d43b8370a6eb571d8e3045959b7fa9865a249` against upstream `d5bccb022`:

- Python 3.11 and 3.12 in Linux Docker: all 13 tests passed, including real protobuf/gRPC streaming and video decoding. A clean Python 3.11 install without PyAV passed the 12 core tests and skipped the optional video test.
- Ruff syntax/import checks and formatting; `git diff --check`.
- Real integration with two official dfdaemon v1.5.5 containers, separate caches, manager/scheduler, and MinIO: signed piece GETs returned 206; changing Range after signing in the control request returned 403.
- Repeated ranges fetched 8 MiB from the remote peer without a source GET; overlapping ranges retained the same task ID and hit the daemon's local cache. Small reads used remote peers with `ALWAYS` and fell back to source with `AUTO`.
- Two MinIO STS sessions succeeded; invalid credentials on cold objects failed. URL-encoded keys and empty objects passed.
- Two one-minute windows at the two-hour mark of a synthetic three-hour indexed MP4 matched sequential local decoding. The reader transferred 9,923,151 of 39,283,279 object bytes in three RPCs; a fresh reader repeated the windows entirely from daemon cache with no new source GET.

The live tests used MinIO, not AWS S3. Cache hits can still issue metadata HEADs, and these results are functional checks, not throughput benchmarks. Local test deployments and generated logs are excluded from this PR.

## AI Assistance

AI tools assisted implementation and testing. I reviewed the code and the testing process.
